### PR TITLE
Add a static bundle sidecar container build 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,11 @@ WORKDIR /workspace
 COPY go.mod go.mod
 COPY go.sum go.sum
 
-# Copy the go source files
+# Copy build scripts
 COPY Makefile Makefile
+COPY make/ make/
+
+# Copy the go source files
 COPY cmd/ cmd/
 COPY pkg/ pkg/
 

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ OS     ?= $(shell go env GOOS)
 
 HELM_VERSION ?= 3.6.3
 KUBEBUILDER_TOOLS_VERISON ?= 1.21.2
+CRANE_VERSION ?= v0.12.1
 IMAGE_PLATFORMS ?= linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le
 
 RELEASE_VERSION ?= v0.3.0
@@ -87,7 +88,7 @@ smoke: demo ## create cluster, deploy trust and run smoke tests
 	REPO_ROOT=$(shell pwd) ./hack/ci/run-smoke-test.sh
 
 .PHONY: depend
-depend: $(BINDIR)/deepcopy-gen $(BINDIR)/controller-gen $(BINDIR)/ginkgo $(BINDIR)/kubectl $(BINDIR)/kind $(BINDIR)/helm $(BINDIR)/kubebuilder/bin/kube-apiserver
+depend: $(BINDIR)/deepcopy-gen $(BINDIR)/controller-gen $(BINDIR)/ginkgo $(BINDIR)/kubectl $(BINDIR)/kind $(BINDIR)/helm $(BINDIR)/kubebuilder/bin/kube-apiserver $(BINDIR)/crane
 
 $(BINDIR)/deepcopy-gen: | $(BINDIR)
 	go build -o $@ k8s.io/code-generator/cmd/deepcopy-gen
@@ -113,6 +114,9 @@ $(BINDIR)/helm-docs: | $(BINDIR)
 $(BINDIR)/kubectl: | $(BINDIR)
 	curl -o $@ -LO "https://storage.googleapis.com/kubernetes-release/release/$(shell curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/$(OS)/$(ARCH)/kubectl"
 	chmod +x $@
+
+$(BINDIR)/crane: | $(BINDIR)
+	GOBIN=$(BINDIR) go install github.com/google/go-containerregistry/cmd/crane@$(CRANE_VERSION)
 
 $(BINDIR)/kubebuilder/bin/kube-apiserver: | $(BINDIR)/kubebuilder
 	curl -sSLo $(BINDIR)/envtest-bins.tar.gz "https://storage.googleapis.com/kubebuilder-tools/kubebuilder-tools-$(KUBEBUILDER_TOOLS_VERISON)-$(OS)-$(ARCH).tar.gz"

--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,14 @@ verify: depend test verify-helm-docs build ## tests and builds trust
 image: | $(BINDIR) ## build docker image targeting all supported platforms
 	docker buildx build --platform=$(IMAGE_PLATFORMS) -t quay.io/jetstack/trust-manager:$(RELEASE_VERSION) --output type=local,dest=$(BINDIR)/trust-manager .
 
+.PHONY: kind-load
+kind-load: local-images | $(BINDIR)/kind
+	$(BINDIR)/kind load docker-image quay.io/jetstack/trust-manager:$(RELEASE_VERSION)
+
+.PHONY: local-images
+local-images:
+	docker buildx build --platform=linux/amd64 -t quay.io/jetstack/trust-manager:$(RELEASE_VERSION) --load .
+
 .PHONY: chart
 chart: | $(BINDIR)/helm $(BINDIR)/chart
 	$(BINDIR)/helm package --app-version=$(RELEASE_VERSION) --version=$(RELEASE_VERSION) --destination "$(BINDIR)/chart" ./deploy/charts/trust-manager

