### PR TITLE
BUGFIX: fix migration from csa to ssa

### DIFF
--- a/pkg/bundle/controller.go
+++ b/pkg/bundle/controller.go
@@ -49,12 +49,22 @@ func AddBundleController(
 	opts Options,
 	targetCache cache.Cache,
 ) error {
+	directClient, err := client.New(mgr.GetConfig(), client.Options{
+		HTTPClient: mgr.GetHTTPClient(),
+		Scheme:     mgr.GetScheme(),
+		Mapper:     mgr.GetRESTMapper(),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create direct client: %w", err)
+	}
+
 	b := &bundle{
-		client:      mgr.GetClient(),
-		targetCache: targetCache,
-		recorder:    mgr.GetEventRecorderFor("bundles"),
-		clock:       clock.RealClock{},
-		Options:     opts,
+		client:       mgr.GetClient(),
+		directClient: directClient,
+		targetCache:  targetCache,
+		recorder:     mgr.GetEventRecorderFor("bundles"),
+		clock:        clock.RealClock{},
+		Options:      opts,
 	}
 
 	if b.Options.DefaultPackageLocation != "" {


### PR DESCRIPTION
@erikgb noticed that the client-side-apply to server-side-apply migration functions are not working as expected (https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1694172356236499).
In https://github.com/cert-manager/trust-manager/pull/89, I made the wrong assumption that the fieldmanager was set to "trust-manager" in previous versions.
In this PR, I fixed this mistake. I also added a test to make sure that the confimap resources are also correctly migrated.