### PR TITLE
Add a static bundle sidecar container build 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,8 +20,11 @@ WORKDIR /workspace
 COPY go.mod go.mod
 COPY go.sum go.sum
 
-# Copy the go source files
+# Copy build scripts
 COPY Makefile Makefile
+COPY make/ make/
+
+# Copy the go source files
 COPY cmd/ cmd/
 COPY pkg/ pkg/
 

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,12 @@ IMAGE_PLATFORMS ?= linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le
 
 RELEASE_VERSION ?= v0.3.0
 
+BUILDX_BUILDER ?= trust-manager-builder
+
+CONTAINER_REGISTRY ?= quay.io/jetstack
+
+include make/image-bundle-debian.mk
+
 .PHONY: help
 help:  ## display this help
 	@awk 'BEGIN {FS = ":.*##"; printf "\nUsage:\n  make \033[36m<target>\033[0m\n\nTargets:\n"} /^[a-zA-Z0-9_-]+:.*?##/ { printf "  \033[36m%-20s\033[0m %s\n", $$1, $$2 }' $(MAKEFILE_LIST)
@@ -53,20 +59,30 @@ generate: depend ## generate code
 .PHONY: verify
 verify: depend test verify-helm-docs build ## tests and builds trust
 
+# See wait-for-buildx.sh for an explanation of why it's needed
+.PHONY: provision-buildx
+provision-buildx:  ## set up docker buildx for multiarch building
+	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+	docker buildx rm $(BUILDX_BUILDER) &>/dev/null || :
+	./hack/wait-for-buildx.sh $(BUILDX_BUILDER) gone
+	docker buildx create --name $(BUILDX_BUILDER) --driver docker-container --use
+	./hack/wait-for-buildx.sh $(BUILDX_BUILDER) exists
+	docker buildx inspect --bootstrap --builder $(BUILDX_BUILDER)
+
 # image will only build and store the image locally, targeted in OCI format.
 # To actually push an image to the public repo, replace the `--output` flag and
 # arguments to `--push`.
 .PHONY: image
 image: | $(BINDIR) ## build docker image targeting all supported platforms
-	docker buildx build --platform=$(IMAGE_PLATFORMS) -t quay.io/jetstack/trust-manager:$(RELEASE_VERSION) --output type=local,dest=$(BINDIR)/trust-manager .
+	docker buildx build --builder $(BUILDX_BUILDER) --platform=$(IMAGE_PLATFORMS) -t $(CONTAINER_REGISTRY)/trust-manager:$(RELEASE_VERSION) --output type=local,dest=$(BINDIR)/trust-manager .
 
 .PHONY: kind-load
 kind-load: local-images | $(BINDIR)/kind
-	$(BINDIR)/kind load docker-image quay.io/jetstack/trust-manager:$(RELEASE_VERSION)
+	$(BINDIR)/kind load docker-image $(CONTAINER_REGISTRY)/trust-manager:$(RELEASE_VERSION) $(CONTAINER_REGISTRY)/cert-manager-bundle-debian:latest
 
 .PHONY: local-images
-local-images:
-	docker buildx build --platform=linux/amd64 -t quay.io/jetstack/trust-manager:$(RELEASE_VERSION) --load .
+local-images: bundle-debian-load
+	docker buildx build --builder $(BUILDX_BUILDER) --platform=linux/amd64 -t $(CONTAINER_REGISTRY)/trust-manager:$(RELEASE_VERSION) --load .
 
 .PHONY: chart
 chart: | $(BINDIR)/helm $(BINDIR)/chart

--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,14 @@ verify: depend test verify-helm-docs build ## tests and builds trust
 image: | $(BINDIR) ## build docker image targeting all supported platforms
 	docker buildx build --platform=$(IMAGE_PLATFORMS) -t quay.io/jetstack/trust-manager:$(RELEASE_VERSION) --output type=local,dest=$(BINDIR)/trust-manager .
 
+.PHONY: kind-load
+kind-load: local-images | $(BINDIR)/kind
+	$(BINDIR)/kind load docker-image quay.io/jetstack/trust-manager:$(RELEASE_VERSION)
+
+.PHONY: local-images
+local-images:
+	docker buildx build --platform=linux/amd64 -t quay.io/jetstack/trust-manager:$(RELEASE_VERSION) --load .
+
 .PHONY: chart
 chart: | $(BINDIR)/helm $(BINDIR)/chart
 	$(BINDIR)/helm package --app-version=$(RELEASE_VERSION) --version=$(RELEASE_VERSION) --destination "$(BINDIR)/chart" ./deploy/charts/trust-manager