--- a/bundles/debian/Containerfile
+++ b/bundles/debian/Containerfile
@@ -1,0 +1,51 @@
+# Copyright 2022 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM docker.io/library/debian:11-slim as debbase
+
+ARG EXPECTED_VERSION
+ARG VERSION_SUFFIX
+
+WORKDIR /work
+
+COPY ./build.sh /work/build.sh
+
+RUN /work/build.sh $EXPECTED_VERSION $VERSION_SUFFIX /work/bundle.json
+
+FROM docker.io/library/golang:1.19 as gobuild
+
+WORKDIR /work
+
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY main.go main.go
+
+RUN CGO_ENABLED=0 go build -o copypause main.go
+
+FROM scratch
+
+ARG EXPECTED_VERSION
+ARG VERSION_SUFFIX
+
+LABEL description="cert-manager debian static trust bundle"
+
+USER 1001
+
+COPY --from=debbase /usr/bin/tini-static /tini
+COPY --from=debbase /work/bundle.json /packaged-bundles/bundle-debian-$EXPECTED_VERSION$VERSION_SUFFIX.json
+COPY --from=gobuild /work/copypause /copypause
+
+ENTRYPOINT ["/tini", "--"]
+
+CMD ["/copypause", "/packaged-bundles", "/bundles"]

--- a/bundles/debian/build.sh
+++ b/bundles/debian/build.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This script is designed to be run during a build of the debian bundle container
+# As such, it's not designed to be portable and may only work in that situation
+
+EXPECTED_VERSION=${1:-}
+VERSION_SUFFIX=${2:-}
+DESTINATION_FILE=${3:-}
+
+if [[ -z $EXPECTED_VERSION || -z $VERSION_SUFFIX || -z $DESTINATION_FILE ]]; then
+	echo "usage: $0 <expected version> <version suffix> <destination file>"
+	exit 1
+fi
+
+apt-get -yq update
+DEBIAN_FRONTEND=noninteractive apt-get -yq -o=Dpkg::Use-Pty=0 install --no-install-recommends ca-certificates jq tini
+
+INSTALLED_VERSION=$(dpkg-query --show --showformat="\${Version}" ca-certificates)
+
+if [[ "$EXPECTED_VERSION" != "latest" ]]; then
+	if [[ "$EXPECTED_VERSION" != "$INSTALLED_VERSION" ]]; then
+		echo "expected version $EXPECTED_VERSION but got $INSTALLED_VERSION"
+		echo "this might mean that debian released an update between querying for version $EXPECTED_VERSION and running this build script"
+		echo "exiting for safety"
+		exit 1
+	fi
+fi
+
+echo "{}" | jq \
+	--rawfile bundle /etc/ssl/certs/ca-certificates.crt \
+	--arg type "static" \
+	--arg version "$EXPECTED_VERSION$VERSION_SUFFIX" \
+	'.bundle = $bundle | .type = $type | .version = $version' \
+	> $DESTINATION_FILE

--- a/bundles/debian/go.mod
+++ b/bundles/debian/go.mod
@@ -1,0 +1,3 @@
+module github.com/cert-manager/trust-manager/bundle-static
+
+go 1.19

--- a/bundles/debian/main.go
+++ b/bundles/debian/main.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"log"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+)
+
+func main() {
+	stderrLogger := log.New(os.Stderr, "", log.LstdFlags)
+
+	if len(os.Args) != 3 {
+		stderrLogger.Fatalf("usage: %s <input-folder> <output-folder>", os.Args[0])
+	}
+
+	inputDir := os.Args[1]
+	destinationDir := os.Args[2]
+
+	stderrLogger.Printf("reading from %q", inputDir)
+	stderrLogger.Printf("writing to %q", destinationDir)
+
+	if err := dirOrError(inputDir); err != nil {
+		stderrLogger.Fatalf("couldn't confirm that input path is a directory that exists: %s", err.Error())
+	}
+
+	if err := dirOrError(destinationDir); err != nil {
+		stderrLogger.Fatalf("couldn't confirm that output path is a directory that exists: %s", err.Error())
+	}
+
+	walkErr := filepath.Walk(inputDir, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if filepath.Ext(path) != ".json" {
+			return nil
+		}
+
+		var input *os.File
+		var target *os.File
+
+		input, err = os.Open(path)
+		if err != nil {
+			return fmt.Errorf("failed to open file %q for reading: %w", path, err)
+		}
+
+		defer func() {
+			err := input.Close()
+			if err != nil {
+				stderrLogger.Printf("failed to close input file: %s", err.Error())
+			}
+		}()
+
+		destinationFile := filepath.Join(destinationDir, filepath.Base(path))
+
+		target, err = os.OpenFile(destinationFile, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0o664)
+		if err != nil {
+			return fmt.Errorf("failed to open file %q for writing: %w", destinationFile, err)
+		}
+
+		defer func() {
+			err := target.Close()
+			if err != nil {
+				stderrLogger.Printf("failed to close output file: %s", err.Error())
+			}
+		}()
+
+		if _, err := io.Copy(target, input); err != nil {
+			return fmt.Errorf("failed to copy source %q to destination %q: %w", path, destinationFile, err)
+		}
+
+		stderrLogger.Printf("successfully copied %q to %q", path, destinationFile)
+
+		return nil
+	})
+
+	if walkErr != nil {
+		stderrLogger.Fatalf("failed to walk input dir %q: %s", inputDir, walkErr.Error())
+	}
+
+	stderrLogger.Printf("finished copying, waiting for termination signal")
+
+	// TODO: if we add the ability to reap zombie processes, this could function as a full init
+
+	sigs := make(chan os.Signal, 1)
+
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	<-sigs
+
+	stderrLogger.Println("received interrupt, closing")
+}
+
+func dirOrError(name string) error {
+	info, err := os.Stat(name)
+	if err != nil {
+		return err
+	}
+
+	if !info.IsDir() {
+		return fmt.Errorf("%q is not a directory", name)
+	}
+
+	return nil
+}

