### PR TITLE
Add PEM verification function

### DIFF
--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -49,10 +49,10 @@ type bundle struct {
 	// client is a Kubernetes client that makes calls to the API for every
 	// request.
 	// Should be used for updating, deleting, and when requesting data from
-	// resources who's informer only caches metadata.
+	// resources whose informer only caches metadata.
 	client client.Client
 
-	// lister makes requests to the informer cache. Beware that resources who's
+	// lister makes requests to the informer cache. Beware that resources whose
 	// informer only caches metadata, will not return underlying data of that
 	// resource. Use client instead.
 	lister client.Reader

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -36,6 +36,7 @@ import (
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
+	"github.com/cert-manager/trust-manager/test/dummy"
 	"github.com/cert-manager/trust-manager/test/gen"
 )
 
@@ -62,7 +63,7 @@ func Test_Reconcile(t *testing.T) {
 				Namespace: trustNamespace,
 			},
 			Data: map[string]string{
-				"configmap-key": "A",
+				"configmap-key": dummy.TestCertificate1,
 			},
 		}
 		sourceSecret runtime.Object = &corev1.Secret{
@@ -72,7 +73,7 @@ func Test_Reconcile(t *testing.T) {
 				Namespace: trustNamespace,
 			},
 			Data: map[string][]byte{
-				"secret-key": []byte("B"),
+				"secret-key": []byte(dummy.TestCertificate2),
 			},
 		}
 
@@ -88,7 +89,7 @@ func Test_Reconcile(t *testing.T) {
 				Sources: []trustapi.BundleSource{
 					{ConfigMap: &trustapi.SourceObjectKeySelector{Name: sourceConfigMapName, KeySelector: trustapi.KeySelector{Key: sourceConfigMapKey}}},
 					{Secret: &trustapi.SourceObjectKeySelector{Name: sourceSecretName, KeySelector: trustapi.KeySelector{Key: sourceSecretKey}}},
-					{InLine: pointer.String("C")},
+					{InLine: pointer.String(dummy.TestCertificate3)},
 				},
 				Target: trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{Key: targetKey}},
 			},
@@ -121,7 +122,7 @@ func Test_Reconcile(t *testing.T) {
 			expObjects:      append(namespaces, sourceConfigMap, sourceSecret),
 			expEvent:        "",
 		},
-		"if Bundle references a ConfigMap which does not exist, update not found": {
+		"if Bundle references a ConfigMap which does not exist, update with 'not found'": {
 			existingObjects: append(namespaces, sourceSecret, gen.BundleFrom(baseBundle)),
 			expResult:       ctrl.Result{},
 			expError:        false,
@@ -142,7 +143,7 @@ func Test_Reconcile(t *testing.T) {
 			),
 			expEvent: `Warning SourceNotFound Bundle source was not found: failed to retrieve bundle from source: configmaps "source-configmap" not found`,
 		},
-		"if Bundle references a ConfigMap who's key doesn't exist, update not found": {
+		"if Bundle references a ConfigMap whose key doesn't exist, update with 'not found'": {
 			existingObjects: append(namespaces,
 				&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: trustNamespace, Name: sourceConfigMapName}},
 				sourceSecret, gen.BundleFrom(baseBundle)),
@@ -169,7 +170,7 @@ func Test_Reconcile(t *testing.T) {
 			),
 			expEvent: `Warning SourceNotFound Bundle source was not found: failed to retrieve bundle from source: no data found in ConfigMap trust-namespace/source-configmap at key "configmap-key"`,
 		},
-		"if Bundle references a Secret which does not exist, update not found": {
+		"if Bundle references a Secret which does not exist, update with 'not found'": {
 			existingObjects: append(namespaces, sourceConfigMap, gen.BundleFrom(baseBundle)),
 			expResult:       ctrl.Result{},
 			expError:        false,
@@ -190,7 +191,7 @@ func Test_Reconcile(t *testing.T) {
 			),
 			expEvent: `Warning SourceNotFound Bundle source was not found: failed to retrieve bundle from source: secrets "source-secret" not found`,
 		},
-		"if Bundle references a Secret who's key doesn't exist, update not found": {
+		"if Bundle references a Secret whose key doesn't exist, update with 'not found'": {
 			existingObjects: append(namespaces, sourceConfigMap,
 				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: trustNamespace, Name: sourceSecretName}},
 				gen.BundleFrom(baseBundle)),
@@ -273,17 +274,17 @@ func Test_Reconcile(t *testing.T) {
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: trustNamespace, Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "1"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: dummy.DefaultJoinedCerts()},
 				},
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-1", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "1"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: dummy.DefaultJoinedCerts()},
 				},
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-2", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "1"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: dummy.DefaultJoinedCerts()},
 				},
 			),
 			expEvent: "Normal Synced Successfully synced Bundle to all namespaces",