--- a/bundles/debian/Containerfile
+++ b/bundles/debian/Containerfile
@@ -1,0 +1,51 @@
+# Copyright 2022 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM docker.io/library/debian:11-slim as debbase
+
+ARG EXPECTED_VERSION
+ARG VERSION_SUFFIX
+
+WORKDIR /work
+
+COPY ./build.sh /work/build.sh
+
+RUN /work/build.sh $EXPECTED_VERSION $VERSION_SUFFIX /work/bundle.json
+
+FROM docker.io/library/golang:1.19 as gobuild
+
+WORKDIR /work
+
+COPY go.mod go.mod
+COPY go.sum go.sum
+COPY main.go main.go
+
+RUN CGO_ENABLED=0 go build -o copyandpause main.go
+
+FROM scratch
+
+ARG EXPECTED_VERSION
+ARG VERSION_SUFFIX
+
+LABEL description="cert-manager debian static trust bundle"
+
+USER 1001
+
+COPY --from=debbase /usr/bin/tini-static /tini
+COPY --from=debbase /work/bundle.json /packaged-bundles/bundle-debian-$EXPECTED_VERSION$VERSION_SUFFIX.json
+COPY --from=gobuild /work/copyandpause /copyandpause
+
+ENTRYPOINT ["/tini", "--"]
+
+CMD ["/copyandpause", "/packaged-bundles", "/bundles"]

--- a/bundles/debian/build.sh
+++ b/bundles/debian/build.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This script is designed to be run during a build of the debian bundle container
+# As such, it's not designed to be portable and may only work in that situation
+
+EXPECTED_VERSION=${1:-}
+VERSION_SUFFIX=${2:-}
+DESTINATION_FILE=${3:-}
+
+if [[ -z $EXPECTED_VERSION || -z $VERSION_SUFFIX || -z $DESTINATION_FILE ]]; then
+	echo "usage: $0 <expected version> <version suffix> <destination file>"
+	exit 1
+fi
+
+apt-get -yq update
+DEBIAN_FRONTEND=noninteractive apt-get -yq -o=Dpkg::Use-Pty=0 install --no-install-recommends ca-certificates jq tini
+
+INSTALLED_VERSION=$(dpkg-query --show --showformat="\${Version}" ca-certificates)
+
+if [[ "$EXPECTED_VERSION" != "latest" ]]; then
+	if [[ "$EXPECTED_VERSION" != "$INSTALLED_VERSION" ]]; then
+		echo "expected version $EXPECTED_VERSION but got $INSTALLED_VERSION"
+		echo "this might mean that debian released an update between querying for version $EXPECTED_VERSION and running this build script"
+		echo "exiting for safety"
+		exit 1
+	fi
+fi
+
+echo "{}" | jq \
+	--rawfile bundle /etc/ssl/certs/ca-certificates.crt \
+	--arg type "static" \
+	--arg version "$EXPECTED_VERSION$VERSION_SUFFIX" \
+	'.bundle = $bundle | .type = $type | .version = $version' \
+	> $DESTINATION_FILE

--- a/bundles/debian/go.mod
+++ b/bundles/debian/go.mod
@@ -1,0 +1,3 @@
+module github.com/cert-manager/trust-manager/debian-bundle-static
+
+go 1.19

