### PR TITLE
Pass GOPROXY to build environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@
 # Build the trust binary
 FROM docker.io/library/golang:1.19 as builder
 
+ARG GOPROXY
+
 WORKDIR /workspace
 # Copy the Go Modules manifests
 COPY go.mod go.mod
@@ -28,7 +30,7 @@ COPY make/ make/
 COPY cmd/ cmd/
 COPY pkg/ pkg/
 
-RUN go mod download
+RUN GOPROXY=$GOPROXY go mod download
 
 # Build
 RUN make build

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ BUILDX_BUILDER ?= trust-manager-builder
 
 CONTAINER_REGISTRY ?= quay.io/jetstack
 
+GOPROXY ?= https://proxy.golang.org,direct
+
 include make/trust-package-debian.mk
 
 .PHONY: help
@@ -74,7 +76,7 @@ provision-buildx:  ## set up docker buildx for multiarch building
 # arguments to `--push`.
 .PHONY: image
 image: | $(BINDIR) ## build docker image targeting all supported platforms
-	docker buildx build --builder $(BUILDX_BUILDER) --platform=$(IMAGE_PLATFORMS) -t $(CONTAINER_REGISTRY)/trust-manager:$(RELEASE_VERSION) --output type=local,dest=$(BINDIR)/trust-manager .
+	docker buildx build --builder $(BUILDX_BUILDER) --build-arg GOPROXY=$(GOPROXY) --platform=$(IMAGE_PLATFORMS) -t $(CONTAINER_REGISTRY)/trust-manager:$(RELEASE_VERSION) --output type=local,dest=$(BINDIR)/trust-manager .
 
 .PHONY: kind-load
 kind-load: local-images | $(BINDIR)/kind
@@ -82,7 +84,7 @@ kind-load: local-images | $(BINDIR)/kind
 
 .PHONY: local-images
 local-images: trust-package-debian-load
-	docker buildx build --builder $(BUILDX_BUILDER) --platform=linux/amd64 -t $(CONTAINER_REGISTRY)/trust-manager:$(RELEASE_VERSION) --load .
+	docker buildx build --builder $(BUILDX_BUILDER) --build-arg GOPROXY=$(GOPROXY) --platform=linux/amd64 -t $(CONTAINER_REGISTRY)/trust-manager:$(RELEASE_VERSION) --load .
 
 .PHONY: chart
 chart: | $(BINDIR)/helm $(BINDIR)/chart

--- a/make/trust-package-debian.mk
+++ b/make/trust-package-debian.mk
@@ -5,6 +5,7 @@ define build_debian_trust_package
 	docker buildx build --builder $(BUILDX_BUILDER) \
 		--platform=$(3) \
 		-t $(CONTAINER_REGISTRY)/cert-manager-package-debian:$(2)$(DEBIAN_TRUST_PACKAGE_SUFFIX) \
+		--build-arg GOPROXY=$(GOPROXY) \
 		--build-arg EXPECTED_VERSION=$(2) \
 		--build-arg VERSION_SUFFIX=$(DEBIAN_TRUST_PACKAGE_SUFFIX) \
 		--output $(1) \

--- a/trust-packages/debian/Containerfile
+++ b/trust-packages/debian/Containerfile
@@ -25,13 +25,15 @@ RUN /work/build.sh $EXPECTED_VERSION $VERSION_SUFFIX /work/package.json
 
 FROM docker.io/library/golang:1.19 as gobuild
 
+ARG GOPROXY
+
 WORKDIR /work
 
 COPY go.mod go.mod
 COPY go.sum go.sum
 COPY main.go main.go
 
-RUN CGO_ENABLED=0 go build -o copyandmaybepause main.go
+RUN GOPROXY=$GOPROXY CGO_ENABLED=0 go build -o copyandmaybepause main.go
 
 FROM scratch
 


### PR DESCRIPTION
This will enable devs with a custom GOPROXY to leverage it when building + testing trust-manager!

NOTE: I couldn't see a way to do this without build args using `docker buildx`. Maybe I missed the equivalent of `docker build -e GOPROXY` but in any case I can see why they maybe wouldn't want that for buildx.