--- a/hack/update-debian-ca-bundle.sh
+++ b/hack/update-debian-ca-bundle.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This script uses a container to install the latest ca-certificates package, and then
+# checks to see if the installed version of that package matches the latest available
+# debian bundle image in our container registry.
+
+# If we installed a newer version in the local container, we build a new image container
+# and push it upstream
+
+CTR=${CTR:-docker}
+
+REPO=${1:-}
+DEBIAN_BUNDLE_SUFFIX=${2:-}
+
+DEBIAN_IMAGE=docker.io/library/debian:11-slim
+
+function print_usage() {
+	echo "usage: $0 <target-repo> <version-suffix>"
+}
+
+if ! command -v $CTR &>/dev/null; then
+	print_usage
+	echo "This script requires a docker CLI compatible runtime, either docker or podman"
+	echo "If CTR is not set, defaults to using docker"
+	echo "Couldn't find $CTR command; exiting"
+	exit 1
+fi
+
+if [[ -z $REPO ]]; then
+	print_usage
+	echo "Missing target-repo"
+	exit 1
+fi
+
+if [[ -z $DEBIAN_BUNDLE_SUFFIX ]]; then
+	print_usage
+	echo "Missing version suffix"
+	exit 1
+fi
+
+function latest_ca_certificate_package_version() {
+	# Install the latest version of ca-certificates in a fresh container and print the
+	# installed version
+
+	# There are several commands for querying remote repos (e.g. apt-cache madison) but
+	# it's not clear that these commands are guaranteed to return installable versions
+	# in order or in a parseable format
+
+	# We specifically only want to query the latest version and without a guarantee on
+	# output ordering it's safest to install what apt thinks is the latest version and
+	# then see what we got.
+
+	# NB: It's also very difficult to make 'apt-get' stay quiet when installing packages
+	# so we just let it be loud and then only take the last line of output
+
+	$CTR run -it --rm $DEBIAN_IMAGE bash -c 'apt-get -yq update >/dev/null && DEBIAN_FRONTEND=noninteractive apt-get -qy -o=Dpkg::Use-Pty=0 install --no-install-recommends ca-certificates >/dev/null && dpkg-query --show --showformat="\${Version}" ca-certificates' | tail -1
+}
+
+echo "+++ fetching latest version of ca-certificates package"
+
+CA_CERTIFICATES_VERSION=$(latest_ca_certificate_package_version)
+
+# Rather than use CA_CERTIFICATES_VERSION directly as an image tag, suffix our own version number
+# that we control. We can increment this if we need to build a second version of a given ca-certificates,
+# say to add a new file or update the contents.
+
+IMAGE_TAG=$CA_CERTIFICATES_VERSION$DEBIAN_BUNDLE_SUFFIX
+
+FULL_IMAGE=$REPO:$IMAGE_TAG
+
+echo "+++ searching for $FULL_IMAGE in upstream registry"
+
+# Look for an image tagged with IMAGE_TAG; if it exists, we're done. If not, we need to build + upload it.
+crane digest $FULL_IMAGE && echo "latest image appears to be up-to-date; exiting" && exit 0
+
+echo "+++ latest image appears not to exist; building and pushing $FULL_IMAGE"
+
+make DEBIAN_BUNDLE_VERSION=$CA_CERTIFICATES_VERSION DEBIAN_BUNDLE_SUFFIX=$DEBIAN_BUNDLE_SUFFIX bundle-debian-push

