### PR TITLE
Bump version to v0.5.0-beta.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ BOILERSUITE_VERSION ?= v0.1.0
 GINKGO_VERSION ?= $(shell grep "github.com/onsi/ginkgo/v2" go.mod | awk '{print $$NF}')
 IMAGE_PLATFORMS ?= linux/amd64,linux/arm64,linux/arm/v7,linux/ppc64le
 
-RELEASE_VERSION ?= v0.5.0-beta.0
+RELEASE_VERSION ?= v0.5.0-beta.1
 
 BUILDX_BUILDER ?= trust-manager-builder
 

--- a/deploy/charts/trust-manager/Chart.yaml
+++ b/deploy/charts/trust-manager/Chart.yaml
@@ -16,5 +16,8 @@ maintainers:
 sources:
 - https://github.com/cert-manager/trust-manager
 
-appVersion: v0.5.0-beta.0
-version: v0.5.0-beta.0
+appVersion: v0.5.0-beta.1
+version: v0.5.0-beta.1
+
+annotations:
+  artifacthub.io/prerelease: "true"

--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -1,6 +1,6 @@
 # trust-manager
 
-![Version: v0.5.0-beta.0](https://img.shields.io/badge/Version-v0.5.0--beta.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.5.0-beta.0](https://img.shields.io/badge/AppVersion-v0.5.0--beta.0-informational?style=flat-square)
+![Version: v0.5.0-beta.1](https://img.shields.io/badge/Version-v0.5.0--beta.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.5.0-beta.1](https://img.shields.io/badge/AppVersion-v0.5.0--beta.1-informational?style=flat-square)
 
 trust-manager is the easiest way to manage TLS trust bundles in Kubernetes and OpenShift clusters
 
@@ -46,7 +46,7 @@ Kubernetes: `>= 1.22.0-0`
 | defaultPackageImage.tag | string | `"20210119.0"` | Tag for the default package image |
 | image.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on Deployment. |
 | image.repository | string | `"quay.io/jetstack/trust-manager"` | Target image repository. |
-| image.tag | string | `"v0.5.0-beta.0"` | Target image version tag. |
+| image.tag | string | `"v0.5.0-beta.1"` | Target image version tag. |
 | imagePullSecrets | list | `[]` | For Private docker registries, authentication is needed. Registry secrets are applied to the service account |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Configure the nodeSelector; defaults to any Linux node (trust-manager doesn't support Windows nodes) |
 | replicaCount | int | `1` | Number of replicas of trust to run. |

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -8,7 +8,7 @@ image:
   # -- Target image repository.
   repository: quay.io/jetstack/trust-manager
   # -- Target image version tag.
-  tag: v0.5.0-beta.0
+  tag: v0.5.0-beta.1
   # -- Kubernetes imagePullPolicy on Deployment.
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Note that the prerelease annotation wasn't committed for v0.5.0-beta.0 (in #125 ) and I added it manually before I generated the helm chart. I've added it here, so we just need to remember to update that annotation when we release the next non-prerelease version!