### PR TITLE
Add deprecation notes for the old cert-manager-trust name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,26 +1,7 @@
-<p align="center">
-  <img src="https://raw.githubusercontent.com/cert-manager/cert-manager/d53c0b9270f8cd90d908460d69502694e1838f5f/logo/logo-small.png" height="256" width="256" alt="cert-manager project logo" />
-</p>
-<p align="center">
-  <a href="https://godoc.org/github.com/cert-manager/trust"><img src="https://godoc.org/github.com/cert-manager/trust?status.svg" alt="cert-manager/trust godoc"></a>
-  <a href="https://goreportcard.com/report/github.com/cert-manager/trust"><img alt="Go Report Card" src="https://goreportcard.com/badge/github.com/cert-manager/trust" /></a>
-  <a href="https://artifacthub.io/packages/search?repo=cert-manager"><img alt="Artifact Hub" src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/cert-manager" /></a>
-</p>
+# trust-manager
 
-# trust
+This branch contains a new Helm chart version for the old "cert-manager-trust" chart which was used before the rename to "trust-manager".
 
-trust is an operator for distributing trust bundles across a Kubernetes cluster.
-trust is designed to complement
-[cert-manager](https://github.com/cert-manager/cert-manager) by enabling services to
-trust X.509 certificates signed by Issuers, as well as external CAs which may
-not be known to cert-manager at all.
+The intent is that users installing using the old chart name should see warnings and deprecation notices telling them to use the new name.
 
-⚠️ Trust is still an early stage project and will undergo large changes as it's developed.
-
-We'd encourage you to test it and we'd hope it'll be useful; just be prepared for breaking changes!
-
----
-
-Please follow the documentation at
-[cert-manager.io](https://cert-manager.io/docs/projects/trust/) for
-installing and using trust.
+It should also ensure that the ArtifactHub listings for the old chart are clear that the old name is to be avoided.

--- a/deploy/charts/trust/Chart.yaml
+++ b/deploy/charts/trust/Chart.yaml
@@ -2,15 +2,19 @@ apiVersion: v1
 
 name: cert-manager-trust
 type: application
-description: A Helm chart for cert-manager-trust
 
-home: https://github.com/cert-manager/trust
+description: "DEPRECATED: The old name for trust-manager. Use the 'trust-manager' chart instead."
+
+home: https://github.com/cert-manager/trust-manager
 maintainers:
 - name: cert-manager-maintainers
   email: cert-manager-maintainers@googlegroups.com
   url: https://cert-manager.io
+
 sources:
-- https://github.com/cert-manager/trust
+- https://github.com/cert-manager/trust-manager
 
 appVersion: v0.2.0
-version: v0.2.0
+version: v0.2.1
+
+deprecated: true

--- a/deploy/charts/trust/README.md
+++ b/deploy/charts/trust/README.md
@@ -1,10 +1,12 @@
 # cert-manager-trust
 
-![Version: v0.2.0](https://img.shields.io/badge/Version-v0.2.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
+> **:exclamation: This Helm Chart is deprecated!**
 
-A Helm chart for cert-manager-trust
+![Version: v0.2.1](https://img.shields.io/badge/Version-v0.2.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.2.0](https://img.shields.io/badge/AppVersion-v0.2.0-informational?style=flat-square)
 
-**Homepage:** <https://github.com/cert-manager/trust>
+DEPRECATED: The old name for trust-manager. Use the 'trust-manager' chart instead.
+
+**Homepage:** <https://github.com/cert-manager/trust-manager>
 
 ## Maintainers
 
@@ -14,7 +16,7 @@ A Helm chart for cert-manager-trust
 
 ## Source Code
 
-* <https://github.com/cert-manager/trust>
+* <https://github.com/cert-manager/trust-manager>
 
 ## Values
 

--- a/deploy/charts/trust/templates/NOTES.txt
+++ b/deploy/charts/trust/templates/NOTES.txt
@@ -1,0 +1,18 @@
+**************
+* DEPRECATED *
+**************
+
+'cert-manager-trust' has been renamed to 'trust-manager'.
+
+No further releases will be made under this old, deprecated name.
+
+Use 'trust-manager' instead and get all kinds of useful features including:
+
+- Support for publicly trusted certificate bundles
+- JKS support
+- Much improved validation and error checking
+- And much more!
+
+**************
+* DEPRECATED *
+**************


### PR DESCRIPTION
The intent here is to encourage users to use 'trust-manager' instead.

This was discussed in the cert-manager biweekly meeting on 2023-06-01.