### PR TITLE
Explicitly define resource namespaces in Helm chart

### DIFF
--- a/deploy/charts/trust-manager/templates/certificate.yaml
+++ b/deploy/charts/trust-manager/templates/certificate.yaml
@@ -2,6 +2,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ include "trust-manager.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "trust-manager.labels" . | indent 4 }}
 spec:
@@ -11,6 +12,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "trust-manager.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "trust-manager.labels" . | indent 4 }}
 spec:

--- a/deploy/charts/trust-manager/templates/deployment.yaml
+++ b/deploy/charts/trust-manager/templates/deployment.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "trust-manager.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "trust-manager.labels" . | indent 4 }}
 spec:

--- a/deploy/charts/trust-manager/templates/metrics-service.yaml
+++ b/deploy/charts/trust-manager/templates/metrics-service.yaml
@@ -3,6 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "trust-manager.name" . }}-metrics
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "trust-manager.name" . }}
 {{ include "trust-manager.labels" . | indent 4 }}

--- a/deploy/charts/trust-manager/templates/metrics-servicemonitor.yaml
+++ b/deploy/charts/trust-manager/templates/metrics-servicemonitor.yaml
@@ -3,6 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "trust-manager.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "trust-manager.name" . }}
 {{ include "trust-manager.labels" . | indent 4 }}

--- a/deploy/charts/trust-manager/templates/serviceaccount.yaml
+++ b/deploy/charts/trust-manager/templates/serviceaccount.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "trust-manager.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
 {{ include "trust-manager.labels" . | indent 4 }}
 {{- with .Values.imagePullSecrets }}

--- a/deploy/charts/trust-manager/templates/webhook.yaml
+++ b/deploy/charts/trust-manager/templates/webhook.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "trust-manager.name" . }}
+  namespace: {{ .Release.Namespace }}
   labels:
     app: {{ include "trust-manager.name" . }}
 {{ include "trust-manager.labels" . | indent 4 }}


### PR DESCRIPTION
This is very useful in combination with Helm template. It makes sure that all templated resources have the namespace set. This way, it is not possible to `k apply -f` in a different namespace; potentially breaking some of our references that contain namespace names.