### PR TITLE
HELM: add options for configuring image

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -43,14 +43,16 @@ Kubernetes: `>= 1.25.0`
 | app.webhook.tls.approverPolicy.enabled | bool | `false` | Whether to create an approver-policy CertificateRequestPolicy allowing auto-approval of the trust-manager webhook certificate. If you have approver-policy installed, you almost certainly want to enable this. |
 | crds.enabled | bool | `true` | Whether or not to install the crds. |
 | defaultPackage.enabled | bool | `true` | Whether to load the default trust package during pod initialization and include it in main container args. This container enables the 'useDefaultCAs' source on Bundles. |
+| defaultPackageImage.digest | string | `nil` | Target image digest. Will override any tag if set. for example: digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20 |
 | defaultPackageImage.pullPolicy | string | `"IfNotPresent"` | imagePullPolicy for the default package image |
+| defaultPackageImage.registry | string | `nil` | Target image registry. Will be prepended to the target image repositry if set. |
 | defaultPackageImage.repository | string | `"quay.io/jetstack/cert-manager-package-debian"` | Repository for the default package image. This image enables the 'useDefaultCAs' source on Bundles. |
 | defaultPackageImage.tag | string | `"20210119.0"` | Tag for the default package image |
-| image.digest | string | `nil` | Target image digest. Will override any tag if set. |
+| image.digest | string | `nil` | Target image digest. Will override any tag if set. for example: digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20 |
 | image.pullPolicy | string | `"IfNotPresent"` | Kubernetes imagePullPolicy on Deployment. |
 | image.registry | string | `nil` | Target image registry. Will be prepended to the target image repositry if set. |
 | image.repository | string | `"quay.io/jetstack/trust-manager"` | Target image repository. |
-| image.tag | string | `"v0.7.0-alpha.0"` | Target image version tag. |
+| image.tag | string | `nil` | Target image version tag. Defaults to the chart's appVersion. |
 | imagePullSecrets | list | `[]` | For Private docker registries, authentication is needed. Registry secrets are applied to the service account |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Configure the nodeSelector; defaults to any Linux node (trust-manager doesn't support Windows nodes) |
 | replicaCount | int | `1` | Number of replicas of trust to run. |

--- a/deploy/charts/trust-manager/templates/_helpers.tpl
+++ b/deploy/charts/trust-manager/templates/_helpers.tpl
@@ -25,3 +25,17 @@ app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 {{- end }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 {{- end -}}
+
+{{/*
+Util function for generating the image URL based on the provided options.
+IMPORTANT: This function is standarized across all charts in the cert-manager GH organization.
+Any changes to this function should also be made in cert-manager, trust-manager, approver-policy, ...
+See https://github.com/cert-manager/cert-manager/issues/6329 for a list of linked PRs.
+*/}}
+{{- define "image" -}}
+{{- $defaultTag := index . 1 -}}
+{{- with index . 0 -}}
+{{- if .registry -}}{{ printf "%s/%s" .registry .repository }}{{- else -}}{{- .repository -}}{{- end -}}
+{{- if .digest -}}{{ printf "@%s" .digest }}{{- else -}}{{ printf ":%s" (default $defaultTag .tag) }}{{- end -}}
+{{- end }}
+{{- end }}

--- a/deploy/charts/trust-manager/templates/deployment.yaml
+++ b/deploy/charts/trust-manager/templates/deployment.yaml
@@ -19,7 +19,7 @@ spec:
       {{- if .Values.defaultPackage.enabled }}
       initContainers:
       - name: cert-manager-package-debian
-        image: "{{ .Values.defaultPackageImage.repository }}:{{ .Values.defaultPackageImage.tag }}"
+        image: "{{ template "image" (tuple .Values.defaultPackageImage "missing") }}"
         imagePullPolicy: {{ .Values.defaultPackageImage.pullPolicy }}
         args:
           - "/copyandmaybepause"
@@ -41,9 +41,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ include "trust-manager.name" . }}
-        {{- with .Values.image }}
-        image: "{{- if .registry -}}{{ .registry }}/{{- end -}}{{ .repository }}{{- if (.digest) -}} @{{ .digest }}{{- else -}}:{{ .tag }}{{- end -}}"
-        {{- end }}
+        image: "{{ template "image" (tuple .Values.image $.Chart.AppVersion) }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.app.webhook.port }}

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -10,11 +10,14 @@ image:
   # -- Target image registry. Will be prepended to the target image repositry if set.
   registry:
 
-  # -- Target image version tag.
-  tag: v0.7.0-alpha.0
+  # -- Target image version tag. Defaults to the chart's appVersion.
+  tag:
 
   # -- Target image digest. Will override any tag if set.
+  # for example:
+  # digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
   digest:
+
   # -- Kubernetes imagePullPolicy on Deployment.
   pullPolicy: IfNotPresent
 
@@ -25,8 +28,17 @@ defaultPackage:
 defaultPackageImage:
   # -- Repository for the default package image. This image enables the 'useDefaultCAs' source on Bundles.
   repository: quay.io/jetstack/cert-manager-package-debian
+  # -- Target image registry. Will be prepended to the target image repositry if set.
+  registry:
+
   # -- Tag for the default package image
   tag: "20210119.0"
+
+  # -- Target image digest. Will override any tag if set.
+  # for example:
+  # digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
+  digest:
+
   # -- imagePullPolicy for the default package image
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
I'm standardising the image options across all our charts (https://github.com/cert-manager/cert-manager/issues/6329).