### PR TITLE
Fix code generation

### DIFF
--- a/deploy/charts/trust-manager/templates/trust.cert-manager.io_bundles.yaml
+++ b/deploy/charts/trust-manager/templates/trust.cert-manager.io_bundles.yaml
@@ -102,7 +102,7 @@ spec:
                       type: object
                       properties:
                         jks:
-                          description: KeySelector is a reference to a key for some map data object.
+                          description: JKS requests a JKS-formatted binary trust bundle to be written to the target. The bundle is created with the hardcoded password "changeit".
                           type: object
                           required:
                             - key
@@ -174,7 +174,7 @@ spec:
                       type: object
                       properties:
                         jks:
-                          description: KeySelector is a reference to a key for some map data object.
+                          description: JKS requests a JKS-formatted binary trust bundle to be written to the target. The bundle is created with the hardcoded password "changeit".
                           type: object
                           required:
                             - key

--- a/deploy/crds/trust.cert-manager.io_bundles.yaml
+++ b/deploy/crds/trust.cert-manager.io_bundles.yaml
@@ -101,7 +101,7 @@ spec:
                       type: object
                       properties:
                         jks:
-                          description: KeySelector is a reference to a key for some map data object.
+                          description: JKS requests a JKS-formatted binary trust bundle to be written to the target. The bundle is created with the hardcoded password "changeit".
                           type: object
                           required:
                             - key
@@ -173,7 +173,7 @@ spec:
                       type: object
                       properties:
                         jks:
-                          description: KeySelector is a reference to a key for some map data object.
+                          description: JKS requests a JKS-formatted binary trust bundle to be written to the target. The bundle is created with the hardcoded password "changeit".
                           type: object
                           required:
                             - key

--- a/hack/boilerplate/boilerplate.go.txt
+++ b/hack/boilerplate/boilerplate.go.txt
@@ -1,0 +1,16 @@
+/*
+Copyright 2023 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -43,7 +43,7 @@ for GVs in ${GROUPS_WITH_VERSIONS}; do
 done
 
 echo "Generating deepcopy funcs"
-${BIN_DIR}/deepcopy-gen --input-dirs "$(codegen::join , "${FQ_APIS[@]}")" -O zz_generated.deepcopy --bounding-dirs "${APIS_PKG}" -h $BOILERPLATE
+${BIN_DIR}/deepcopy-gen --input-dirs "$(codegen::join , "${FQ_APIS[@]}")" -O zz_generated.deepcopy --bounding-dirs "${APIS_PKG}" --trim-path-prefix="$TRUST_DISTRIBUTION_PKG" -h $BOILERPLATE
 
 echo "Generating CRDs in ./deploy/crds"
 ${BIN_DIR}/controller-gen crd schemapatch:manifests=./deploy/crds output:dir=./deploy/crds paths=./pkg/apis/...


### PR DESCRIPTION
Codegen wasn't working on a new checkout running `make generate` because the boilerplate was missing and the generated deepcopy was being created under an additional `github.com/cert-manager/trust-manager` hierarchy.

This PR puts the boilerplate in (based on the existing deepcopy boilerplate), fixes the pathing, and includes a couple of changes to generated files that hadn't been applied.