### PR TITLE
Validate CA package during build

### DIFF
--- a/trust-packages/debian/Containerfile
+++ b/trust-packages/debian/Containerfile
@@ -12,17 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/library/debian:11-slim as debbase
-
-ARG EXPECTED_VERSION
-ARG VERSION_SUFFIX
-
-WORKDIR /work
-
-COPY ./build.sh /work/build.sh
-
-RUN /work/build.sh $EXPECTED_VERSION $VERSION_SUFFIX /work/package.json
-
 FROM docker.io/library/golang:1.19 as gobuild
 
 ARG GOPROXY
@@ -34,6 +23,20 @@ COPY go.sum go.sum
 COPY main.go main.go
 
 RUN GOPROXY=$GOPROXY CGO_ENABLED=0 go build -o copyandmaybepause main.go
+
+RUN GOPROXY=$GOPROXY CGO_ENABLED=0 go install github.com/cert-manager/trust-manager/cmd/validate-trust-package@main
+
+FROM docker.io/library/debian:11-slim as debbase
+
+ARG EXPECTED_VERSION
+ARG VERSION_SUFFIX
+
+WORKDIR /work
+
+COPY ./build.sh /work/build.sh
+COPY --from=gobuild /go/bin/validate-trust-package /usr/bin/validate-trust-package
+
+RUN /work/build.sh $EXPECTED_VERSION $VERSION_SUFFIX /work/package.json
 
 FROM scratch
 

--- a/trust-packages/debian/build.sh
+++ b/trust-packages/debian/build.sh
@@ -50,3 +50,5 @@ echo "{}" | jq \
 	--arg version "$EXPECTED_VERSION$VERSION_SUFFIX" \
 	'.name = $name | .bundle = $bundle | .version = $version' \
 	> $DESTINATION_FILE
+
+validate-trust-package < $DESTINATION_FILE


### PR DESCRIPTION
Probably it would be ideal to use a tagged version of the validator rather than `main` in the future, but for now we don't have a tag which includes the validator.

For now, since it's unlikely to change much, it should be fine to use `main`.