### PR TITLE
Supporting a secret target

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -38,6 +38,7 @@ Kubernetes: `>= 1.22.0-0`
 | app.webhook.port | int | `6443` | Port that the webhook listens on. |
 | app.webhook.service | object | `{"type":"ClusterIP"}` | Type of Kubernetes Service used by the Webhook |
 | app.webhook.timeoutSeconds | int | `5` | Timeout of webhook HTTP request. |
+| authorizedSecrets[0] | string | `"ca-bundle"` |  |
 | crds.enabled | bool | `true` | Whether or not to install the crds. |
 | defaultPackageImage.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the default package image |
 | defaultPackageImage.repository | string | `"quay.io/jetstack/cert-manager-package-debian"` | Repository for the default package image. This image enables the 'useDefaultCAs' source on Bundles. |

--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -38,7 +38,7 @@ Kubernetes: `>= 1.22.0-0`
 | app.webhook.port | int | `6443` | Port that the webhook listens on. |
 | app.webhook.service | object | `{"type":"ClusterIP"}` | Type of Kubernetes Service used by the Webhook |
 | app.webhook.timeoutSeconds | int | `5` | Timeout of webhook HTTP request. |
-| authorizedSecrets[0] | string | `"ca-bundle"` |  |
+| authorizedSecrets | list | `["ca-bundle"]` | List of secrets trust-manager is allowed to read/write. Used when the secret target is set when creating a bundle. |
 | crds.enabled | bool | `true` | Whether or not to install the crds. |
 | defaultPackageImage.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the default package image |
 | defaultPackageImage.repository | string | `"quay.io/jetstack/cert-manager-package-debian"` | Repository for the default package image. This image enables the 'useDefaultCAs' source on Bundles. |

--- a/deploy/charts/trust-manager/templates/clusterrole.yaml
+++ b/deploy/charts/trust-manager/templates/clusterrole.yaml
@@ -34,6 +34,17 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - "secrets"
+  verbs: ["get", "list", "update", "watch", "delete"]
+  resourceNames: {{ .Values.authorizedSecrets | toYaml | nindent 2 }}
+- apiGroups:
+  - ""
+  resources:
+  - "secrets"
+  verbs: ["create"]
+- apiGroups:
+  - ""
+  resources:
   - "namespaces"
   verbs: ["get", "list", "watch"]
 

--- a/deploy/charts/trust-manager/templates/trust.cert-manager.io_bundles.yaml
+++ b/deploy/charts/trust-manager/templates/trust.cert-manager.io_bundles.yaml
@@ -115,6 +115,15 @@ spec:
                           type: object
                           additionalProperties:
                             type: string
+                    secret:
+                      description: Secret is the target Secret in Namespaces that all Bundle source data will be synced to.
+                      type: object
+                      required:
+                        - key
+                      properties:
+                        key:
+                          description: Key is the key of the entry in the object's `data` field to be used.
+                          type: string
             status:
               description: Status of the Bundle. This is set and managed automatically.
               type: object
@@ -174,6 +183,15 @@ spec:
                           type: object
                           additionalProperties:
                             type: string
+                    secret:
+                      description: Secret is the target Secret in Namespaces that all Bundle source data will be synced to.
+                      type: object
+                      required:
+                        - key
+                      properties:
+                        key:
+                          description: Key is the key of the entry in the object's `data` field to be used.
+                          type: string
       served: true
       storage: true
       subresources:

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -67,6 +67,8 @@ app:
     # -- If false, disables the default seccomp profile, which might be required to run on certain platforms
     seccompProfileEnabled: true
 
+authorizedSecrets: ['ca-bundle']
+
 resources: {}
   # -- Kubernetes pod resource limits for trust.
   # limits:

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -67,6 +67,8 @@ app:
     # -- If false, disables the default seccomp profile, which might be required to run on certain platforms
     seccompProfileEnabled: true
 
