### PR TITLE
Fix misinterpretation, ByObject cache settings are GVK specific

### DIFF
--- a/cmd/trust-manager/app/app.go
+++ b/cmd/trust-manager/app/app.go
@@ -23,7 +23,6 @@ import (
 
 	"github.com/spf13/cobra"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	clientv1 "k8s.io/client-go/kubernetes/typed/core/v1"
 	"k8s.io/client-go/tools/record"
@@ -103,18 +102,10 @@ func NewCommand() *cobra.Command {
 							},
 						},
 						&corev1.ConfigMap{}: {
-							// Only cache full ConfigMaps in the "watched" namespace.
-							Namespaces: map[string]cache.Config{
-								opts.Bundle.Namespace: {},
-							},
+							// Watch full config maps across all namespaces.
+							// TODO: create a seperate cache for targets and sources and only
+							// cache full config maps for the sources.
 						},
-						// Only cache partial metadata for targets.
-						&metav1.PartialObjectMetadata{
-							TypeMeta: metav1.TypeMeta{
-								APIVersion: "v1",
-								Kind:       "ConfigMap",
-							},
-						}: {},
 					},
 				},
 			})


### PR DESCRIPTION
In https://github.com/cert-manager/trust-manager/pull/161, I switched to a single cache that uses the ByObject cache option.
I did no realise that partial metadata settings collide with the typed object settings.
This PR fixes the confusing config and adds a TODO note.
We aim to fix the TODO in https://github.com/cert-manager/trust-manager/pull/89