### PR TITLE
Add ability to set pod level securityContext

### DIFF
--- a/deploy/charts/trust-manager/templates/deployment.yaml
+++ b/deploy/charts/trust-manager/templates/deployment.yaml
@@ -16,8 +16,9 @@ spec:
         app: {{ include "trust-manager.name" . }}
     spec:
       serviceAccountName: {{ include "trust-manager.name" . }}
-      securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- if .Values.podSecurityContext }}
+      securityContext: {{ .Values.podSecurityContext | toYaml | nindent 8 }}
+      {{- end }}
       {{- if .Values.defaultPackage.enabled }}
       initContainers:
       - name: cert-manager-package-debian

--- a/deploy/charts/trust-manager/templates/deployment.yaml
+++ b/deploy/charts/trust-manager/templates/deployment.yaml
@@ -16,6 +16,8 @@ spec:
         app: {{ include "trust-manager.name" . }}
     spec:
       serviceAccountName: {{ include "trust-manager.name" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
       {{- if .Values.defaultPackage.enabled }}
       initContainers:
       - name: cert-manager-package-debian

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -23,7 +23,12 @@ defaultPackageImage:
   tag: "20210119.0"
   # -- imagePullPolicy for the default package image
   pullPolicy: IfNotPresent
-
+# Kubernetes pod level securityContext: see https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+# for example:
+#   podSecurityContext:
+#     seccompProfile:
+#       type: RuntimeDefault
+podSecurityContext: {}
 app:
   # -- Verbosity of trust logging; takes a value from 1-5, with higher being more verbose
   logLevel: 1


### PR DESCRIPTION
What
---
Adds the ability to inject pod level securityContext values via the `podSecurityContext` value. Retains existing behavior by defaulting to an empty object.

Why
---
I'd like to be able to set pod level securityContext values that can be inherited by injected sidecars.


Evidence
---
Helm template snippet with defaults.

``` shell
helm template test .
```
``` yaml
template:
  metadata:
    labels:
      app: trust-manager
  spec:
    serviceAccountName: trust-manager
    initContainers: 
```

Helm template snippet with values injected
``` shell
helm template test . --set podSecurityContext.fsGroup=1001
```
output
``` yaml
template:
    metadata:
      labels:
        app: trust-manager
    spec:
      serviceAccountName: trust-manager
      securityContext: 
        fsGroup: 1001
      initContainers:
```