--- a/bundles/debian/main.go
+++ b/bundles/debian/main.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"io/fs"
+	"log"
+	"os"
+	"os/signal"
+	"path/filepath"
+	"syscall"
+)
+
+func main() {
+	stderrLogger := log.New(os.Stderr, "", log.LstdFlags)
+
+	if len(os.Args) != 3 {
+		stderrLogger.Fatalf("usage: %s <input-folder> <output-folder>", os.Args[0])
+	}
+
+	inputDir := os.Args[1]
+	destinationDir := os.Args[2]
+
+	stderrLogger.Printf("reading from %q", inputDir)
+	stderrLogger.Printf("writing to %q", destinationDir)
+
+	if err := dirOrError(inputDir); err != nil {
+		stderrLogger.Fatalf("couldn't confirm that input path is a directory that exists: %s", err.Error())
+	}
+
+	if err := dirOrError(destinationDir); err != nil {
+		stderrLogger.Fatalf("couldn't confirm that output path is a directory that exists: %s", err.Error())
+	}
+
+	walkErr := filepath.Walk(inputDir, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if filepath.Ext(path) != ".json" {
+			return nil
+		}
+
+		var input *os.File
+		var target *os.File
+
+		input, err = os.Open(path)
+		if err != nil {
+			return fmt.Errorf("failed to open file %q for reading: %w", path, err)
+		}
+
+		defer func() {
+			err := input.Close()
+			if err != nil {
+				stderrLogger.Printf("failed to close input file: %s", err.Error())
+			}
+		}()
+
+		destinationFile := filepath.Join(destinationDir, filepath.Base(path))
+
+		target, err = os.OpenFile(destinationFile, os.O_WRONLY|os.O_TRUNC|os.O_CREATE, 0o664)
+		if err != nil {
+			return fmt.Errorf("failed to open file %q for writing: %w", destinationFile, err)
+		}
+
+		defer func() {
+			err := target.Close()
+			if err != nil {
+				stderrLogger.Printf("failed to close output file: %s", err.Error())
+			}
+		}()
+
+		if _, err := io.Copy(target, input); err != nil {
+			return fmt.Errorf("failed to copy source %q to destination %q: %w", path, destinationFile, err)
+		}
+
+		stderrLogger.Printf("successfully copied %q to %q", path, destinationFile)
+
+		return nil
+	})
+
+	if walkErr != nil {
+		stderrLogger.Fatalf("failed to walk input dir %q: %s", inputDir, walkErr.Error())
+	}
+
+	stderrLogger.Printf("finished copying, waiting for termination signal")
+
+	// TODO: if we add the ability to reap zombie processes, this could function as a full init
+
+	sigs := make(chan os.Signal, 1)
+
+	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)
+	<-sigs
+
+	stderrLogger.Println("received interrupt, closing")
+}
+
+func dirOrError(name string) error {
+	info, err := os.Stat(name)
+	if err != nil {
+		return err
+	}
+
+	if !info.IsDir() {
+		return fmt.Errorf("%q is not a directory", name)
+	}
+
+	return nil
+}

--- a/gcb/ci-update-debian-bundle.yaml
+++ b/gcb/ci-update-debian-bundle.yaml
@@ -1,0 +1,49 @@
+# This job runs the ci-update-debian-bundle target to keep the debian bundle up-to-date
+# It's designed to be a cloudbuild trigger invoked on a regular schedule
+
+timeout: 14400s
+
+secrets:
+- kmsKeyName: projects/cert-manager-release/locations/europe-west1/keyRings/cert-manager-release/cryptoKeys/cert-manager-release-secret-key
+  secretEnv:
+    DOCKER_CONFIG: CiQAPjqeEyZx+aSgFNoW7KQ4wE4hp/9vbWElifjHJNTI0/71ywMSkwIAUOH2xwTfrn72i6p+Op2PYnjDfwMBcInMEtgKAqiTsaup3R5HeL8BsZGuWxVhCEm5CJJ0Rg3CPdFUx2IVmCfC3j32LkAiMxMpszdHTjWHEyWmxwtBlTJW8NFmoYzxfN4Ox9rYFF66eZ0XVdLz1UejXpqAkGFVzTzQSu4rvNFnAsP5Sj7ZKJpXn+p0ZZW1IdMTD0xzCwZjW9hhcTjyNaCKDJYwl8j6Y/bYeoUMrzDQNk48fzKIBgxEdUTR2OOAI785GWSrkB4Y03oEyrfw8jTd1yAoil2S6p3AGV1FbvFleajSCy3Ov+5gjomjtqCbTx06hVsTcqLHC45WzAWPa/8TsiXh5PPgBbkg+pfBQUTj6i9+WA==
+
+steps:
+# NB: REF_NAME is auto-populated by cloud build based on the
+# configured repo in the GCB trigger
+- name: gcr.io/cloud-builders/git
+  dir: "trust-manager"
+  entrypoint: bash
+  args:
+  - -c
+  - |
+    set -e
+    git clone ${_REPO} .
+    git checkout ${REF_NAME}
+
+- name: 'eu.gcr.io/jetstack-build-infra-images/bazelbuild:${_BUILDER_IMAGE_TAG}'
+  entrypoint: bash
+  secretEnv:
+  - DOCKER_CONFIG
+  args:
+  - -c
+  - |
+    mkdir -p $$HOME/.docker
+    echo "$${DOCKER_CONFIG}" > $$HOME/.docker/config.json
+
+- name: 'eu.gcr.io/jetstack-build-infra-images/bazelbuild:${_BUILDER_IMAGE_TAG}'
+  dir: "trust-manager"
+  entrypoint: bash
+  args:
+  - -c
+  - |
+    set -eu -o pipefail
+    make provision-buildx
+    make ci-update-debian-bundle
+
+tags:
+- "trust-manager-bundle"
+
+substitutions:
+  _REPO: "https://github.com/cert-manager/trust-manager"
+  _BUILDER_IMAGE_TAG: "20220629-ee75d11-4.2.1"

