### PR TITLE
Respect seccomp toggle in init container

### DIFF
--- a/deploy/charts/trust-manager/templates/deployment.yaml
+++ b/deploy/charts/trust-manager/templates/deployment.yaml
@@ -36,8 +36,10 @@ spec:
             - ALL
           readOnlyRootFilesystem: true
           runAsNonRoot: true
+          {{- if .Values.app.securityContext.seccompProfileEnabled }}
           seccompProfile:
             type: RuntimeDefault
+          {{- end }}
       {{- end }}
       containers:
       - name: {{ include "trust-manager.name" . }}


### PR DESCRIPTION
I worked on #69 in order to disable seccomp in the deployment but it looks like an initcontainer was added. I cannot deploy the bog-standard trust-manager until this too is disabled.