### PR TITLE
Add missing permission to update bundle finalizers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -133,12 +133,12 @@ demo: ensure-kind kind-load ensure-cert-manager ensure-trust-manager $(BINDIR)/k
 smoke: demo  ## ensure local cluster exists, deploy trust-manager and run smoke tests
 	$(BINDIR)/ginkgo -procs 1 test/smoke/ -- --kubeconfig-path $(BINDIR)/kubeconfig.yaml
 
-$(BINDIR)/kubeconfig.yaml: depend ensure-ci-docker-network _FORCE | $(BINDIR)
+$(BINDIR)/kubeconfig.yaml: depend ensure-ci-docker-network _FORCE test/kind-cluster.yaml | $(BINDIR)
 	@if $(BINDIR)/kind get clusters | grep -q "^trust$$"; then \
 		echo "cluster already exists, not trying to create"; \
 		$(BINDIR)/kind get kubeconfig --name trust > $@ && chmod 600 $@; \
 	else \
-		$(BINDIR)/kind create cluster --name trust --kubeconfig $@ && chmod 600 $@; \
+		$(BINDIR)/kind create cluster --config test/kind-cluster.yaml --kubeconfig $@ && chmod 600 $@; \
 		echo -e "$(_RED)kind cluster 'trust' was created; to access it, pass '--kubeconfig  $(BINDIR)/kubeconfig.yaml' to kubectl/helm$(_END)"; \
 		sleep 2; \
 	fi

--- a/deploy/charts/trust-manager/templates/clusterrole.yaml
+++ b/deploy/charts/trust-manager/templates/clusterrole.yaml
@@ -10,6 +10,15 @@ rules:
   resources:
   - "bundles"
   verbs: ["get", "list", "watch"]
+
+# Permissions to update finalizers are required for trust-manager to work correctly
+# on OpenShift, even though we don't directly use finalizers at the time of writing
+- apiGroups:
+  - "trust.cert-manager.io"
+  resources:
+  - "bundles/finalizers"
+  verbs: ["update"]
+
 - apiGroups:
   - "trust.cert-manager.io"
   resources:
@@ -21,6 +30,7 @@ rules:
   resources:
   - "configmaps"
   verbs: ["get", "list", "create", "update", "watch", "delete"]
+
 - apiGroups:
   - ""
   resources:

--- a/test/kind-cluster.yaml
+++ b/test/kind-cluster.yaml
@@ -1,0 +1,16 @@
+# This configuration is used to set up a Kind cluster for smoke tests or demo environments.
+
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+# WARNING: Makefile commands which interact with the cluster _require_ that it be called "trust"
+# Changing the name here will stop the cluster being able to be controlled via Make!
+name: trust
+nodes:
+- role: control-plane
+  # Enable OwnerReferencesPermissionEnforcement to better match OpenShift environments in tests
+  kubeadmConfigPatches:
+  - |
+    kind: ClusterConfiguration
+    apiServer:
+        extraArgs:
+          enable-admission-plugins: OwnerReferencesPermissionEnforcement


### PR DESCRIPTION
This should enable trust-manager to work in OpenShift!

Based on a [slack thread](https://kubernetes.slack.com/archives/C4NV3DWUC/p1675277465934999) which reported the issue