+# -- List of secrets trust-manager is allowed to read/write. Used when the secret target is set when creating
+# a bundle.
 authorizedSecrets: ['ca-bundle']
 
 resources: {}

--- a/deploy/crds/trust.cert-manager.io_bundles.yaml
+++ b/deploy/crds/trust.cert-manager.io_bundles.yaml
@@ -114,6 +114,15 @@ spec:
                           type: object
                           additionalProperties:
                             type: string
+                    secret:
+                      description: Secret is the target Secret in Namespaces that all Bundle source data will be synced to.
+                      type: object
+                      required:
+                        - key
+                      properties:
+                        key:
+                          description: Key is the key of the entry in the object's `data` field to be used.
+                          type: string
             status:
               description: Status of the Bundle. This is set and managed automatically.
               type: object
@@ -173,6 +182,15 @@ spec:
                           type: object
                           additionalProperties:
                             type: string
+                    secret:
+                      description: Secret is the target Secret in Namespaces that all Bundle source data will be synced to.
+                      type: object
+                      required:
+                        - key
+                      properties:
+                        key:
+                          description: Key is the key of the entry in the object's `data` field to be used.
+                          type: string
       served: true
       storage: true
       subresources:

--- a/pkg/apis/trust/v1alpha1/types_bundle.go
+++ b/pkg/apis/trust/v1alpha1/types_bundle.go
@@ -96,6 +96,10 @@ type BundleTarget struct {
 	// data will be synced to.
 	ConfigMap *KeySelector `json:"configMap,omitempty"`
 
+    // Secret is the target Secret in Namespaces that all Bundle source
+    // data will be synced to.
+    Secret *KeySelector `json:"secret,omitempty"`
+
 	// NamespaceSelector will, if set, only sync the target resource in
 	// Namespaces which match the selector.
 	// +optional

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -187,16 +187,16 @@ func (b *bundle) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, 
 			continue
 		}
 
-		synced, err := b.syncTarget(ctx, log, &bundle, namespaceSelector, &namespace, resolvedBundle.data)
+		cmSynced, err := b.syncTarget(ctx, log, &bundle, namespaceSelector, &namespace, resolvedBundle.data)
 		if err != nil {
 			log.Error(err, "failed sync bundle to target namespace")
-			b.recorder.Eventf(&bundle, corev1.EventTypeWarning, "SyncTargetFailed", "Failed to sync target in Namespace %q: %s", namespace.Name, err)
+			b.recorder.Eventf(&bundle, corev1.EventTypeWarning, "SyncTargetFailed", "Failed to sync configMap target in Namespace %q: %s", namespace.Name, err)
 
 			b.setBundleCondition(&bundle, trustapi.BundleCondition{
 				Type:    trustapi.BundleConditionSynced,
 				Status:  corev1.ConditionFalse,
 				Reason:  "SyncTargetFailed",
-				Message: fmt.Sprintf("Failed to sync bundle to namespace %q: %s", namespace.Name, err),
+				Message: fmt.Sprintf("Failed to sync bundle target configMap to namespace %q: %s", namespace.Name, err),
 			})
 
 			return ctrl.Result{Requeue: true}, b.targetDirectClient.Status().Update(ctx, &bundle)
@@ -221,7 +221,7 @@ func (b *bundle) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, 
             }
         }
 
-		if synced || secretSynced {
+		if cmSynced || secretSynced {
 			// We need to update if any target is synced.
 			needsUpdate = true
 		}


### PR DESCRIPTION
This was requested in https://github.com/cert-manager/trust-manager/issues/10

Motivation:
Many helm charts/operators support a certificate authority mount only in the form of a Secret, and do not support ConfigMap. This is due to the fact that certificate authority is often shipped with TLS-type secrets (along with their certificate and key). cert-manager also require a certificate authority in the form of a Secret for its Vault issuer.

trust-manager should support the target being a Secret, along with a ConfigMap, to guarantee maximum usability.

For security concerns, we will allow trust-manager to only view/update a given list of managed secrets in the helm chart.