### PR TITLE
Add erikgb to project reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -16,3 +16,4 @@ reviewers:
 - irbekrm
 - sgtcodfish
 - inteon
+- erikgb


### PR DESCRIPTION
Under the cert-manager umbrella, trust-manager is a fairly simple component. After submitting [some PRs](https://github.com/cert-manager/trust-manager/pulls?q=is%3Apr+author%3Aerikgb) (and more to come), I feel pretty confident in the code base and would like to apply for the project reviewer role - ref. the WIP Governance document.

We (as in the company I'm working for) are in the process of adopting trust-manager, and it would be nice to get more involved.

Sponsors: @inteon @SgtCoDFish 