### PR TITLE
WIP: Add Mozilla Root certs as a bundle source

### DIFF
--- a/deploy/charts/trust/templates/trust.cert-manager.io_bundles.yaml
+++ b/deploy/charts/trust/templates/trust.cert-manager.io_bundles.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.6.1
+    controller-gen.kubebuilder.io/version: v0.8.0
   creationTimestamp: null
   name: bundles.trust.cert-manager.io
 spec:
@@ -60,6 +60,9 @@ spec:
                     description: BundleSource is the set of sources whose data will be appended and synced to the BundleTarget in all Namespaces.
                     type: object
                     properties:
+                      ccadb:
+                        description: CCADB is an embedded copy of the certificates in Mozilla's root store that have the websites trust bit enabled.
+                        type: boolean
                       configMap:
                         description: ConfigMap is a reference to a ConfigMap's `data` key, in the trust Namespace.
                         type: object

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/cert-manager/trust
 go 1.18
 
 require (
+	github.com/breml/rootcerts v0.2.4
 	github.com/go-logr/logr v1.2.3
 	github.com/onsi/ginkgo v1.16.5
 	github.com/onsi/ginkgo/v2 v2.1.3

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bketelsen/crypt v0.0.3-0.20200106085610-5cbc8cc4026c/go.mod h1:MKsuJmJgSg28kpZDP6UIiPt0e0Oz0kqKNGyRaWEPv84=
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
+github.com/breml/rootcerts v0.2.4 h1:+c6FN0W7f7bvHeVrQ7ggsnG0dC7Px/YE52MZIbwDFIQ=
+github.com/breml/rootcerts v0.2.4/go.mod h1:24FDtzYMpqIeYC7QzaE8VPRQaFZU5TIUDlyk8qwjD88=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/certifi/gocertifi v0.0.0-20191021191039-0944d244cd40/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=
 github.com/certifi/gocertifi v0.0.0-20200922220541-2c3bb06c6054/go.mod h1:sGbDF6GwGcLpkNXPUTkMRoywsNa/ol15pxFe6ERfguA=

--- a/pkg/apis/trust/v1alpha1/types_bundle.go
+++ b/pkg/apis/trust/v1alpha1/types_bundle.go
@@ -76,6 +76,10 @@ type BundleSource struct {
 	// InLine is a simple string to append as the source data.
 	// +optional
 	InLine *string `json:"inLine,omitempty"`
+
+	// CCADB is an embedded copy of the certificates in Mozilla's root store
+	// that have the websites trust bit enabled.
+	CCADB *bool `json:"ccadb,omitempty"`
 }
 
 // BundleTarget is the target resource that the Bundle will sync all source

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -18,9 +18,11 @@ package bundle
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/breml/rootcerts/embedded"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -88,6 +90,7 @@ func Test_Reconcile(t *testing.T) {
 					{ConfigMap: &trustapi.SourceObjectKeySelector{Name: sourceConfigMapName, KeySelector: trustapi.KeySelector{Key: sourceConfigMapKey}}},
 					{Secret: &trustapi.SourceObjectKeySelector{Name: sourceSecretName, KeySelector: trustapi.KeySelector{Key: sourceSecretKey}}},
 					{InLine: pointer.String("C")},
+					{CCADB: pointer.Bool(true)},
 				},
 				Target: trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{Key: targetKey}},
 			},
@@ -272,17 +275,17 @@ func Test_Reconcile(t *testing.T) {
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: trustNamespace, Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "1"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: "A\nB\nC\n" + strings.TrimSpace(embedded.MozillaCACertificatesPEM()) + "\n"},
 				},
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-1", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "1"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: "A\nB\nC\n" + strings.TrimSpace(embedded.MozillaCACertificatesPEM()) + "\n"},
 				},
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-2", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "1"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: "A\nB\nC\n" + strings.TrimSpace(embedded.MozillaCACertificatesPEM()) + "\n"},
 				},
 			),
 			expEvent: "Normal Synced Successfully synced Bundle to all namespaces",
@@ -317,17 +320,17 @@ func Test_Reconcile(t *testing.T) {
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: trustNamespace, Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "1"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: "A\nB\nC\n" + strings.TrimSpace(embedded.MozillaCACertificatesPEM()) + "\n"},
 				},
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-1", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "1"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: "A\nB\nC\n" + strings.TrimSpace(embedded.MozillaCACertificatesPEM()) + "\n"},
 				},
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-2", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "1"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: "A\nB\nC\n" + strings.TrimSpace(embedded.MozillaCACertificatesPEM()) + "\n"},
 				},
 			),
 			expEvent: "Normal Synced Successfully synced Bundle to all namespaces",
