### PR TITLE
WIP: feat: add HTTPS bundle source

### DIFF
--- a/deploy/charts/trust/templates/trust.cert-manager.io_bundles.yaml
+++ b/deploy/charts/trust/templates/trust.cert-manager.io_bundles.yaml
@@ -73,6 +73,22 @@ spec:
                           name:
                             description: Name is the name of the source object in the trust Namespace.
                             type: string
+                      https:
+                        description: HTTPS downloads a PEM-Formatted trust bundle from an HTTPS server
+                        type: object
+                        required:
+                          - caBundle
+                          - url
+                        properties:
+                          caBundle:
+                            description: CABundle is the CA Bundle required to verify the target server's identity.
+                            type: string
+                          pollInterval:
+                            description: PollInterval is the period at which the controller will check for changes on the server.
+                            type: string
+                          url:
+                            description: URL is an HTTPS URL.
+                            type: string
                       inLine:
                         description: InLine is a simple string to append as the source data.
                         type: string

--- a/hack/boilerplate/boilerplate.Dockerfile.txt
+++ b/hack/boilerplate/boilerplate.Dockerfile.txt
@@ -1,4 +1,4 @@
-# Copyright 2021 The cert-manager Authors.
+# Copyright YEAR The cert-manager Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/boilerplate/boilerplate.Makefile.txt
+++ b/hack/boilerplate/boilerplate.Makefile.txt
@@ -1,4 +1,4 @@
-# Copyright 2021 The cert-manager Authors.
+# Copyright YEAR The cert-manager Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/boilerplate/boilerplate.go.txt
+++ b/hack/boilerplate/boilerplate.go.txt
@@ -1,5 +1,5 @@
 /*
-Copyright 2021 The cert-manager Authors.
+Copyright YEAR The cert-manager Authors.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -200,8 +200,8 @@ def get_regexs():
     regexs = {}
     # Search for "YEAR" which exists in the boilerplate, but shouldn't in the real thing
     regexs["year"] = re.compile('YEAR')
-    # dates can be 2014, 2015, 2016, or 2017; company holder names can be anything
-    regexs["date"] = re.compile('(2014|2015|2016|2017)')
+    # dates can be 20XX; company holder names can be anything
+    regexs["date"] = re.compile('20[0-9][0-9]')
     # strip the following build constraints/tags:
     # //go:build
     # // +build \n\n

--- a/pkg/apis/trust/v1alpha1/types_bundle.go
+++ b/pkg/apis/trust/v1alpha1/types_bundle.go
@@ -51,7 +51,7 @@ type BundleList struct {
 	Items []Bundle `json:"items"`
 }
 
-// BundleSepc defines the desired state of a Bundle.
+// BundleSpec defines the desired state of a Bundle.
 type BundleSpec struct {
 	// Sources is a set of references to data whose data will sync to the target.
 	Sources []BundleSource `json:"sources"`
@@ -76,6 +76,21 @@ type BundleSource struct {
 	// InLine is a simple string to append as the source data.
 	// +optional
 	InLine *string `json:"inLine,omitempty"`
+
+	// HTTPS downloads a PEM-Formatted trust bundle from an HTTPS server
+	// +optional
+	HTTPS *SourceHTTPS `json:"https,omitempty"`
+}
+
+// SourceHTTPS represents a target HTTPS URL that will serve a PEM-formatted trust bundle.
+type SourceHTTPS struct {
+	// URL is an HTTPS URL.
+	URL string `json:"url"`
+	// CABundle is the CA Bundle required to verify the target server's identity.
+	CABundle string `json:"caBundle"`
+	// PollInterval is the period at which the controller will check for changes on the server.
+	// +optional
+	PollInterval *string `json:"pollInterval,omitempty"`
 }
 
 // BundleTarget is the target resource that the Bundle will sync all source

--- a/pkg/bundle/controller.go
+++ b/pkg/bundle/controller.go
@@ -47,11 +47,12 @@ import (
 // The controller will only cache metadata for ConfigMaps and Secrets.
 func AddBundleController(ctx context.Context, mgr manager.Manager, opts Options) error {
 	b := &bundle{
-		client:   mgr.GetClient(),
-		lister:   mgr.GetCache(),
-		recorder: mgr.GetEventRecorderFor("bundles"),
-		clock:    clock.RealClock{},
-		Options:  opts,
+		client:    mgr.GetClient(),
+		lister:    mgr.GetCache(),
+		recorder:  mgr.GetEventRecorderFor("bundles"),
+		clock:     clock.RealClock{},
+		etagCache: newEtagCache(),
+		Options:   opts,
 	}
 
 	// Only reconcile config maps that match the well known name

--- a/pkg/bundle/etagcache.go
+++ b/pkg/bundle/etagcache.go
@@ -1,0 +1,20 @@
+package bundle
+
+import "sync"
+
+// etagCache holds the responses to HTTPS bundle sources, with their etags and date.
+type etagCache struct {
+	cache map[string]dataWithEtag
+	sync.RWMutex
+}
+
+type dataWithEtag struct {
+	etag, date string
+	data       []byte
+}
+
+func newEtagCache() *etagCache {
+	return &etagCache{
+		cache: make(map[string]dataWithEtag),
+	}
+}

--- a/pkg/bundle/etagcache.go
+++ b/pkg/bundle/etagcache.go
@@ -1,3 +1,19 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
 package bundle
 
 import "sync"

--- a/pkg/bundle/sync.go
+++ b/pkg/bundle/sync.go
@@ -187,7 +187,7 @@ func (b *bundle) httpsBundle(ctx context.Context, ref *trustapi.SourceHTTPS) (st
 		date: date,
 		data: body,
 	}
-	b.etagCache.Lock()
+	b.etagCache.Unlock()
 	return string(body), nil
 }
 


### PR DESCRIPTION
This PR adds a "fetch from remote server over HTTPS" bundle source. It's used like this:

```yaml
spec:
  sources:
  - https:
      url: https://foo.bar/baz
      caBundle: |
        -----BEGIN CERTIFICATE-----
        ...
      pollInterval: 60s
```

It uses etags / if-modified-since headers to avoid redownloading bundles every pollInterval.

It's somewhat opinionated - it only allows https:// schemes and will only use the trust roots specied inline in the spec. This is to prevent users doing something unsafe, but I'm open to discussion.

