### PR TITLE
Refactor CM binary data reconcile preparing for PKCS#12 support

### DIFF
--- a/pkg/bundle/sync_test.go
+++ b/pkg/bundle/sync_test.go
@@ -712,7 +712,7 @@ func Test_encodeJKSAliases(t *testing.T) {
 
 	password := []byte(DefaultJKSPassword)
 
-	jksFile, err := encodeJKS(bundle, password)
+	jksFile, err := jksEncoder{password: password}.encode(bundle)
 	if err != nil {
 		t.Fatalf("didn't expect an error but got: %s", err)
 	}
@@ -750,7 +750,7 @@ func Test_jksAlias(t *testing.T) {
 		t.Fatalf("Dummy certificate TestCertificate1 couldn't be parsed: %s", err)
 	}
 
-	alias := jksAlias(cert.Raw, cert.Subject.String())
+	alias := jksEncoder{}.alias(cert.Raw, cert.Subject.String())
 
 	expectedAlias := "548b988f|CN=cmct-test-root,O=cert-manager"
 


### PR DESCRIPTION
Before filing a PR to add support for PKCS#12 truststores (ref. remaining in https://github.com/cert-manager/trust-manager/issues/17), I think it makes sense to slightly refactor the JKS truststore support introduced in https://github.com/cert-manager/trust-manager/pull/122. I think it will make the follow-up PR easier to review.