@@ -316,17 +317,17 @@ func Test_Reconcile(t *testing.T) {
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: trustNamespace, Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "1"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: dummy.DefaultJoinedCerts()},
 				},
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-1", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "1"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: dummy.DefaultJoinedCerts()},
 				},
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-2", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "1"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: dummy.DefaultJoinedCerts()},
 				},
 			),
 			expEvent: "Normal Synced Successfully synced Bundle to all namespaces",
@@ -376,12 +377,12 @@ func Test_Reconcile(t *testing.T) {
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: "random-namespace", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "1"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: dummy.DefaultJoinedCerts()},
 				},
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: "another-random-namespace", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "1"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: dummy.DefaultJoinedCerts()},
 				},
 			),
 			expEvent: "Normal Synced Successfully synced Bundle to namespaces with selector [matchLabels:map[foo:bar]]",
@@ -393,17 +394,17 @@ func Test_Reconcile(t *testing.T) {
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: trustNamespace, Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "1"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: dummy.DefaultJoinedCerts()},
 				},
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-1", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "1"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: dummy.DefaultJoinedCerts()},
 				},
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-2", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "1"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: dummy.DefaultJoinedCerts()},
 				},
 			),
 			expResult: ctrl.Result{},
@@ -453,15 +454,15 @@ func Test_Reconcile(t *testing.T) {
 				),
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Namespace: trustNamespace, Name: baseBundle.Name},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: dummy.DefaultJoinedCerts()},
 				},
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-1", Name: baseBundle.Name},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: dummy.DefaultJoinedCerts()},
 				},
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-2", Name: baseBundle.Name},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: dummy.DefaultJoinedCerts()},
 				},
 			),
 			expResult: ctrl.Result{},
@@ -486,17 +487,17 @@ func Test_Reconcile(t *testing.T) {
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: trustNamespace, Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "1000"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: dummy.DefaultJoinedCerts()},
 				},
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-1", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "1000"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: dummy.DefaultJoinedCerts()},
 				},
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-2", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "1000"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: dummy.DefaultJoinedCerts()},
 				},
 			),
 			expEvent: "Normal Synced Successfully synced Bundle to all namespaces",
@@ -506,17 +507,17 @@ func Test_Reconcile(t *testing.T) {
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: trustNamespace, Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: dummy.DefaultJoinedCerts()},
 				},
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-1", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: dummy.DefaultJoinedCerts()},
 				},
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-2", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: dummy.DefaultJoinedCerts()},
 				},
 			),
 			expResult: ctrl.Result{},
@@ -541,17 +542,17 @@ func Test_Reconcile(t *testing.T) {
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: trustNamespace, Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "999"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: dummy.DefaultJoinedCerts()},
 				},
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-1", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "999"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: dummy.DefaultJoinedCerts()},
 				},
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-2", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "999"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: dummy.DefaultJoinedCerts()},
 				},
 			),
 			expEvent: "Normal Synced Successfully synced Bundle to all namespaces",
@@ -575,15 +576,15 @@ func Test_Reconcile(t *testing.T) {
 				),
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Namespace: trustNamespace, Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: dummy.DefaultJoinedCerts()},
 				},
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-1", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: dummy.DefaultJoinedCerts()},
 				},
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-2", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: dummy.DefaultJoinedCerts()},
 				},
 			),
 			expResult: ctrl.Result{},
@@ -608,17 +609,17 @@ func Test_Reconcile(t *testing.T) {
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: trustNamespace, Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "999"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: dummy.DefaultJoinedCerts()},
 				},
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-1", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "999"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: dummy.DefaultJoinedCerts()},
 				},
 				&corev1.ConfigMap{
 					TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 					ObjectMeta: metav1.ObjectMeta{Namespace: "ns-2", Name: baseBundle.Name, OwnerReferences: baseBundleOwnerRef, ResourceVersion: "999"},
-					Data:       map[string]string{targetKey: "A\nB\nC\n"},
+					Data:       map[string]string{targetKey: dummy.DefaultJoinedCerts()},
 				},
 			),
 			expEvent: "",

