### PR TITLE
Add description for JKS field for better docs

### DIFF
--- a/pkg/apis/trust/v1alpha1/types_bundle.go
+++ b/pkg/apis/trust/v1alpha1/types_bundle.go
@@ -108,6 +108,8 @@ type BundleTarget struct {
 
 // AdditionalFormats specifies any additional formats to write to the target
 type AdditionalFormats struct {
+	// JKS requests a JKS-formatted binary trust bundle to be written to the target.
+	// The bundle is created with the hardcoded password "changeit".
 	JKS *KeySelector `json:"jks,omitempty"`
 }
 
@@ -125,8 +127,7 @@ type SourceObjectKeySelector struct {
 	// Name is the name of the source object in the trust Namespace.
 	Name string `json:"name"`
 
-	// KeySelector is the key of the entry in the objects' `data` field to be
-	// referenced.
+	// KeySelector is the key of the entry in the objects' `data` field to be referenced.
 	KeySelector `json:",inline"`
 }
 


### PR DESCRIPTION
This will improve [this page](https://cert-manager.io/docs/projects/trust-manager/api-reference/) (after a followup PR for the website!)

I now realise (of course, just after the official release :grin: ) that JKS shouldn't be a `KeySelector`, it should be a `JKSFormat` or something. That'll have to be fixed in `v1alpha2` or `v1beta1`!