### PR TITLE
Bump values in helm chart

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -44,7 +44,7 @@ Kubernetes: `>= 1.22.0-0`
 | defaultPackageImage.tag | string | `"20210119.0"` | Tag for the default package image |
 | image.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on Deployment. |
 | image.repository | string | `"quay.io/jetstack/trust-manager"` | Target image repository. |
-| image.tag | string | `"v0.3.0"` | Target image version tag. |
+| image.tag | string | `"v0.4.0"` | Target image version tag. |
 | imagePullSecrets | list | `[]` | For Private docker registries, authentication is needed. Registry secrets are applied to the service account |
 | replicaCount | int | `1` | Number of replicas of trust to run. |
 | resources | object | `{}` |  |

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -8,7 +8,7 @@ image:
   # -- Target image repository.
   repository: quay.io/jetstack/trust-manager
   # -- Target image version tag.
-  tag: v0.3.0
+  tag: v0.4.0
   # -- Kubernetes imagePullPolicy on Deployment.
   pullPolicy: IfNotPresent
 

--- a/hack/update-helm-docs.sh
+++ b/hack/update-helm-docs.sh
@@ -25,4 +25,4 @@ if [[ -z $HELM_DOCS_BIN ]]; then
 	exit 1
 fi
 
-$HELM_DOCS_BIN ./deploy/charts/csi-driver
+$HELM_DOCS_BIN ./deploy/charts/trust-manager


### PR DESCRIPTION
This should've been done before the tag + release of `v0.4.0` but was missed. We agreed in standup on 2023-02-03 that it was fine to release the container images built from the v0.4.0 tag and use this commit for releasing the chart.