### PR TITLE
Add support for generating certificates with helm

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -401,6 +401,13 @@ Sets the families that should be supported and the order in which they should be
 
 The nodePort set on the Service used by the webhook.
 
+#### **app.webhook.tls.helmCert.enabled** ~ `bool`
+> Default value:
+> ```yaml
+> false
+> ```
+
+Whether to issue a webhook cert using Helm, which removes the need to install cert-manager. Helm-issued certificates can be challenging to rotate and maintain, and the issued cert will have a duration of 10 years and be modified when trust-manager is updated. It's safer and easier to rely on cert-manager for issuing the webhook cert - avoid using Helm-generated certs in production.
 #### **app.webhook.tls.approverPolicy.enabled** ~ `bool`
 > Default value:
 > ```yaml

--- a/deploy/charts/trust-manager/templates/certificate.yaml
+++ b/deploy/charts/trust-manager/templates/certificate.yaml
@@ -1,3 +1,5 @@
+{{- if not .Values.app.webhook.tls.helmCert.enabled -}}
+
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -82,5 +84,7 @@ subjects:
 - kind: ServiceAccount
   name: {{ .Values.app.webhook.tls.approverPolicy.certManagerServiceAccount }}
   namespace: {{ .Values.app.webhook.tls.approverPolicy.certManagerNamespace }}
+
+{{ end }}
 
 {{ end }}

--- a/deploy/charts/trust-manager/templates/deployment.yaml
+++ b/deploy/charts/trust-manager/templates/deployment.yaml
@@ -12,9 +12,15 @@ spec:
       app: {{ include "trust-manager.name" . }}
   template:
     metadata:
-      {{- with .Values.app.podAnnotations }}
+      {{- if or .Values.app.podAnnotations .Values.app.webhook.tls.helmCert.enabled }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        {{- if .Values.app.podAnnotations }}
+        {{- toYaml .Values.app.podAnnotations | nindent 8 }}
+        {{- end }}
+        {{- if .Values.app.webhook.tls.helmCert.enabled }}
+        {{- /* When using a helm cert, the cert will be regenerated every time the chart is updated. When that happens, we need to restart the pods in the deployment to ensure the new cert is picked up. */}}
+        rollme-due-to-helm-cert: {{ randAlphaNum 5 | quote }}
+        {{- end }}
       {{- end }}
       labels:
         app: {{ include "trust-manager.name" . }}

--- a/deploy/charts/trust-manager/templates/webhook.yaml
+++ b/deploy/charts/trust-manager/templates/webhook.yaml
@@ -1,3 +1,52 @@
+{{- if and .Values.app.webhook.tls.helmCert.enabled .Values.app.webhook.tls.approverPolicy.enabled -}}
+{{- fail "cannot set .app.webhook.tls.helmCert.enabled and .Values.app.webhook.tls.approverPolicy.enabled" }}
+{{- end -}}
+
+{{- /*
+$ca is always generated here even if .Values.app.webhook.tls.helmCert.enabled is false because we need it to be
+visible in the scope for the ValidatingWebhookConfiguration below.
+
+genCA has two args - first is cert commonName (CN) and second is validity in days (9125 = ~25 years)
+
+We don't write this CA's private key to a secret because we don't want it to be used for any other purpose
+except for generating $cert below.
+
+DO NOT USE $ca ANYWHERE IF app.tls.helmCert.enabled IS FALSE
+*/}}
+
+{{- $ca := genCA (printf "*.%s.svc" .Release.Namespace ) 9125 -}}
+
+
+{{- if .Values.app.webhook.tls.helmCert.enabled -}}
+{{- $svcName := (printf "%s.%s.svc" (include "trust-manager.name" . ) .Release.Namespace ) -}}
+
+{{- /*
+genSignedCert has the following args, in order:
+1. The cert CN
+2. A list of IP addresses the cert is valid for
+3. A list of DNS altnames the cert is valid for
+4. The duration in days (3650 = ~10 years)
+5. The signing CA
+*/}}
+{{- $cert := genSignedCert $svcName nil (list $svcName) 3650 $ca -}}
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "trust-manager.name" . }}-tls
+  namespace: {{ .Release.Namespace }}
+  labels:
+{{ include "trust-manager.labels" . | indent 4 }}
+type: kubernetes.io/tls
+data:
+  ca.crt: {{ $ca.Cert | b64enc }}
+  tls.key: {{ $cert.Key | b64enc }}
+  tls.crt: {{ $cert.Cert | b64enc }}
+
+---
+
+{{ end }}
+
 apiVersion: v1
 kind: Service
 metadata:
@@ -24,7 +73,9 @@ spec:
       name: webhook
   selector:
     app: {{ include "trust-manager.name" . }}
+
 ---
+
 apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
@@ -32,8 +83,10 @@ metadata:
   labels:
     app: {{ include "trust-manager.name" . }}
     {{- include "trust-manager.labels" . | nindent 4 }}
+{{ if not .Values.app.webhook.tls.helmCert.enabled }}
   annotations:
     cert-manager.io/inject-ca-from: "{{ include "trust-manager.namespace" . }}/{{ include "trust-manager.name" . }}"
+{{ end }}
 
 webhooks:
   - name: trust.cert-manager.io
@@ -52,6 +105,9 @@ webhooks:
     failurePolicy: Fail
     sideEffects: None
     clientConfig:
+{{ if .Values.app.webhook.tls.helmCert.enabled }}
+      caBundle: "{{ $ca.Cert | b64enc }}"
+{{ end }}
       service:
         name: {{ include "trust-manager.name" . }}
         namespace: {{ include "trust-manager.namespace" . }}

--- a/deploy/charts/trust-manager/values.schema.json
+++ b/deploy/charts/trust-manager/values.schema.json
@@ -366,6 +366,9 @@
       "properties": {
         "approverPolicy": {
           "$ref": "#/$defs/helm-values.app.webhook.tls.approverPolicy"
+        },
+        "helmCert": {
+          "$ref": "#/$defs/helm-values.app.webhook.tls.helmCert"
         }
       },
       "type": "object"
@@ -398,6 +401,20 @@
     "helm-values.app.webhook.tls.approverPolicy.enabled": {
       "default": false,
       "description": "Whether to create an approver-policy CertificateRequestPolicy allowing auto-approval of the trust-manager webhook certificate. If you have approver-policy installed, you almost certainly want to enable this.",
+      "type": "boolean"
+    },
+    "helm-values.app.webhook.tls.helmCert": {
+      "additionalProperties": false,
+      "properties": {
+        "enabled": {
+          "$ref": "#/$defs/helm-values.app.webhook.tls.helmCert.enabled"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.app.webhook.tls.helmCert.enabled": {
+      "default": false,
+      "description": "Whether to issue a webhook cert using Helm, which removes the need to install cert-manager. Helm-issued certificates can be challenging to rotate and maintain, and the issued cert will have a duration of 10 years and be modified when trust-manager is updated. It's safer and easier to rely on cert-manager for issuing the webhook cert - avoid using Helm-generated certs in production.",
       "type": "boolean"
     },
     "helm-values.commonLabels": {

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -227,6 +227,12 @@ app:
       # nodePort: 8080
 
     tls:
+      helmCert:
+        # Whether to issue a webhook cert using Helm, which removes the need to install cert-manager.
+        # Helm-issued certificates can be challenging to rotate and maintain, and the issued cert will have a duration of 10 years and be modified when trust-manager is updated.
+        # It's safer and easier to rely on cert-manager for issuing the webhook cert - avoid using Helm-generated certs in production.
+        enabled: false
+
       approverPolicy:
         # Whether to create an approver-policy CertificateRequestPolicy allowing auto-approval of the trust-manager webhook certificate. If you have approver-policy installed, you almost certainly want to enable this.
         enabled: false


### PR DESCRIPTION
This removes the hard dependency on cert-manager by allowing users to choose not to create a Certificate.

The extremely long lifetime of the cert is to remove the chance of it expiring in the lifetime of a typical cluster. Users who want rotation would be well advised to use cert-manager, which remains the default