--- a/hack/update-debian-ca-bundle.sh
+++ b/hack/update-debian-ca-bundle.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This script uses a container to install the latest ca-certificates package, and then
+# checks to see if the installed version of that package matches the latest available
+# debian bundle image in our container registry.
+
+# If we installed a newer version in the local container, we build a new image container
+# and push it upstream
+
+CTR=${CTR:-docker}
+
+REPO=${1:-}
+DEBIAN_BUNDLE_SUFFIX=${2:-}
+
+DEBIAN_IMAGE=docker.io/library/debian:11-slim
+
+function print_usage() {
+	echo "usage: $0 <target-repo> <version-suffix>"
+}
+
+if ! command -v $CTR &>/dev/null; then
+	print_usage
+	echo "This script requires a docker CLI compatible runtime, either docker or podman"
+	echo "If CTR is not set, defaults to using docker"
+	echo "Couldn't find $CTR command; exiting"
+	exit 1
+fi
+
+if [[ -z $REPO ]]; then
+	print_usage
+	echo "Missing target-repo"
+	exit 1
+fi
+
+if [[ -z $DEBIAN_BUNDLE_SUFFIX ]]; then
+	print_usage
+	echo "Missing version suffix"
+	exit 1
+fi
+
+function latest_ca_certificate_package_version() {
+	# Install the latest version of ca-certificates in a fresh container and print the
+	# installed version
+
+	# There are several commands for querying remote repos (e.g. apt-cache madison) but
+	# it's not clear that these commands are guaranteed to return installable versions
+	# in order or in a parseable format
+
+	# We specifically only want to query the latest version and without a guarantee on
+	# output ordering it's safest to install what apt thinks is the latest version and
+	# then see what we got.
+
+	# NB: It's also very difficult to make 'apt-get' stay quiet when installing packages
+	# so we just let it be loud and then only take the last line of output
+
+	$CTR run --rm $DEBIAN_IMAGE bash -c 'apt-get -yq update >/dev/null && DEBIAN_FRONTEND=noninteractive apt-get -qy -o=Dpkg::Use-Pty=0 install --no-install-recommends ca-certificates >/dev/null && dpkg-query --show --showformat="\${Version}" ca-certificates' | tail -1
+}
+
+echo "+++ fetching latest version of ca-certificates package"
+
+CA_CERTIFICATES_VERSION=$(latest_ca_certificate_package_version)
+
+# Rather than use CA_CERTIFICATES_VERSION directly as an image tag, suffix our own version number
+# that we control. We can increment this if we need to build a second version of a given ca-certificates,
+# say to add a new file or update the contents.
+
+IMAGE_TAG=$CA_CERTIFICATES_VERSION$DEBIAN_BUNDLE_SUFFIX
+
+FULL_IMAGE=$REPO:$IMAGE_TAG
+
+echo "+++ searching for $FULL_IMAGE in upstream registry"
+
+# Look for an image tagged with IMAGE_TAG; if it exists, we're done. If not, we need to build + upload it.
+$CTR run --rm gcr.io/go-containerregistry/crane:v0.12.1 digest $FULL_IMAGE && echo "latest image appears to be up-to-date; exiting" && exit 0
+
+echo "+++ latest image appears not to exist; building and pushing $FULL_IMAGE"
+
+make DEBIAN_BUNDLE_VERSION=$CA_CERTIFICATES_VERSION DEBIAN_BUNDLE_SUFFIX=$DEBIAN_BUNDLE_SUFFIX bundle-debian-push

