### PR TITLE
Remove type from trust packages + add validation on package build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,12 @@ ifneq ($(strip $(CI)),)
 	sleep 2
 endif
 
+.PHONY: build-validate-trust-package
+build-validate-trust-package: $(BINDIR)/validate-trust-package
+
+$(BINDIR)/validate-trust-package: cmd/validate-trust-package/main.go pkg/fspkg/package.go | $(BINDIR)
+	CGO_ENABLED=0 go build -o $@ $<
+
 .PHONY: depend
 depend: $(BINDIR)/deepcopy-gen $(BINDIR)/controller-gen $(BINDIR)/ginkgo $(BINDIR)/kubectl $(BINDIR)/kind $(BINDIR)/helm $(BINDIR)/kubebuilder/bin/kube-apiserver
 

--- a/cmd/app/app.go
+++ b/cmd/app/app.go
@@ -34,10 +34,14 @@ import (
 )
 
 const (
-	helpOutput = "Operator for distributing bundles from a trust Namespace across a Kubernetes Cluster to be made available to all services"
+	helpOutput = `trust-manager is an operator for distributing bundles in Kubernetes clusters
+
+Sources are loaded by being defined in Bundle resources, and are concatenated
+into an output bundle 'target', which can then be made available to all
+services across a cluster.`
 )
 
-// NewCommand will return a new command instance for the trust operator.
+// NewCommand will return a new command instance for the trust-manager operator.
 func NewCommand() *cobra.Command {
 	opts := options.New()
 

--- a/cmd/validate-trust-package/main.go
+++ b/cmd/validate-trust-package/main.go
@@ -1,0 +1,34 @@
+/*
+Copyright 2023 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"log"
+	"os"
+
+	"github.com/cert-manager/trust-manager/pkg/fspkg"
+)
+
+func main() {
+	stderrLogger := log.New(os.Stderr, "", log.LstdFlags)
+
+	_, err := fspkg.LoadPackage(os.Stdin)
+	if err != nil {
+		stderrLogger.Printf("failed to load and validate trust package: %s", err.Error())
+		os.Exit(1)
+	}
+}

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -193,7 +193,7 @@ def get_regexs():
     # Search for "YEAR" which exists in the boilerplate, but shouldn't in the real thing
     regexs["year"] = re.compile('YEAR')
     # dates can be 2014, 2015, 2016, or 2017; company holder names can be anything
-    regexs["date"] = re.compile('(2014|2015|2016|2017|2018|2019|2020|2021|2022)')
+    regexs["date"] = re.compile('(2014|2015|2016|2017|2018|2019|2020|2021|2022|2023)')
     # strip the following build constraints/tags:
     # //go:build
     # // +build \n\n

--- a/trust-packages/debian/build.sh
+++ b/trust-packages/debian/build.sh
@@ -47,7 +47,6 @@ fi
 echo "{}" | jq \
 	--rawfile bundle /etc/ssl/certs/ca-certificates.crt \
 	--arg name "cert-manager-debian" \
-	--arg type "static" \
 	--arg version "$EXPECTED_VERSION$VERSION_SUFFIX" \
-	'.name = $name | .bundle = $bundle | .type = $type | .version = $version' \
+	'.name = $name | .bundle = $bundle | .version = $version' \
 	> $DESTINATION_FILE


### PR DESCRIPTION
Also adds a validator for trust packages, which we'll use to ensure we don't publish packages which trust-manager won't be able to load.

This PR doesn't actually _use_ the validator yet - that'll come in a separate PR to solve the chicken and egg problem (we want the build for the trust-package to happen in a container, but don't want to share anything from the local environment with that container. So we'll `go install github.com/cert-manager/trust-manager/cmd/validate-trust-package@latest` during the build of the trust package, but to do that we need to publish the build for that first)