--- a/pkg/bundle/sync.go
+++ b/pkg/bundle/sync.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
+	"github.com/cert-manager/trust-manager/pkg/util"
 )
 
 type notFoundError struct{ error }
@@ -61,7 +62,12 @@ func (b *bundle) buildSourceBundle(ctx context.Context, bundle *trustapi.Bundle)
 			return "", fmt.Errorf("failed to retrieve bundle from source: %w", err)
 		}
 
-		data = append(data, strings.TrimSpace(sourceData))
+		sanitizedBundle, err := util.ValidateAndSanitizePEMBundle([]byte(sourceData))
+		if err != nil {
+			return "", fmt.Errorf("invalid PEM data in source: %w", err)
+		}
+
+		data = append(data, string(sanitizedBundle))
 	}
 
 	// return early to prevent returning just newline

--- a/pkg/util/pem.go
+++ b/pkg/util/pem.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"bytes"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+)
+
+// ValidateAndSanitizePEMBundle strictly validates a given input PEM bundle to confirm it contains
+// only valid CERTIFICATE PEM blocks. If successful, returns the validated PEM blocks with any
+// comments or extra data stripped.
+
+// This validation is broadly similar to the standard library funtion
+// crypto/x509.CertPool.AppendCertsFromPEM - that is, we decode each PEM block at a time and parse
+// it as a certificate.
+
+// The difference here is that we want to ensure that the bundle _only_ contains certificates, and
+// not just skip over things which aren't certificates.
+
+// If, for example, someone accidentally used a combined cert + private key as an input to a trust
+// bundle, we wouldn't want to then distribute the private key in the target.
+
+// In addition, the standard library AppendCertsFromPEM also silently skips PEM blocks with
+// non-empty Headers. We error on such PEM blocks, for the same reason as above; headers could
+// contain (accidental) private information. They're also non-standard according to
+// https://www.rfc-editor.org/rfc/rfc7468
+
+// See also https://github.com/golang/go/blob/5d5ed57b134b7a02259ff070864f753c9e601a18/src/crypto/x509/cert_pool.go#L201-L239
+func ValidateAndSanitizePEMBundle(data []byte) ([]byte, error) {
+	var certificates [][]byte
+
+	for {
+		var b *pem.Block
+		b, data = pem.Decode(data)
+
+		if b == nil {
+			break
+		}
+
+		if b.Type != "CERTIFICATE" {
+			// only certificates are allowed in a bundle
+			return nil, fmt.Errorf("invalid PEM block in bundle: only CERTIFICATE blocks are permitted but found '%s'", b.Type)
+		}
+
+		if len(b.Headers) != 0 {
+			return nil, fmt.Errorf("invalid PEM block in bundle; blocks are not permitted to have PEM headers")
+		}
+
+		_, err := x509.ParseCertificate(b.Bytes)
+		if err != nil {
+			// the presence of an invalid cert (including things which aren't certs)
+			// should cause the bundle to be rejected
+			return nil, fmt.Errorf("invalid PEM block in bundle; invalid PEM certificate: %w", err)
+		}
+
+		certificates = append(certificates, pem.EncodeToMemory(b))
+	}
+
+	if len(certificates) == 0 {
+		return nil, fmt.Errorf("bundle contains no PEM certificates")
+	}
+
+	return bytes.TrimSpace(bytes.Join(certificates, nil)), nil
+}