--- a/hack/wait-for-buildx.sh
+++ b/hack/wait-for-buildx.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# File taken from a closed-source project originally written by SgtCoDFish
+# Contributed to the trust-manager project under the above Apache license
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# This script is required as "buildx rm" and "buildx create" can return successfully
+# before they actually finish. We need to ensure that the builder is actually removed
+# or created (as needed) before we proceed.
+
+BUILDX_BUILDER=${1:-}
+MODE=${2:-}
+
+if [[ -z $BUILDX_BUILDER ]]; then
+	echo "usage: $0 <builder-name> <mode>"
+	echo "error: missing builder name. exiting"
+	exit 1
+fi
+
+if [[ $MODE != "exists" && $MODE != "gone" ]]; then
+	echo "usage: $0 <builder-name> <mode>"
+	echo "error: invalid mode, expected either 'exists' or 'gone'"
+	echo "'exists' means 'wait for the builder to exist'"
+	echo "'gone' means 'wait for the builder to not exist'"
+	exit 1
+fi
+
+RETRIES=5
+
+if [[ $MODE = "exists" ]]; then
+	until docker buildx inspect --builder $1 >/dev/null 2>&1 || [ $RETRIES -eq 0 ]; do
+		echo "Waiting for buildx builder to exist, $((RETRIES--)) remaining attempts..."
+		sleep 1
+	done
+else
+	while docker buildx inspect --builder $1 >/dev/null 2>&1 || [ $RETRIES -eq 0 ]; do
+		echo "Waiting for buildx builder to not exist, $((RETRIES--)) remaining attempts..."
+		sleep 1
+	done
+fi

--- a/make/image-bundle-debian.mk
+++ b/make/image-bundle-debian.mk
@@ -1,0 +1,40 @@
+DEBIAN_BUNDLE_VERSION ?=
+DEBIAN_BUNDLE_SUFFIX ?= .0
+
+define build_image_bundle
+	docker buildx build --builder $(BUILDX_BUILDER) \
+		--platform=$(3) \
+		-t $(CONTAINER_REGISTRY)/cert-manager-bundle-debian:$(2)$(DEBIAN_BUNDLE_SUFFIX) \
+		--build-arg EXPECTED_VERSION=$(2) \
+		--build-arg VERSION_SUFFIX=$(DEBIAN_BUNDLE_SUFFIX) \
+		--output $(1) \
+		-f ./bundles/debian/Containerfile \
+		./bundles/debian
+endef
+
+# can't use a comma in an argument to a make function, so define a variable instead
+_COMMA := ,
+
+.PHONY: bundle-debian-save
+bundle-debian-save:
+ifeq ($(strip $(DEBIAN_BUNDLE_VERSION)),)
+	$(error DEBIAN_BUNDLE_VERSION must be set for $@)
+endif
+
+	$(call build_image_bundle,type=local$(_COMMA)dest=$(BINDIR)/cert-manager-bundle-debian,$(DEBIAN_BUNDLE_VERSION),$(IMAGE_PLATFORMS))
+
+.PHONY: bundle-debian-load
+bundle-debian-load:
+	$(call build_image_bundle,type=docker,latest,linux/amd64)
+
+.PHONY: bundle-debian-push
+bundle-debian-push:
+ifeq ($(strip $(DEBIAN_BUNDLE_VERSION)),)
+	$(error DEBIAN_BUNDLE_VERSION must be set for $@)
+endif
+
+	$(call build_image_bundle,type=registry,$(DEBIAN_BUNDLE_VERSION),$(IMAGE_PLATFORMS))
+
+.PHONY: ci-update-debian-bundle
+ci-update-debian-bundle:
+	./hack/update-debian-ca-bundle.sh "$(CONTAINER_REGISTRY)/cert-manager-bundle-debian" $(DEBIAN_BUNDLE_SUFFIX)


### PR DESCRIPTION
This only adds the build process so we can start generating these images regualarly, ahead of creating a trust-manager release which actually uses the images.

Also adds buildx provisioning and uses named a named buildx builder for trust-manager specifically.

The build is intended to be regularly scheduled in cloudbuild using the provided `gcb/ci-update-debian-bundle.yaml` file.

I'd propose currently that this takes the form of us creating a cloudbuild trigger and schedule by hand. I've done that in my own GCP project and confirmed it works as expected. Ideally we'd terraform this, but we don't have that infrastructure in place currently and I don't think this is the time to shave that yak!

See https://quay.io/repository/adjetstack/cert-manager-bundle-debian?tab=tags for an example of the built images in practice.