### PR TITLE
Fix logic error in trust-manager tests

### DIFF
--- a/test/env/data.go
+++ b/test/env/data.go
@@ -172,7 +172,9 @@ func BundleHasSyncedAllNamespaces(ctx context.Context, cl client.Client, name, e
 			continue
 		}
 
-		return BundleHasSynced(ctx, cl, name, namespace.Name, expectedData)
+		if !BundleHasSynced(ctx, cl, name, namespace.Name, expectedData) {
+			return false
+		}
 	}
 
 	return true


### PR DESCRIPTION
Before this change, the function was checking if a bundle had synced to the first namespace returned and not checking if all namespaces had synced the bundle

Spotted while refactoring tests more widely but this seems too important to leave!