--- a/pkg/util/pem_test.go
+++ b/pkg/util/pem_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	"github.com/cert-manager/trust-manager/test/dummy"
+)
+
+func TestValidateAndSanitizePEMBundle(t *testing.T) {
+	poisonComment := []byte{0xFF}
+	// strippableComments is a list of things which should not be present in the output
+	strippableText := [][]byte{
+		[]byte(randomComment),
+		poisonComment,
+	}
+
+	cases := map[string]struct {
+		parts []string
+
+		expectErr bool
+	}{
+		"valid bundle with all types of cert and no comments succeeds": {
+			parts:     []string{dummy.TestCertificate1, dummy.TestCertificate2, dummy.TestCertificate3},
+			expectErr: false,
+		},
+		"valid bundle with all types of cert and a random comment succeeds": {
+			parts:     []string{dummy.TestCertificate1, randomComment, dummy.TestCertificate2, randomComment, dummy.TestCertificate3, randomComment},
+			expectErr: false,
+		},
+		"valid bundle with all types of cert and a poison comment succeeds": {
+			parts:     []string{dummy.TestCertificate1, string(poisonComment), dummy.TestCertificate2, randomComment, dummy.TestCertificate3, string(poisonComment)},
+			expectErr: false,
+		},
+		"invalid bundle with a certificate with a header fails": {
+			parts:     []string{dummy.TestCertificate1, dummyCertificateWithHeader, dummy.TestCertificate3},
+			expectErr: true,
+		},
+		"invalid bundle with a certificate with invalid base64 fails": {
+			parts:     []string{dummy.TestCertificate1, invalidCertificate, dummy.TestCertificate3},
+			expectErr: true,
+		},
+		"invalid bundle containing a private key fails": {
+			parts:     []string{dummy.TestCertificate1, privateKey},
+			expectErr: true,
+		},
+		"invalid bundle with no certificates fails": {
+			parts:     []string{"abc123"},
+			expectErr: true,
+		},
+	}
+
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			inputBundle := []byte(strings.Join(test.parts, "\n"))
+
+			sanitizedBundleBytes, err := ValidateAndSanitizePEMBundle(inputBundle)
+
+			if test.expectErr != (err != nil) {
+				t.Fatalf("ValidateAndSanitizePEMBundle: expectErr: %v | err: %v", test.expectErr, err)
+			}
+
+			if test.expectErr {
+				return
+			}
+
+			if sanitizedBundleBytes == nil {
+				t.Fatalf("got no error from ValidateAndSanitizePEMBundle but sanitizedBundle was nil")
+			}
+
+			for _, strippable := range strippableText {
+				if bytes.Contains(sanitizedBundleBytes, strippable) {
+					// can't print the comment since it could be an invalid string
+					t.Errorf("expected sanitizedBundle to not contain a comment but it did")
+				}
+			}
+
+			if !utf8.Valid(sanitizedBundleBytes) {
+				t.Error("expected sanitizedBundle to be valid UTF-8 but it wasn't")
+			}
+
+			sanitizedBundle := string(sanitizedBundleBytes)
+
+			if strings.HasSuffix(sanitizedBundle, "\n") {
+				t.Errorf("expected sanitizedBundle not to end with a newline")
+			}
+
+			for _, line := range strings.Split(sanitizedBundle, "\n") {
+				// Check that each "encapsulation boundary" (-----BEGIN/END <x>-----) is on its
+				// own line. ("Encapsulation boundary" is apparently the name according to rfc7468)
+				if !strings.HasPrefix(line, "-----") {
+					continue
+				}
+
+				if !strings.HasSuffix(line, "-----") || strings.Count(line, "-----") != 2 {
+					t.Errorf("invalid encapsulation boundary on line of certificate")
+				}
+			}
+		})
+	}
+}
+
+const randomComment = `some random commentary`
+
+const dummyCertificateWithHeader = `-----BEGIN CERTIFICATE-----
+My-Header: Abc123
+
+MIIBVDCCAQagAwIBAgIRANcos1c12CXTCm8qyZto2LswBQYDK2VwMDAxFTATBgNV
+BAoTDGNlcnQtbWFuYWdlcjEXMBUGA1UEAxMOY21jdC10ZXN0LXJvb3QwHhcNMjIx
+MjA1MTYyMjQyWhcNMzIxMjAyMTYyMjQyWjAwMRUwEwYDVQQKEwxjZXJ0LW1hbmFn
+ZXIxFzAVBgNVBAMTDmNtY3QtdGVzdC1yb290MCowBQYDK2VwAyEAWjVDu9495KZ4
+g0YFJ94jggGrt3NFXWk6Mb51pCBylSyjNTAzMBIGA1UdEwEB/wQIMAYBAf8CAQMw
+HQYDVR0OBBYEFFjCqrTVVpQRdBANLzgdKx3agWxIMAUGAytlcANBAEqb5PmhXtlA
+gySihG5glByO5ZajFBNBIhjOF6+yfN1Bo5XjJ7bGwVIhGoRPHCtbvsnfuQ5ySz95
+CFD1BItRnQM=
+-----END CERTIFICATE-----`
+
+// invalidCertificate has random characters manually replaced with "a"s; if we'd just randomly
+// deleted characters to make the base64 invalid, then pem.Decode would skip over the block and we
+// wouldn't ever try to parse it
+const invalidCertificate = `-----BEGIN CERTIFICATE-----
+MIIBVDCCAQagAwIBAgIRANcos1c12CXTCm8qyZto2LswBQYDK2VwMDAxFTATBgNV
+BAoTDGNlcnQtbWFuYWdlcjEXMBUGA1UEAxMOY21jdC10ZXN0LHhcNMjIxaaaaaaa
+MjA1MTYyMjQyWhcNMzIxMjAyMTYyMjQyWjAwMRUwEwYDVQQKEwxjZXJ0LW1hbmFn
+xFzAVBgNVBAMTDmNtY3QtdGVzdC1yb290MCowBQYDK2VwAyEAWjVDu9495KZ4aaa
+g0YFJ94jggGrt3NFXWk6Mb51pCBylSyjNTAzMBIGA1UdEwEB/wQIMAYBAf8CAQMw
+VR0OBBYEFFjCqrTVVpQRdBANLzgdKx3agWxIMAUGAytlcAEqb5PmhXtlAaaaaaaa
+gySihG5glByO5ZajFBNBIhjOF6+yfN1Bo5XjJ7bGwVIhGoRPHCtbvsnfuQ5ySz95
+CFD1BItRnQM=
+-----END CERTIFICATE-----`
+
+const privateKey = `-----BEGIN EC PRIVATE KEY-----
+MHcCAQEEIHThSpdYMjW1k4K2r8RwhIGmknKrr0XKQLOJeL2fVoxToAoGCCqGSM49
+AwEHoUQDQgAEoMocv03WW/kCmyYM7CN7Ge7J5NOhJOKUYjF15NRBevWbxd8GYsvj
+9yCaAWu1mIQpIuWI4pXHU9s4V0FDlIKerQ==
+-----END EC PRIVATE KEY-----`