--- a/make/image-bundle-debian.mk
+++ b/make/image-bundle-debian.mk
@@ -1,0 +1,39 @@
+DEBIAN_BUNDLE_VERSION ?=
+DEBIAN_BUNDLE_SUFFIX ?= .0
+
+define build_image_bundle
+	docker buildx build --platform=$(3) \
+		-t $(CONTAINER_REGISTRY)/cert-manager-bundle-debian:$(2) \
+		--build-arg EXPECTED_VERSION=$(2) \
+		--build-arg VERSION_SUFFIX=$(DEBIAN_BUNDLE_SUFFIX) \
+		--output $(1) \
+		-f ./bundles/debian/Containerfile \
+		./bundles/debian
+endef
+
+# can't use a comma in an argument to a make function, so define a variable instead
+_COMMA := ,
+
+.PHONY: bundle-debian-save
+bundle-debian-save:
+ifeq ($(strip $(DEBIAN_BUNDLE_VERSION)),)
+	$(error DEBIAN_BUNDLE_VERSION must be set for $@)
+endif
+
+	$(call build_image_bundle,type=local$(_COMMA)dest=$(BINDIR)/cert-manager-bundle-debian,$(DEBIAN_BUNDLE_VERSION),$(IMAGE_PLATFORMS))
+
+.PHONY: bundle-debian-load
+bundle-debian-load:
+	$(call build_image_bundle,type=docker,latest,linux/amd64)
+
+.PHONY: bundle-debian-push
+bundle-debian-push:
+ifeq ($(strip $(DEBIAN_BUNDLE_VERSION)),)
+	$(error DEBIAN_BUNDLE_VERSION must be set for $@)
+endif
+
+	$(call build_image_bundle,type=registry,$(DEBIAN_BUNDLE_VERSION),$(IMAGE_PLATFORMS))
+
+.PHONY: ci-update-debian-bundle
+ci-update-debian-bundle:
+	./hack/update-debian-ca-bundle.sh "$(CONTAINER_REGISTRY)/cert-manager-bundle-debian" $(DEBIAN_BUNDLE_SUFFIX)

--- a/make/image-bundle-debian.mk
+++ b/make/image-bundle-debian.mk
@@ -2,7 +2,8 @@ DEBIAN_BUNDLE_VERSION ?=
 DEBIAN_BUNDLE_SUFFIX ?= .0
 
 define build_image_bundle
-	docker buildx build --platform=$(3) \
+	docker buildx build --builder $(BUILDX_BUILDER) \
+		--platform=$(3) \
 		-t $(CONTAINER_REGISTRY)/cert-manager-bundle-debian:$(2) \
 		--build-arg EXPECTED_VERSION=$(2) \
 		--build-arg VERSION_SUFFIX=$(DEBIAN_BUNDLE_SUFFIX) \

--- a/pkg/sidecar/bundle_blob.go
+++ b/pkg/sidecar/bundle_blob.go
@@ -1,0 +1,33 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sidecar
+
+type BlobType string
+
+const (
+	BlobTypeStatic  BlobType = "static"
+	BlobTypeDynamic BlobType = "dynamic"
+)
+
+type BundleBlob struct {
+	Name string `json:"name"`
+
+	Bundle     string   `json:"bundle"`
+	BundleType BlobType `json:"type"`
+
+	Version string `json:"version"`
+}


### PR DESCRIPTION
This only adds the build process for the bundle image so we can start generating these images regularly, ahead of creating a trust-manager release which actually uses the images.

The intention here is that we'll make a PR to https://github.com/jetstack/testing which will add a regular periodic to check if the latest image version available is the same as the latest `ca-certificates` version available in Debian.

That job will run `make ci-update-debian-bundle`, but this PR adds several targets relating to image building jobs we might need.

It's also proposed that if we're happy with `make/image-bundle-debian.mk` as a method of building, we could use that sort of approach for building and releasing trust-manager and other "sideprojects" where there's no defined repeatable build process.