### PR TITLE
Fix non-cached client

### DIFF
--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -808,10 +808,10 @@ func Test_Reconcile(t *testing.T) {
 			fakerecorder := record.NewFakeRecorder(1)
 
 			b := &bundle{
-				client:   fakeclient,
-				lister:   fakeclient,
-				recorder: fakerecorder,
-				clock:    fixedclock,
+				directClient: fakeclient,
+				lister:       fakeclient,
+				recorder:     fakerecorder,
+				clock:        fixedclock,
 				Options: Options{
 					Log:       klogr.New(),
 					Namespace: trustNamespace,

--- a/pkg/bundle/controller.go
+++ b/pkg/bundle/controller.go
@@ -47,12 +47,20 @@ import (
 // when any related resource event in the Bundle source and target.
 // The controller will only cache metadata for ConfigMaps and Secrets.
 func AddBundleController(ctx context.Context, mgr manager.Manager, opts Options) error {
+	directClient, err := client.New(mgr.GetConfig(), client.Options{
+		Scheme: mgr.GetScheme(),
+		Mapper: mgr.GetRESTMapper(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create client: %w", err)
+	}
+
 	b := &bundle{
-		client:   mgr.GetClient(),
-		lister:   mgr.GetCache(),
-		recorder: mgr.GetEventRecorderFor("bundles"),
-		clock:    clock.RealClock{},
-		Options:  opts,
+		directClient: directClient,
+		lister:       mgr.GetCache(),
+		recorder:     mgr.GetEventRecorderFor("bundles"),
+		clock:        clock.RealClock{},
+		Options:      opts,
 	}
 
 	if b.Options.DefaultPackageLocation != "" {

--- a/pkg/bundle/sync_test.go
+++ b/pkg/bundle/sync_test.go
@@ -333,7 +333,7 @@ func Test_syncTarget(t *testing.T) {
 			fakeclient := clientBuilder.Build()
 			fakerecorder := record.NewFakeRecorder(1)
 
-			b := &bundle{client: fakeclient, recorder: fakerecorder}
+			b := &bundle{directClient: fakeclient, recorder: fakerecorder}
 
 			needsUpdate, err := b.syncTarget(context.TODO(), klogr.New(), &trustapi.Bundle{
 				ObjectMeta: metav1.ObjectMeta{Name: bundleName},
@@ -551,7 +551,7 @@ func Test_buildSourceBundle(t *testing.T) {
 				Build()
 
 			b := &bundle{
-				client: fakeclient,
+				directClient: fakeclient,
 				defaultPackage: &fspkg.Package{
 					Name:    "testpkg",
 					Version: "123",


### PR DESCRIPTION
Here, we incorrectly assume that the client is a non-cached client:
https://github.com/cert-manager/trust-manager/blob/f2da89271eb887093f434a4e79b80d1fee02a212/pkg/bundle/bundle.go#L57-L60
This results in caching all these resources fully. Additionally, we are already caching the metadata-only representation of these resources, effectively caching each resource twice (more info: https://github.com/kubernetes-sigs/controller-runtime/blob/master/pkg/builder/options.go#L103-L132).

In this PR, I fix this issue and also rename the `client` field to `directClient` to make clear that this client is not cached.
Also, I simplified the cache.go code a bit by using an external library.

fixes #91 