### PR TITLE
Update bundle output and add wait option to copyandpause

### DIFF
--- a/bundles/debian/Containerfile
+++ b/bundles/debian/Containerfile
@@ -31,7 +31,7 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 COPY main.go main.go
 
-RUN CGO_ENABLED=0 go build -o copyandpause main.go
+RUN CGO_ENABLED=0 go build -o copyandmaybepause main.go
 
 FROM scratch
 
@@ -43,9 +43,9 @@ LABEL description="cert-manager debian static trust bundle"
 USER 1001
 
 COPY --from=debbase /usr/bin/tini-static /tini
-COPY --from=debbase /work/bundle.json /packaged-bundles/bundle-debian-$EXPECTED_VERSION$VERSION_SUFFIX.json
-COPY --from=gobuild /work/copyandpause /copyandpause
+COPY --from=debbase /work/bundle.json /packaged-bundles/bundle-cert-manager-debian.json
+COPY --from=gobuild /work/copyandmaybepause /copyandmaybepause
 
 ENTRYPOINT ["/tini", "--"]
 
-CMD ["/copyandpause", "/packaged-bundles", "/bundles"]
+CMD ["/copyandmaybepause", "/packaged-bundles", "/bundles"]

--- a/bundles/debian/build.sh
+++ b/bundles/debian/build.sh
@@ -46,7 +46,8 @@ fi
 
 echo "{}" | jq \
 	--rawfile bundle /etc/ssl/certs/ca-certificates.crt \
+	--arg name "cert-manager-debian" \
 	--arg type "static" \
 	--arg version "$EXPECTED_VERSION$VERSION_SUFFIX" \
-	'.bundle = $bundle | .type = $type | .version = $version' \
+	'.name = $name | .bundle = $bundle | .type = $type | .version = $version' \
 	> $DESTINATION_FILE


### PR DESCRIPTION
- Bundles are now written without the version in their name.

- Bundles have their names added as fields in the JSON

- copyandpause is now copyandmaybepause, with pausing being an optional choice. This is to enable its use in init containers.