@@ -351,15 +354,15 @@ func Test_Reconcile(t *testing.T) {
 				),
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Namespace: trustNamespace, Name: baseBundle.Name},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: "A\nB\nC\n" + strings.TrimSpace(embedded.MozillaCACertificatesPEM()) + "\n"},
 				},
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-1", Name: baseBundle.Name},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: "A\nB\nC\n" + strings.TrimSpace(embedded.MozillaCACertificatesPEM()) + "\n"},
 				},
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-2", Name: baseBundle.Name},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: "A\nB\nC\n" + strings.TrimSpace(embedded.MozillaCACertificatesPEM()) + "\n"},
 				},
 			),
 			expResult: ctrl.Result{},
@@ -384,17 +387,17 @@ func Test_Reconcile(t *testing.T) {
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: trustNamespace, Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "1000"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: "A\nB\nC\n" + strings.TrimSpace(embedded.MozillaCACertificatesPEM()) + "\n"},
 				},
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-1", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "1000"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: "A\nB\nC\n" + strings.TrimSpace(embedded.MozillaCACertificatesPEM()) + "\n"},
 				},
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-2", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "1000"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: "A\nB\nC\n" + strings.TrimSpace(embedded.MozillaCACertificatesPEM()) + "\n"},
 				},
 			),
 			expEvent: "Normal Synced Successfully synced Bundle to all namespaces",
@@ -404,17 +407,17 @@ func Test_Reconcile(t *testing.T) {
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: trustNamespace, Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: "A\nB\nC\n" + strings.TrimSpace(embedded.MozillaCACertificatesPEM()) + "\n"},
 				},
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-1", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: "A\nB\nC\n" + strings.TrimSpace(embedded.MozillaCACertificatesPEM()) + "\n"},
 				},
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-2", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: "A\nB\nC\n" + strings.TrimSpace(embedded.MozillaCACertificatesPEM()) + "\n"},
 				},
 			),
 			expResult: ctrl.Result{},
@@ -439,17 +442,17 @@ func Test_Reconcile(t *testing.T) {
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: trustNamespace, Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "999"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: "A\nB\nC\n" + strings.TrimSpace(embedded.MozillaCACertificatesPEM()) + "\n"},
 				},
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-1", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "999"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: "A\nB\nC\n" + strings.TrimSpace(embedded.MozillaCACertificatesPEM()) + "\n"},
 				},
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-2", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "999"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: "A\nB\nC\n" + strings.TrimSpace(embedded.MozillaCACertificatesPEM()) + "\n"},
 				},
 			),
 			expEvent: "Normal Synced Successfully synced Bundle to all namespaces",
@@ -473,15 +476,15 @@ func Test_Reconcile(t *testing.T) {
 				),
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Namespace: trustNamespace, Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: "A\nB\nC\n" + strings.TrimSpace(embedded.MozillaCACertificatesPEM()) + "\n"},
 				},
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-1", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: "A\nB\nC\n" + strings.TrimSpace(embedded.MozillaCACertificatesPEM()) + "\n"},
 				},
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-2", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: "A\nB\nC\n" + strings.TrimSpace(embedded.MozillaCACertificatesPEM()) + "\n"},
 				},
 			),
 			expResult: ctrl.Result{},
@@ -506,17 +509,17 @@ func Test_Reconcile(t *testing.T) {
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: trustNamespace, Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "999"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: "A\nB\nC\n" + strings.TrimSpace(embedded.MozillaCACertificatesPEM()) + "\n"},
 				},
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-1", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "999"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: "A\nB\nC\n" + strings.TrimSpace(embedded.MozillaCACertificatesPEM()) + "\n"},
 				},
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-2", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "999"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: "A\nB\nC\n" + strings.TrimSpace(embedded.MozillaCACertificatesPEM()) + "\n"},
 				},
 			),
 			expEvent: "",

--- a/pkg/bundle/sync.go
+++ b/pkg/bundle/sync.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/breml/rootcerts/embedded"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -54,6 +55,11 @@ func (b *bundle) buildSourceBundle(ctx context.Context, bundle *trustapi.Bundle)
 
 		case source.InLine != nil:
 			sourceData = *source.InLine
+
+		case source.CCADB != nil:
+			if *source.CCADB {
+				sourceData = embedded.MozillaCACertificatesPEM()
+			}
 		}
 
 		if err != nil {


### PR DESCRIPTION
Fixes #8 
/kind feature

This embeds the latest version of the Mozilla Root Certificates that have the web SSL/TLS bit set, using https://github.com/breml/rootcerts

This adds a new bundle source: CCADB, which will add said embedded root CAs to the target.

breml/rootcerts is under consideration to be included in the Go standard library, but until then, keeping it up-to-date should be seen as a vital security concern, perhaps automated with dependabot.