### PR TITLE
helm: make installation of default trust package optional

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -39,6 +39,7 @@ Kubernetes: `>= 1.22.0-0`
 | app.webhook.service | object | `{"type":"ClusterIP"}` | Type of Kubernetes Service used by the Webhook |
 | app.webhook.timeoutSeconds | int | `5` | Timeout of webhook HTTP request. |
 | crds.enabled | bool | `true` | Whether or not to install the crds. |
+| defaultPackage.enabled | bool | `true` | Whether to load the default trust package during pod initialization and include it in main container args. This container enables the 'useDefaultCAs' source on Bundles. |
 | defaultPackageImage.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the default package image |
 | defaultPackageImage.repository | string | `"quay.io/jetstack/cert-manager-package-debian"` | Repository for the default package image. This image enables the 'useDefaultCAs' source on Bundles. |
 | defaultPackageImage.tag | string | `"20210119.0"` | Tag for the default package image |

--- a/deploy/charts/trust-manager/templates/NOTES.txt
+++ b/deploy/charts/trust-manager/templates/NOTES.txt
@@ -1,12 +1,13 @@
 trust-manager {{ .Chart.AppVersion }} has been deployed successfully!
 
+{{- if .Values.defaultPackage.enabled }}
 Your installation includes a default CA package, using the following
 default CA package image:
 
 {{ .Values.defaultPackageImage.repository }}:{{ .Values.defaultPackageImage.tag }}
 
 It's imperative that you keep the default CA package image up to date.
-
+{{- end }}
 To find out more about securely running trust-manager and to get started
 with creating your first bundle, check out the documentation on the
 cert-manager website:

--- a/deploy/charts/trust-manager/templates/deployment.yaml
+++ b/deploy/charts/trust-manager/templates/deployment.yaml
@@ -15,6 +15,7 @@ spec:
         app: {{ include "trust-manager.name" . }}
     spec:
       serviceAccountName: {{ include "trust-manager.name" . }}
+      {{- if .Values.defaultPackage.enabled }}
       initContainers:
       - name: cert-manager-package-debian
         image: "{{ .Values.defaultPackageImage.repository }}:{{ .Values.defaultPackageImage.tag }}"
@@ -36,6 +37,7 @@ spec:
           runAsNonRoot: true
           seccompProfile:
             type: RuntimeDefault
+      {{- end }}
       containers:
       - name: {{ include "trust-manager.name" . }}
         image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
@@ -61,7 +63,9 @@ spec:
           - "--webhook-host={{.Values.app.webhook.host}}"
           - "--webhook-port={{.Values.app.webhook.port}}"
           - "--webhook-certificate-dir=/tls"
+          {{- if .Values.defaultPackage.enabled }}
           - "--default-package-location=/packages/cert-manager-package-debian.json"
+          {{- end }}
         volumeMounts:
         - mountPath: /tls
           name: tls

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -12,6 +12,10 @@ image:
   # -- Kubernetes imagePullPolicy on Deployment.
   pullPolicy: IfNotPresent
 
+defaultPackage:
+  # -- Whether to load the default trust package during pod initialization and include it in main container args. This container enables the 'useDefaultCAs' source on Bundles.
+  enabled: true
+
 defaultPackageImage:
   # -- Repository for the default package image. This image enables the 'useDefaultCAs' source on Bundles.
   repository: quay.io/jetstack/cert-manager-package-debian


### PR DESCRIPTION
The init container is a bit noisy when distributing in-house trust in environments with no internet connection.