### PR TITLE
Add verify-versions script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ integration-test: depend  ## runs integration tests, defined as tests which requ
 	KUBEBUILDER_ASSETS=$(BINDIR)/kubebuilder/bin go test -v ./test/integration/...
 
 .PHONY: lint
-lint: vet verify-boilerplate verify-helm-docs
+lint: vet verify-boilerplate verify-helm-docs verify-versions
 
 .PHONY: verify
 verify: depend build test ## tests and builds trust-manager
@@ -72,6 +72,10 @@ verify: depend build test ## tests and builds trust-manager
 .PHONY: verify-boilerplate
 verify-boilerplate:
 	./hack/verify-boilerplate.sh
+
+.PHONY: verify-versions
+verify-versions:
+	./hack/verify-versions.sh
 
 .PHONY: vet
 vet:

--- a/hack/boilerplate/boilerplate.py
+++ b/hack/boilerplate/boilerplate.py
@@ -17,6 +17,7 @@
 from __future__ import print_function
 
 import argparse
+import datetime
 import difflib
 import glob
 import os
@@ -188,12 +189,16 @@ def get_files(extensions):
     return outfiles
 
 
+def get_allowed_years():
+    years = datetime.datetime.now().year
+    return '(%s)' % '|'.join((str(year) for year in range(2014, years+1)))
+
+
 def get_regexs():
     regexs = {}
     # Search for "YEAR" which exists in the boilerplate, but shouldn't in the real thing
     regexs["year"] = re.compile('YEAR')
-    # dates can be 2014, 2015, 2016, or 2017; company holder names can be anything
-    regexs["date"] = re.compile('(2014|2015|2016|2017|2018|2019|2020|2021|2022|2023)')
+    regexs["date"] = re.compile(get_allowed_years())
     # strip the following build constraints/tags:
     # //go:build
     # // +build \n\n

--- a/hack/verify-versions.sh
+++ b/hack/verify-versions.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+MAKEFILE_RELEASE_VERSION=$(grep -E "^RELEASE_VERSION" Makefile | awk '{print $3}')
+
+# This is a tortured way to avoid installing yq
+HELM_CHART_VALUES_VERSION=$(grep -E -A1 "Target image version" deploy/charts/trust-manager/values.yaml | grep "tag:" | awk '{print $2}')
+
+HELM_CHART_VERSION=$(grep -E "^version:" deploy/charts/trust-manager/Chart.yaml | awk '{print $2}')
+
+# We might not always want appVersion to match version, but for now it probably
+# makes sense to enforce that they remain the same
+HELM_CHART_APP_VERSION=$(grep -E "^appVersion:" deploy/charts/trust-manager/Chart.yaml | awk '{print $2}')
+
+# echo "makefile RELEASE_VERSION: $MAKEFILE_RELEASE_VERSION"
+# echo "helm chart version: $HELM_CHART_VERSION"
+# echo "helm chart app version: $HELM_CHART_APP_VERSION"
+# echo "helm chart values version: $HELM_CHART_VALUES_VERSION"
+
+mismatch=0
+
+if [[ $MAKEFILE_RELEASE_VERSION != $HELM_CHART_VERSION ]]; then
+	echo "!!! mismatch between makefile version and helm chart version"
+
+	mismatch=1
+fi
+
+if [[ $MAKEFILE_RELEASE_VERSION != $HELM_CHART_APP_VERSION ]]; then
+	echo "!!! mismatch between makefile version and helm chart appVersion"
+
+	mismatch=1
+fi
+
+if [[ $MAKEFILE_RELEASE_VERSION != $HELM_CHART_VALUES_VERSION ]]; then
+	echo "!!! mismatch between makefile version and helm values controller container tag"
+
+	mismatch=1
+fi
+
+if [[ mismatch -ne 0 ]]; then
+	echo "at least one version was incorrect"
+	exit 1
+fi


### PR DESCRIPTION
During the release of trust-manager 0.4.0 a version update was missed (see #114 ). This adds a simple script which should ensure that if one value is updated, they all are.

Grepping through YAML isn't really ideal, but I didn't want to add another dependency if it could be avoided.

Also makes a minor tweak to the boilerplate checker, following changes present in other cert-manager subprojects.