### PR TITLE
Allow user to specify the name of cert-manager's ServiceAccount

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -39,7 +39,8 @@ Kubernetes: `>= 1.25.0`
 | app.webhook.port | int | `6443` | Port that the webhook listens on. |
 | app.webhook.service | object | `{"type":"ClusterIP"}` | Type of Kubernetes Service used by the Webhook |
 | app.webhook.timeoutSeconds | int | `5` | Timeout of webhook HTTP request. |
-| app.webhook.tls.approverPolicy.certManagerNamespace | string | `"cert-manager"` | Namespace in which cert-manager was installed. Only used if approverPolicy has been enabled. |
+| app.webhook.tls.approverPolicy.certManagerNamespace | string | `"cert-manager"` | Namespace in which cert-manager was installed. Only used if app.webhook.tls.approverPolicy.enabled is true |
+| app.webhook.tls.approverPolicy.certManagerServiceAccount | string | `"cert-manager"` | Name of cert-manager's ServiceAccount. Only used if app.webhook.tls.approverPolicy.enabled is true |
 | app.webhook.tls.approverPolicy.enabled | bool | `false` | Whether to create an approver-policy CertificateRequestPolicy allowing auto-approval of the trust-manager webhook certificate. If you have approver-policy installed, you almost certainly want to enable this. |
 | crds.enabled | bool | `true` | Whether or not to install the crds. |
 | defaultPackage.enabled | bool | `true` | Whether to load the default trust package during pod initialization and include it in main container args. This container enables the 'useDefaultCAs' source on Bundles. |

--- a/deploy/charts/trust-manager/templates/certificate.yaml
+++ b/deploy/charts/trust-manager/templates/certificate.yaml
@@ -35,7 +35,6 @@ apiVersion: policy.cert-manager.io/v1alpha1
 kind: CertificateRequestPolicy
 metadata:
   name: trust-manager-policy
-  namespace: {{ .Release.Namespace }}
 spec:
   allowed:
     dnsNames:

--- a/deploy/charts/trust-manager/templates/certificate.yaml
+++ b/deploy/charts/trust-manager/templates/certificate.yaml
@@ -71,7 +71,7 @@ roleRef:
   name: trust-manager-policy-role
 subjects:
 - kind: ServiceAccount
-  name: cert-manager
+  name: {{ .Values.app.webhook.tls.approverPolicy.certManagerServiceAccount }}
   namespace: {{ .Values.app.webhook.tls.approverPolicy.certManagerNamespace }}
 
 {{ end }}

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -78,8 +78,11 @@ app:
         # -- Whether to create an approver-policy CertificateRequestPolicy allowing auto-approval of the trust-manager webhook certificate. If you have approver-policy installed, you almost certainly want to enable this.
         enabled: false
 
-        # -- Namespace in which cert-manager was installed. Only used if approverPolicy has been enabled.
+        # -- Namespace in which cert-manager was installed. Only used if app.webhook.tls.approverPolicy.enabled is true
         certManagerNamespace: "cert-manager"
+
+        # -- Name of cert-manager's ServiceAccount. Only used if app.webhook.tls.approverPolicy.enabled is true
+        certManagerServiceAccount: "cert-manager"
 
 
   securityContext:


### PR DESCRIPTION
The cert-manager ServiceAccount is not fixed and so can vary between different installations. [1] [2]

cert-manager users might well want to customise it, and we should support those users in trust-manager!

ℹ️ This also removes the namespace from the CertificateRequestPolicy, since that resource is cluster scoped and so passing a namespace here is a no-op!

[1] https://github.com/cert-manager/cert-manager/blob/cab2b3b68ca834b60931fd76d1fb74f757a03550/deploy/charts/cert-manager/templates/serviceaccount.yaml#L10
[2] https://github.com/cert-manager/cert-manager/blob/cab2b3b68ca834b60931fd76d1fb74f757a03550/deploy/charts/cert-manager/values.yaml#L108