### PR TITLE
Add support for PKCS12 truststores (update CRD)

### DIFF
--- a/deploy/charts/trust-manager/templates/trust.cert-manager.io_bundles.yaml
+++ b/deploy/charts/trust-manager/templates/trust.cert-manager.io_bundles.yaml
@@ -110,6 +110,15 @@ spec:
                             key:
                               description: Key is the key of the entry in the object's `data` field to be used.
                               type: string
+                        pkcs12:
+                          description: PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the target. The bundle is created without a password.
+                          type: object
+                          required:
+                            - key
+                          properties:
+                            key:
+                              description: Key is the key of the entry in the object's `data` field to be used.
+                              type: string
                     configMap:
                       description: ConfigMap is the target ConfigMap in Namespaces that all Bundle source data will be synced to.
                       type: object
@@ -175,6 +184,15 @@ spec:
                       properties:
                         jks:
                           description: JKS requests a JKS-formatted binary trust bundle to be written to the target. The bundle is created with the hardcoded password "changeit".
+                          type: object
+                          required:
+                            - key
+                          properties:
+                            key:
+                              description: Key is the key of the entry in the object's `data` field to be used.
+                              type: string
+                        pkcs12:
+                          description: PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the target. The bundle is created without a password.
                           type: object
                           required:
                             - key

--- a/deploy/crds/trust.cert-manager.io_bundles.yaml
+++ b/deploy/crds/trust.cert-manager.io_bundles.yaml
@@ -109,6 +109,15 @@ spec:
                             key:
                               description: Key is the key of the entry in the object's `data` field to be used.
                               type: string
+                        pkcs12:
+                          description: PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the target. The bundle is created without a password.
+                          type: object
+                          required:
+                            - key
+                          properties:
+                            key:
+                              description: Key is the key of the entry in the object's `data` field to be used.
+                              type: string
                     configMap:
                       description: ConfigMap is the target ConfigMap in Namespaces that all Bundle source data will be synced to.
                       type: object
@@ -174,6 +183,15 @@ spec:
                       properties:
                         jks:
                           description: JKS requests a JKS-formatted binary trust bundle to be written to the target. The bundle is created with the hardcoded password "changeit".
+                          type: object
+                          required:
+                            - key
+                          properties:
+                            key:
+                              description: Key is the key of the entry in the object's `data` field to be used.
+                              type: string
+                        pkcs12:
+                          description: PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the target. The bundle is created without a password.
                           type: object
                           required:
                             - key


### PR DESCRIPTION
This a follow-up PR to https://github.com/cert-manager/trust-manager/pull/163. Somehow I (and also reviewers) did not see that the Bundle CRD wasn't updated. 🤣 Sorry! In my defense, I can only say that the controllers I usually work with (on-prem) have CI to verify that generated files are up-to-date. I will create an issue suggesting the same in this project.

I should probably also update the API docs somewhere, or is that automated?