### PR TITLE
Make seccompProfile optional in initContainer

### DIFF
--- a/deploy/charts/trust-manager/templates/deployment.yaml
+++ b/deploy/charts/trust-manager/templates/deployment.yaml
@@ -36,8 +36,10 @@ spec:
             - ALL
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+          {{- if .Values.app.securityContext.seccompProfileEnabled }}
           seccompProfile:
             type: RuntimeDefault
+          {{- end }}
       {{- end }}
       containers:
       - name: {{ include "trust-manager.name" . }}


### PR DESCRIPTION
When the `initcontainer` was added, we forgot to add the option to disable seccompProfile for that container.
This PR fixes that issue.