--- a/pkg/webhook/validation_test.go
+++ b/pkg/webhook/validation_test.go
@@ -64,7 +64,7 @@ func Test_Handle(t *testing.T) {
 				},
 			},
 		},
-		"a resource who's type is not recognised should return a Denied response": {
+		"a resource whose type is not recognised should return a Denied response": {
 			req: admission.Request{
 				AdmissionRequest: admissionv1.AdmissionRequest{
 					UID: types.UID("abc"),

--- a/test/dummy/certificates.go
+++ b/test/dummy/certificates.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Contains various PEM-encoded certificates for use in other tests.
+
+package dummy
+
+import (
+	"strings"
+)
+
+const (
+	TestCertificate1 = `-----BEGIN CERTIFICATE-----
+MIIBkzCCATmgAwIBAgIQD3oJqHEJAjT25rEGY6kLgTAKBggqhkjOPQQDAjAwMRUw
+EwYDVQQKEwxjZXJ0LW1hbmFnZXIxFzAVBgNVBAMTDmNtY3QtdGVzdC1yb290MB4X
+DTIyMTEyNTEzMDM1NFoXDTMyMTEyMjEzMDM1NFowMDEVMBMGA1UEChMMY2VydC1t
+YW5hZ2VyMRcwFQYDVQQDEw5jbWN0LXRlc3Qtcm9vdDBZMBMGByqGSM49AgEGCCqG
+SM49AwEHA0IABG0axFSG2TE+I2BP2vwdXc79oUCTUewsddgZOq2f+dKjWU5XyPNc
+EAxMp37tVjQvsC4cRYEo+uYSmMVcQi4kkVGjNTAzMBIGA1UdEwEB/wQIMAYBAf8C
+AQMwHQYDVR0OBBYEFNcEG2uzzT9bczLSnPuEe98nJkVQMAoGCCqGSM49BAMCA0gA
+MEUCIQCeN2/Z7jSJJK7m7kcZ/UgJIqbzKS1ktycUQ50+dhqNogIgaTYRjIxZFJ3u
+VhGzjAqH8YyuEObapwh4bTZkapwoDZQ=
+-----END CERTIFICATE-----`
+
+	TestCertificate2 = `-----BEGIN CERTIFICATE-----
+MIIBVDCCAQagAwIBAgIRANcos1c12CXTCm8qyZto2LswBQYDK2VwMDAxFTATBgNV
+BAoTDGNlcnQtbWFuYWdlcjEXMBUGA1UEAxMOY21jdC10ZXN0LXJvb3QwHhcNMjIx
+MjA1MTYyMjQyWhcNMzIxMjAyMTYyMjQyWjAwMRUwEwYDVQQKEwxjZXJ0LW1hbmFn
+ZXIxFzAVBgNVBAMTDmNtY3QtdGVzdC1yb290MCowBQYDK2VwAyEAWjVDu9495KZ4
+g0YFJ94jggGrt3NFXWk6Mb51pCBylSyjNTAzMBIGA1UdEwEB/wQIMAYBAf8CAQMw
+HQYDVR0OBBYEFFjCqrTVVpQRdBANLzgdKx3agWxIMAUGAytlcANBAEqb5PmhXtlA
+gySihG5glByO5ZajFBNBIhjOF6+yfN1Bo5XjJ7bGwVIhGoRPHCtbvsnfuQ5ySz95
+CFD1BItRnQM=
+-----END CERTIFICATE-----`
+
+	TestCertificate3 = `-----BEGIN CERTIFICATE-----
+MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw
+TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh
+cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTUwNjA0MTEwNDM4
+WhcNMzUwNjA0MTEwNDM4WjBPMQswCQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJu
+ZXQgU2VjdXJpdHkgUmVzZWFyY2ggR3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBY
+MTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK3oJHP0FDfzm54rVygc
+h77ct984kIxuPOZXoHj3dcKi/vVqbvYATyjb3miGbESTtrFj/RQSa78f0uoxmyF+
+0TM8ukj13Xnfs7j/EvEhmkvBioZxaUpmZmyPfjxwv60pIgbz5MDmgK7iS4+3mX6U
+A5/TR5d8mUgjU+g4rk8Kb4Mu0UlXjIB0ttov0DiNewNwIRt18jA8+o+u3dpjq+sW
+T8KOEUt+zwvo/7V3LvSye0rgTBIlDHCNAymg4VMk7BPZ7hm/ELNKjD+Jo2FR3qyH
+B5T0Y3HsLuJvW5iB4YlcNHlsdu87kGJ55tukmi8mxdAQ4Q7e2RCOFvu396j3x+UC
+B5iPNgiV5+I3lg02dZ77DnKxHZu8A/lJBdiB3QW0KtZB6awBdpUKD9jf1b0SHzUv
+KBds0pjBqAlkd25HN7rOrFleaJ1/ctaJxQZBKT5ZPt0m9STJEadao0xAH0ahmbWn
+OlFuhjuefXKnEgV4We0+UXgVCwOPjdAvBbI+e0ocS3MFEvzG6uBQE3xDk3SzynTn
+jh8BCNAw1FtxNrQHusEwMFxIt4I7mKZ9YIqioymCzLq9gwQbooMDQaHWBfEbwrbw
+qHyGO0aoSCqI3Haadr8faqU9GY/rOPNk3sgrDQoo//fb4hVC1CLQJ13hef4Y53CI
+rU7m2Ys6xt0nUW7/vGT1M0NPAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNV
+HRMBAf8EBTADAQH/MB0GA1UdDgQWBBR5tFnme7bl5AFzgAiIyBpY9umbbjANBgkq
+hkiG9w0BAQsFAAOCAgEAVR9YqbyyqFDQDLHYGmkgJykIrGF1XIpu+ILlaS/V9lZL
+ubhzEFnTIZd+50xx+7LSYK05qAvqFyFWhfFQDlnrzuBZ6brJFe+GnY+EgPbk6ZGQ
+3BebYhtF8GaV0nxvwuo77x/Py9auJ/GpsMiu/X1+mvoiBOv/2X/qkSsisRcOj/KK
+NFtY2PwByVS5uCbMiogziUwthDyC3+6WVwW6LLv3xLfHTjuCvjHIInNzktHCgKQ5
+ORAzI4JMPJ+GslWYHb4phowim57iaztXOoJwTdwJx4nLCgdNbOhdjsnvzqvHu7Ur
+TkXWStAmzOVyyghqpZXjFaH3pO3JLF+l+/+sKAIuvtd7u+Nxe5AW0wdeRlN8NwdC
+jNPElpzVmbUq4JUagEiuTDkHzsxHpFKVK7q4+63SM1N95R1NbdWhscdCb+ZAJzVc
+oyi3B43njTOQ5yOf+1CceWxG1bQVs5ZufpsMljq4Ui0/1lvh+wjChP4kqKOJ2qxq
+4RgqsahDYVvTH9w7jXbyLeiNdd8XM2w9U/t7y0Ff/9yi0GE44Za4rF2LN9d11TPA
+mRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57d
+emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
+-----END CERTIFICATE-----`
+
+	TestCertificate4 = `-----BEGIN CERTIFICATE-----
+MIICGzCCAaGgAwIBAgIQQdKd0XLq7qeAwSxs6S+HUjAKBggqhkjOPQQDAzBPMQsw
+CQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJuZXQgU2VjdXJpdHkgUmVzZWFyY2gg
+R3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBYMjAeFw0yMDA5MDQwMDAwMDBaFw00
+MDA5MTcxNjAwMDBaME8xCzAJBgNVBAYTAlVTMSkwJwYDVQQKEyBJbnRlcm5ldCBT
+ZWN1cml0eSBSZXNlYXJjaCBHcm91cDEVMBMGA1UEAxMMSVNSRyBSb290IFgyMHYw
+EAYHKoZIzj0CAQYFK4EEACIDYgAEzZvVn4CDCuwJSvMWSj5cz3es3mcFDR0HttwW
++1qLFNvicWDEukWVEYmO6gbf9yoWHKS5xcUy4APgHoIYOIvXRdgKam7mAHf7AlF9
+ItgKbppbd9/w+kHsOdx1ymgHDB/qo0IwQDAOBgNVHQ8BAf8EBAMCAQYwDwYDVR0T
+AQH/BAUwAwEB/zAdBgNVHQ4EFgQUfEKWrt5LSDv6kviejM9ti6lyN5UwCgYIKoZI
+zj0EAwMDaAAwZQIwe3lORlCEwkSHRhtFcP9Ymd70/aTSVaYgLXTWNLxBo1BfASdW
+tL4ndQavEi51mI38AjEAi/V3bNTIZargCyzuFJ0nN6T5U6VR5CmD1/iQMVtCnwr1
+/q4AaOeMSQ+2b1tbFfLn
+-----END CERTIFICATE-----`
+)
+
+func DefaultJoinedCerts() string {
+	return JoinCerts(
+		TestCertificate1,
+		TestCertificate2,
+		TestCertificate3,
+	)
+}
+
+func JoinCerts(certs ...string) string {
+	return strings.Join(certs, "\n") + "\n"
+}

--- a/test/env/data.go
+++ b/test/env/data.go
@@ -30,6 +30,7 @@ import (
 
 	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
 	"github.com/cert-manager/trust-manager/pkg/bundle"
+	"github.com/cert-manager/trust-manager/test/dummy"
 )
 
 // TestData is used as a set of input data to a Bundle suite test. It
@@ -53,14 +54,14 @@ type TestData struct {
 }
 
 // DefaultTrustData returns a well-known set of default data for a test.
-// Resulting Bundle will sync "A\nB\nC\n" to the Target "target-key".
+// Resulting Bundle will sync to the Target "target-key".
 func DefaultTrustData() TestData {
 	var td TestData
 	td.Sources.ConfigMap.Key = "configMap-key"
-	td.Sources.ConfigMap.Data = "A"
+	td.Sources.ConfigMap.Data = dummy.TestCertificate1
 	td.Sources.Secret.Key = "secret-key"
-	td.Sources.Secret.Data = "B"
-	td.Sources.InLine.Data = "C"
+	td.Sources.Secret.Data = dummy.TestCertificate2
+	td.Sources.InLine.Data = dummy.TestCertificate3
 	td.Target.Key = "target-key"
 	return td
 }


### PR DESCRIPTION
This function is intended to validate PEM inputs to ensure that the only contain certificates and that all certificates within are valid.

Also updates tests to use actual dummy PEM certificates rather than junk data. I think hardcoding certs here is fine - for now at least, we don't care if the certs expire in the future - we just care that they're valid PEM certificates.