### PR TITLE
Integration test tweaks

### DIFF
--- a/test/integration/bundle/suite.go
+++ b/test/integration/bundle/suite.go
@@ -23,10 +23,12 @@ import (
 	. "github.com/onsi/gomega"
 	. "github.com/onsi/gomega/gstruct"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -49,6 +51,8 @@ var _ = Describe("Integration", func() {
 		ctx    context.Context
 		cancel func()
 
+		log logr.Logger
+
 		cl   client.Client
 		mgr  manager.Manager
 		opts bundle.Options
@@ -58,7 +62,8 @@ var _ = Describe("Integration", func() {
 	)
 
 	BeforeEach(func() {
-		ctx, cancel = context.WithCancel(context.Background())
+		log, ctx = ktesting.NewTestContext(GinkgoT())
+		ctx, cancel = context.WithCancel(ctx)
 
 		var err error
 		cl, err = client.New(env.Config, client.Options{
@@ -90,7 +95,7 @@ var _ = Describe("Integration", func() {
 			LeaderElectionResourceLock:    "leases",
 			LeaderElectionID:              "trust-manager",
 			LeaderElectionReleaseOnCancel: true,
-			Logger:                        logf.Log,
+			Logger:                        log,
 		})
 		Expect(err).NotTo(HaveOccurred())
 

--- a/test/integration/bundle/suite.go
+++ b/test/integration/bundle/suite.go
@@ -87,16 +87,10 @@ var _ = Describe("Integration", func() {
 		}
 
 		mgr, err = ctrl.NewManager(env.Config, ctrl.Options{
-			Scheme:   trustapi.GlobalScheme,
-			NewCache: bundle.NewCacheFunc(opts),
-			// TODO: can we disable leader election here? The mgr goroutine prints extra output we probably don't need
-			// and it might not be valuable to enable leader election here
-			LeaderElection:                true,
-			LeaderElectionNamespace:       opts.Namespace,
-			LeaderElectionResourceLock:    "leases",
-			LeaderElectionID:              "trust-manager",
-			LeaderElectionReleaseOnCancel: true,
-			Logger:                        log,
+			Scheme:         trustapi.GlobalScheme,
+			NewCache:       bundle.NewCacheFunc(opts),
+			LeaderElection: false,
+			Logger:         log,
 		})
 		Expect(err).NotTo(HaveOccurred())
 

--- a/test/integration/bundle/suite.go
+++ b/test/integration/bundle/suite.go
@@ -53,9 +53,10 @@ var _ = Describe("Integration", func() {
 
 		log logr.Logger
 
-		cl   client.Client
-		mgr  manager.Manager
-		opts bundle.Options
+		cl         client.Client
+		mgr        manager.Manager
+		mgrStopped chan struct{}
+		opts       bundle.Options
 
 		testBundle *trustapi.Bundle
 		testData   testenv.TestData
@@ -99,10 +100,17 @@ var _ = Describe("Integration", func() {
 		})
 		Expect(err).NotTo(HaveOccurred())
 
+		mgrStopped = make(chan struct{})
+
 		Expect(bundle.AddBundleController(ctx, mgr, opts)).NotTo(HaveOccurred())
 
 		By("Running Bundle controller")
-		go mgr.Start(ctx)
+		go func() {
+			defer close(mgrStopped)
+
+			err := mgr.Start(ctx)
+			Expect(err).NotTo(HaveOccurred())
+		}()
 
 		By("Waiting for Informers to Sync")
 		Expect(mgr.GetCache().WaitForCacheSync(ctx)).Should(BeTrue())
@@ -128,6 +136,7 @@ var _ = Describe("Integration", func() {
 
 		By("Stopping Bundle controller")
 		cancel()
+		<-mgrStopped
 	})
 
 	It("should update all targets when a ConfigMap source is added", func() {


### PR DESCRIPTION
See commit messages for more details.

1. Disables leader election (as discussed in standup 2023-01-05)
2. Adds a channel to wait on when shutting down integration test env
3. Uses ginkgo logger explicitly

1 and 2 inspired by: https://github.com/cert-manager/approver-policy/pull/166