### PR TITLE
Add support for approver policy

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -39,6 +39,8 @@ Kubernetes: `>= 1.22.0-0`
 | app.webhook.port | int | `6443` | Port that the webhook listens on. |
 | app.webhook.service | object | `{"type":"ClusterIP"}` | Type of Kubernetes Service used by the Webhook |
 | app.webhook.timeoutSeconds | int | `5` | Timeout of webhook HTTP request. |
+| app.webhook.tls.approverPolicy.certManagerNamespace | string | `"cert-manager"` | Namespace in which cert-manager was installed. Only used if approverPolicy has been enabled. |
+| app.webhook.tls.approverPolicy.enabled | bool | `false` | Whether to create an approver-policy CertificateRequestPolicy allowing auto-approval of the trust-manager webhook certificate. If you have approver-policy installed, you almost certainly want to enable this. |
 | crds.enabled | bool | `true` | Whether or not to install the crds. |
 | defaultPackage.enabled | bool | `true` | Whether to load the default trust package during pod initialization and include it in main container args. This container enables the 'useDefaultCAs' source on Bundles. |
 | defaultPackageImage.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the default package image |

--- a/deploy/charts/trust-manager/templates/certificate.yaml
+++ b/deploy/charts/trust-manager/templates/certificate.yaml
@@ -7,7 +7,9 @@ metadata:
 {{ include "trust-manager.labels" . | indent 4 }}
 spec:
   selfSigned: {}
+
 ---
+
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
@@ -24,3 +26,52 @@ spec:
     name: {{ include "trust-manager.name" . }}
     kind: Issuer
     group: cert-manager.io
+
+---
+
+{{- if .Values.app.webhook.tls.approverPolicy.enabled -}}
+
+apiVersion: policy.cert-manager.io/v1alpha1
+kind: CertificateRequestPolicy
+metadata:
+  name: trust-manager-policy
+  namespace: {{ .Release.Namespace }}
+spec:
+  allowed:
+    dnsNames:
+      values: ["{{ include "trust-manager.name" . }}.{{ .Release.Namespace }}.svc"]
+      required: true
+  selector:
+    issuerRef:
+      name: {{ include "trust-manager.name" . }}
+      kind: Issuer
+      group: cert-manager.io
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: trust-manager-policy-role
+rules:
+  - apiGroups: ["policy.cert-manager.io"]
+    resources: ["certificaterequestpolicies"]
+    verbs: ["use"]
+    resourceNames: ["trust-manager-policy"]
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: trust-manager-policy-binding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: trust-manager-policy-role
+subjects:
+- kind: ServiceAccount
+  name: cert-manager
+  namespace: {{ .Values.app.webhook.tls.approverPolicy.certManagerNamespace }}
+
+{{ end }}

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -67,6 +67,15 @@ app:
     service:
       type: ClusterIP
 
+    tls:
+      approverPolicy:
+        # -- Whether to create an approver-policy CertificateRequestPolicy allowing auto-approval of the trust-manager webhook certificate. If you have approver-policy installed, you almost certainly want to enable this.
+        enabled: false
+
+        # -- Namespace in which cert-manager was installed. Only used if approverPolicy has been enabled.
+        certManagerNamespace: "cert-manager"
+
+
   securityContext:
     # -- If false, disables the default seccomp profile, which might be required to run on certain platforms
     seccompProfileEnabled: true


### PR DESCRIPTION
If using cert-manager with the default approver disabled, it's a pain to install trust-manager since it requires manual approval of the CertificateRequest which is issued for the webhook.

This adds an option to create a CertificateRequestPolicy which approver-policy can use to auto-approve the CR.

This was tested with:

```bash
#!/usr/bin/env bash

set -exu -o pipefail

rm  ./bin/chart/trust-manager-v0.5.0.tgz && make chart
helm template trust-manager ./bin/chart/trust-manager-v0.5.0.tgz --namespace default --set app.trust.namespace=default --set approverPolicy.enabled=true > bin/templated.yaml

helm install \
	cert-manager jetstack/cert-manager \
	--namespace cert-manager \
	--create-namespace \
	--version v1.12.0 \
	--set installCRDs=true \
	--set extraArgs={--controllers='*\,-certificaterequests-approver'}

helm upgrade -i -n cert-manager cert-manager-approver-policy jetstack/cert-manager-approver-policy --wait

helm install trust-manager ./bin/chart/trust-manager-v0.5.0.tgz --namespace default --set app.trust.namespace=default --set approverPolicy.enabled=true

```