### PR TITLE
Setting useDefaultCAs: false no longer causes failures

### DIFF
--- a/pkg/bundle/sync.go
+++ b/pkg/bundle/sync.go
@@ -105,10 +105,7 @@ func (b *bundle) buildSourceBundle(ctx context.Context, bundle *trustapi.Bundle)
 		bundles = append(bundles, string(sanitizedBundle))
 	}
 
-	// NB: bundles should never be empty here, since ValidateAndSanitizePEMBundle errors when a bundle source
-	// contains no valid certificates. Plus, the webhook validation should confirm that there's at least one source
-	// defined to avoid otherwise empty bundles.
-	// Still, just in case, we check and return an error in case somehow an empty bundle snuck through.
+	// NB: empty bundles are not valid so check and return an error if one somehow snuck through.
 
 	if len(bundles) == 0 {
 		return bundleData{}, fmt.Errorf("couldn't find any valid certificates in bundle")

--- a/pkg/bundle/sync.go
+++ b/pkg/bundle/sync.go
@@ -80,7 +80,11 @@ func (b *bundle) buildSourceBundle(ctx context.Context, bundle *trustapi.Bundle)
 		case source.InLine != nil:
 			sourceData = *source.InLine
 
-		case source.UseDefaultCAs != nil && *source.UseDefaultCAs:
+		case source.UseDefaultCAs != nil:
+			if *source.UseDefaultCAs == false {
+				continue
+			}
+
 			if b.defaultPackage == nil {
 				err = notFoundError{fmt.Errorf("no default package was specified when trust-manager was started; default CAs not available")}
 			} else {

--- a/pkg/webhook/validation.go
+++ b/pkg/webhook/validation.go
@@ -105,9 +105,12 @@ func (v *validator) validate(ctx context.Context, obj runtime.Object) (admission
 				unionCount++
 			}
 
-			if source.UseDefaultCAs != nil && *source.UseDefaultCAs {
+			if source.UseDefaultCAs != nil {
 				unionCount++
-				defaultCAsCount++
+
+				if *source.UseDefaultCAs {
+					defaultCAsCount++
+				}
 			}
 
 			if unionCount != 1 {

--- a/pkg/webhook/validation_test.go
+++ b/pkg/webhook/validation_test.go
@@ -87,6 +87,7 @@ func Test_validate(t *testing.T) {
 			},
 			expErr: pointer.String(field.ErrorList{
 				field.Forbidden(field.NewPath("spec", "sources", "[0]"), "must define exactly one source type for each item but found 0 defined types"),
+				field.Forbidden(field.NewPath("spec", "sources"), "must define at least one source"),
 			}.ToAggregate().Error()),
 		},
 		"useDefaultCAs false, with no other defined sources": {
@@ -101,7 +102,7 @@ func Test_validate(t *testing.T) {
 				},
 			},
 			expErr: pointer.String(field.ErrorList{
-				field.Forbidden(field.NewPath("spec", "sources", "[0]"), "must define exactly one source type for each item but found 0 defined types"),
+				field.Forbidden(field.NewPath("spec", "sources"), "must define at least one source"),
 			}.ToAggregate().Error()),
 		},
 		"useDefaultCAs requested twice": {
@@ -120,6 +121,27 @@ func Test_validate(t *testing.T) {
 			},
 			expErr: pointer.String(field.ErrorList{
 				field.Forbidden(field.NewPath("spec", "sources"), "must request default CAs either once or not at all but got 2 requests"),
+			}.ToAggregate().Error()),
+		},
+		"useDefaultCAs requested three times": {
+			bundle: &trustapi.Bundle{
+				Spec: trustapi.BundleSpec{
+					Sources: []trustapi.BundleSource{
+						{
+							UseDefaultCAs: pointer.Bool(true),
+						},
+						{
+							UseDefaultCAs: pointer.Bool(false),
+						},
+						{
+							UseDefaultCAs: pointer.Bool(true),
+						},
+					},
+					Target: trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{Key: "test"}},
+				},
+			},
+			expErr: pointer.String(field.ErrorList{
+				field.Forbidden(field.NewPath("spec", "sources"), "must request default CAs either once or not at all but got 3 requests"),
 			}.ToAggregate().Error()),
 		},
 		"sources no names and keys": {


### PR DESCRIPTION
This fixes #133 - an issue where setting `useDefaultCAs: false` would cause validation (and also sync) errors.

In order to support this the validation code needed to change slightly. It now counts the number of sources in a bundle and will fail if that count is still zero after inspection. Setting `useDefaultCAs: true` is considered a source for this count, but `useDefaultCAs: false` is not.

So these specs are valid:
```yaml
spec:
  sources:
  - useDefaultCAs: true
```
```yaml
spec:
  sources:
  - secret:
      name: "our-org-ca"
      key: "ca.crt"
```
```yaml
spec:
  sources:
  - useDefaultCAs: true
  - secret:
      name: "our-org-ca"
      key: "ca.crt"
```
```yaml
spec:
  sources:
  - useDefaultCAs: false
  - secret:
      name: "our-org-ca"
      key: "ca.crt"
```

But this one is not:
```yaml
spec:
  sources:
  - useDefaultCAs: false