### PR TITLE
Add certificates deduplication feature

### DIFF
--- a/pkg/util/cert_pool.go
+++ b/pkg/util/cert_pool.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+)
+
+// CertPool is a set of certificates.
+type certPool struct {
+	certificatesHashes map[[32]byte]struct{}
+	certificates       []*x509.Certificate
+}
+
+// NewCertPool returns a new, empty CertPool.
+func newCertPool() *certPool {
+	return &certPool{
+		certificatesHashes: make(map[[32]byte]struct{}),
+		certificates:       make([]*x509.Certificate, 0),
+	}
+}
+
+// Check if the given certificate was added to certificates bundle already
+func (cp *certPool) isCertificateDuplicate(certData []byte) bool {
+	// calculate hash sum of the given certificate
+	hash := sha256.Sum256(certData)
+
+	// check a hash existence
+	if _, ok := cp.certificatesHashes[hash]; ok {
+		return ok
+	}
+
+	// put certificate hash into a set of hashes
+	cp.certificatesHashes[hash] = struct{}{}
+
+	return false
+}
+
+// Append certificate to a pool
+func (cp *certPool) appendCertFromPEM(PEMdata []byte) error {
+	if PEMdata == nil {
+		return fmt.Errorf("certificate data can't be nil")
+	}
+
+	for {
+		var block *pem.Block
+		block, PEMdata = pem.Decode(PEMdata)
+
+		if block == nil {
+			break
+		}
+
+		if block.Type != "CERTIFICATE" {
+			// only certificates are allowed in a bundle
+			return fmt.Errorf("invalid PEM block in bundle: only CERTIFICATE blocks are permitted but found '%s'", block.Type)
+		}
+
+		if len(block.Headers) != 0 {
+			return fmt.Errorf("invalid PEM block in bundle; blocks are not permitted to have PEM headers")
+		}
+
+		certificate, err := x509.ParseCertificate(block.Bytes)
+		if err != nil {
+			// the presence of an invalid cert (including things which aren't certs)
+			// should cause the bundle to be rejected
+			return fmt.Errorf("invalid PEM block in bundle; invalid PEM certificate: %w", err)
+		}
+
+		if certificate == nil {
+			return fmt.Errorf("failed appending a certificate: certificate is nil")
+		}
+
+		if !cp.isCertificateDuplicate(block.Bytes) {
+			cp.certificates = append(cp.certificates, certificate)
+		}
+	}
+
+	return nil
+}
+
+// Get PEM certificates from pool
+func (cp *certPool) getCertsPEM() [][]byte {
+	var certsData [][]byte = make([][]byte, len(cp.certificates))
+
+	for i, cert := range cp.certificates {
+		certsData[i] = pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: cert.Raw})
+	}
+
+	return certsData
+}

--- a/pkg/util/cert_pool_test.go
+++ b/pkg/util/cert_pool_test.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2022 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package util
+
+import (
+	"testing"
+
+	"github.com/cert-manager/trust-manager/test/dummy"
+)
+
+func TestNewCertPool(t *testing.T) {
+	certPool := newCertPool()
+
+	if certPool == nil {
+		t.Fatal("pool is nil")
+	}
+}
+
+func TestCertificatesDeduplication(t *testing.T) {
+	// create a pool
+	certPool := newCertPool()
+
+	// list of certificates
+	certificateList := [...]struct {
+		certificateName string
+		certificate     string
+	}{
+		{
+			"TestCertificate3Duplicate", // this certificate is duplicate of TestCertificate3
+			dummy.TestCertificate3Duplicate,
+		},
+		{
+			"TestCertificate1",
+			dummy.TestCertificate1,
+		},
+		{
+			"TestCertificate2",
+			dummy.TestCertificate2,
+		},
+		{
+			"TestCertificate3",
+			dummy.TestCertificate3,
+		},
+		{
+			"TestCertificate5Duplicate", // this certificate is duplicate of TestCertificate5
+			dummy.TestCertificate5Duplicate,
+		},
+		{
+			"TestCertificate4",
+			dummy.TestCertificate4,
+		},
+		{
+			"TestCertificate5",
+			dummy.TestCertificate5,
+		},
+	}
+
+	// certificates bundle structure
+	certificateBundle := []struct {
+		certificateName string
+		certificate     string
+	}{}
+
+	// populate certificates bundle
+	for _, crt := range certificateList {
+		if !certPool.isCertificateDuplicate([]byte(crt.certificate)) {
+			certificateBundle = append(certificateBundle, crt)
+		}
+	}
+
+	// create a new pool
+	newCertPool := newCertPool()
+
+	// check certificates bundle for duplicated certificates
+	for _, crt := range certificateBundle {
+		if newCertPool.isCertificateDuplicate([]byte(crt.certificate)) {
+			t.Errorf("duplicate certificate found %s\n", crt.certificateName)
+		}
+	}
+}
+
+func TestAppendCertFromPEM(t *testing.T) {
+	// list of certificates
+	certificateList := [...]struct {
+		certificateName string
+		certificate     string
+		expectNil       bool
+	}{
+		{
+			"TestCertificate5",
+			dummy.TestCertificate5,
+			false,
+		},
+		{
+			"TestCertificateChain6",
+			dummy.JoinCerts(dummy.TestCertificate1, dummy.TestCertificate2, dummy.TestCertificate3),
+			false,
+		},
+		{
+			// invalid certificate
+			"TestCertificateInvalid7",
+			`-----BEGIN CERTIFICATE-----
+			MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw
+			TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh
+			cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTUwNjA0MTEwNDM4
+			WhcNMzUwNjA0MTEwNDM4WjBPMQswCQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJu
+			ZXQgU2VjdXJpdHkgUmVzZWFyY2ggR3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBY
+			MTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK3oJHP0FDfzm54rVygc
+			h77ct984kIxuPOZXoHj3dcKi/vVqbvYATyjb3miGbESTtrFj/RQSa78f0uoxmyF+
+			0TM8ukj13Xnfs7j/EvEhmkvBioZxaUpmZmyPfjxwv60pIgbz5MDmgK7iS4+3mX6U
+			A5/TR5d8mUgjU+g4rk8Kb4Mu0UlXjIB0ttov0DiNewNwIRt18jA8+o+u3dpjq+sW`,
+			true,
+		},
+		{
+			"TestCertificateInvalid8",
+			"qwerty",
+			true,
+		},
+	}
+
+	// populate certificates bundle
+	for _, crt := range certificateList {
+		certPool := newCertPool()
+
+		if err := certPool.appendCertFromPEM([]byte(crt.certificate)); err != nil {
+			t.Fatalf("error adding PEM certificate into pool %s", err)
+		}
+
+		certPEM := certPool.getCertsPEM()
+		if len(certPEM) != 0 == (crt.expectNil) {
+			t.Fatalf("error getting PEM certificates from pool: certificate data is nil")
+		}
+	}
+}

--- a/pkg/util/pem.go
+++ b/pkg/util/pem.go
@@ -59,38 +59,20 @@ func ValidateAndSanitizePEMBundle(data []byte) ([]byte, error) {
 // ValidateAndSplitPEMBundle takes a PEM bundle as input, validates it and
 // returns the list of certificates as a slice, allowing them to be
 // iterated over.
+// This process involves performs deduplication of certificates to ensure
+// no duplicated certificates in the bundle.
 // For details of the validation performed, see the comment for ValidateAndSanitizePEMBundle
 func ValidateAndSplitPEMBundle(data []byte) ([][]byte, error) {
-	var certificates [][]byte
+	// create a new pool
+	var certPool *certPool = newCertPool()
 
-	for {
-		var b *pem.Block
-		b, data = pem.Decode(data)
-
-		if b == nil {
-			break
-		}
-
-		if b.Type != "CERTIFICATE" {
-			// only certificates are allowed in a bundle
-			return nil, fmt.Errorf("invalid PEM block in bundle: only CERTIFICATE blocks are permitted but found '%s'", b.Type)
-		}
-
-		if len(b.Headers) != 0 {
-			return nil, fmt.Errorf("invalid PEM block in bundle; blocks are not permitted to have PEM headers")
-		}
-
-		_, err := x509.ParseCertificate(b.Bytes)
-		if err != nil {
-			// the presence of an invalid cert (including things which aren't certs)
-			// should cause the bundle to be rejected
-			return nil, fmt.Errorf("invalid PEM block in bundle; invalid PEM certificate: %w", err)
-		}
-
-		certificates = append(certificates, pem.EncodeToMemory(b))
+	// put PEM encoded certificate into a pool
+	err := certPool.appendCertFromPEM(data)
+	if err != nil {
+		return nil, fmt.Errorf("invalid PEM block in bundle; invalid PEM certificate: %w", err)
 	}
 
-	return certificates, nil
+	return certPool.getCertsPEM(), nil
 }
 
 // DecodeX509CertificateChainBytes will decode a PEM encoded x509 Certificate chain.

--- a/test/dummy/certificates.go
+++ b/test/dummy/certificates.go
@@ -290,6 +290,144 @@ Z6tGn6D/Qqc6f1zLXbBwHSs09dR2CQzreExZBfMzQsNhFRAbd03OIozUhfJFfbdT
 2tIMPNuzjsmhDYAPexZ3FL//2wmUspO8IFgV6dtxQ/PeEMMA3KgqlbbC1j+Qa3bb
 bP6MvPJwNQzcmRk13NfIRmPVNnGuV/u3gm3c
 -----END CERTIFICATE-----`
+
+	// DUPLICATE CERTIFICATE
+	// Certificate:
+	//
+	//	Data:
+	//	    Version: 3 (0x2)
+	//	    Serial Number:
+	//	        02:03:e5:93:6f:31:b0:13:49:88:6b:a2:17
+	//	    Signature Algorithm: sha384WithRSAEncryption
+	//	    Issuer: C = US, O = Google Trust Services LLC, CN = GTS Root R1
+	//	    Validity
+	//	        Not Before: Jun 22 00:00:00 2016 GMT
+	//	        Not After : Jun 22 00:00:00 2036 GMT
+	//	    Subject: C = US, O = Google Trust Services LLC, CN = GTS Root R1
+	//	    Subject Public Key Info:
+	//	        Public Key Algorithm: rsaEncryption
+	//	            RSA Public-Key: (4096 bit)
+	//	            Modulus:
+	//	                00:b6:11:02:8b:1e:e3:a1:77:9b:3b:dc:bf:94:3e:
+	//	                <snip>
+	//	                18:05:95
+	//	            Exponent: 65537 (0x10001)
+	//	    X509v3 extensions:
+	//	        X509v3 Key Usage: critical
+	//	            Digital Signature, Certificate Sign, CRL Sign
+	//	        X509v3 Basic Constraints: critical
+	//	            CA:TRUE
+	//	        X509v3 Subject Key Identifier:
+	//	            E4:AF:2B:26:71:1A:2B:48:27:85:2F:52:66:2C:EF:F0:89:13:71:3E
+	//	Signature Algorithm: sha384WithRSAEncryption
+	//	     9f:aa:42:26:db:0b:9b:be:ff:1e:96:92:2e:3e:a2:65:4a:6a:
+	//	     <snip>
+	//	     71:ae:57:fb:b7:82:6d:dc
+	TestCertificate5Duplicate = `-----BEGIN CERTIFICATE-----
+MIIFVzCCAz+gAwIBAgINAgPlk28xsBNJiGuiFzANBgkqhkiG9w0BAQwFADBHMQsw
+CQYDVQQGEwJVUzEiMCAGA1UEChMZR29vZ2xlIFRydXN0IFNlcnZpY2VzIExMQzEU
+MBIGA1UEAxMLR1RTIFJvb3QgUjEwHhcNMTYwNjIyMDAwMDAwWhcNMzYwNjIyMDAw
+MDAwWjBHMQswCQYDVQQGEwJVUzEiMCAGA1UEChMZR29vZ2xlIFRydXN0IFNlcnZp
+Y2VzIExMQzEUMBIGA1UEAxMLR1RTIFJvb3QgUjEwggIiMA0GCSqGSIb3DQEBAQUA
+A4ICDwAwggIKAoICAQC2EQKLHuOhd5s73L+UPreVp0A8of2C+X0yBoJx9vaMf/vo
+27xqLpeXo4xL+Sv2sfnOhB2x+cWX3u+58qPpvBKJXqeqUqv4IyfLpLGcY9vXmX7w
+Cl7raKb0xlpHDU0QM+NOsROjyBhsS+z8CZDfnWQpJSMHobTSPS5g4M/SCYe7zUjw
+TcLCeoiKu7rPWRnWr4+wB7CeMfGCwcDfLqZtbBkOtdh+JhpFAz2weaSUKK0Pfybl
+qAj+lug8aJRT7oM6iCsVlgmy4HqMLnXWnOunVmSPlk9orj2XwoSPwLxAwAtcvfaH
+szVsrBhQf4TgTM2S0yDpM7xSma8ytSmzJSq0SPly4cpk9+aCEI3oncKKiPo4Zor8
+Y/kB+Xj9e1x3+naH+uzfsQ55lVe0vSbv1gHR6xYKu44LtcXFilWr06zqkUspzBmk
+MiVOKvFlRNACzqrOSbTqn3yDsEB750Orp2yjj32JgfpMpf/VjsPOS+C12LOORc92
+wO1AK/1TD7Cn1TsNsYqiA94xrcx36m97PtbfkSIS5r762DL8EGMUUXLeXdYWk70p
+aDPvOmbsB4om3xPXV2V4J95eSRQAogB/mqghtqmxlbCluQ0WEdrHbEg8QOB+DVrN
+VjzRlwW5y0vtOUucxD/SVRNuJLDWcfr0wbrM7Rv1/oFB2ACYPTrIrnqYNxgFlQID
+AQABo0IwQDAOBgNVHQ8BAf8EBAMCAYYwDwYDVR0TAQH/BAUwAwEB/zAdBgNVHQ4E
+FgQU5K8rJnEaK0gnhS9SZizv8IkTcT4wDQYJKoZIhvcNAQEMBQADggIBAJ+qQibb
+C5u+/x6Wki4+omVKapi6Ist9wTrYggoGxval3sBOh2Z5ofmmWJyq+bXmYOfg6LEe
+QkEzCzc9zolwFcq1JKjPa7XSQCGYzyI0zzvFIoTgxQ6KfF2I5DUkzps+GlQebtuy
+h6f88/qBVRRiClmpIgUxPoLW7ttXNLwzldMXG+gnoot7TiYaelpkttGsN/H9oPM4
+7HLwEXWdyzRSjeZ2axfG34arJ45JK3VmgRAhpuo+9K4l/3wV3s6MJT/KYnAK9y8J
+ZgfIPxz88NtFMN9iiMG1D53Dn0reWVlHxYciNuaCp+0KueIHoI17eko8cdLiA6Ef
+MgfdG+RCzgwARWGAtQsgWSl4vflVy2PFPEz0tv/bal8xa5meLMFrUKTX5hgUvYU/
+Z6tGn6D/Qqc6f1zLXbBwHSs09dR2CQzreExZBfMzQsNhFRAbd03OIozUhfJFfbdT
+6u9AWpQKXCBfTkBdYiJ23//OYb2MI3jSNwLgjt7RETeJ9r/tSQdirpLsQBqvFAnZ
+0E6yove+7u7Y/9waLd64NnHi/Hm3lCXRSHNboTXns5lndcEZOitHTtNCjv0xyBZm
+2tIMPNuzjsmhDYAPexZ3FL//2wmUspO8IFgV6dtxQ/PeEMMA3KgqlbbC1j+Qa3bb
+bP6MvPJwNQzcmRk13NfIRmPVNnGuV/u3gm3c
+-----END CERTIFICATE-----`
+
+	// DUPLICATE CERTIFICATE
+	// Certificate:
+	//     Data:
+	//         Version: 3 (0x2)
+	//         Serial Number:
+	//             82:10:cf:b0:d2:40:e3:59:44:63:e0:bb:63:82:8b:00
+	//         Signature Algorithm: sha256WithRSAEncryption
+	//         Issuer: C = US, O = Internet Security Research Group, CN = ISRG Root X1
+	//         Validity
+	//             Not Before: Jun  4 11:04:38 2015 GMT
+	//             Not After : Jun  4 11:04:38 2035 GMT
+	//         Subject: C = US, O = Internet Security Research Group, CN = ISRG Root X1
+	//         Subject Public Key Info:
+	//             Public Key Algorithm: rsaEncryption
+	//                 RSA Public-Key: (4096 bit)
+	//                 Modulus:
+	//                     00:ad:e8:24:73:f4:14:37:f3:9b:9e:2b:57:28:1c:
+	//                     <snip>
+	//                     33:43:4f
+	//                 Exponent: 65537 (0x10001)
+	//         X509v3 extensions:
+	//             X509v3 Key Usage: critical
+	//                 Certificate Sign, CRL Sign
+	//             X509v3 Basic Constraints: critical
+	//                 CA:TRUE
+	//             X509v3 Subject Key Identifier:
+	//                 79:B4:59:E6:7B:B6:E5:E4:01:73:80:08:88:C8:1A:58:F6:E9:9B:6E
+	//     Signature Algorithm: sha256WithRSAEncryption
+	//          55:1f:58:a9:bc:b2:a8:50:d0:0c:b1:d8:1a:69:20:27:29:08:
+	//          <snip>
+	//          9d:7e:62:22:da:de:18:27
+	TestCertificate3Duplicate = `-----BEGIN CERTIFICATE-----
+MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw
+TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh
+cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTUwNjA0MTEwNDM4
+WhcNMzUwNjA0MTEwNDM4WjBPMQswCQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJu
+ZXQgU2VjdXJpdHkgUmVzZWFyY2ggR3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBY
+MTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK3oJHP0FDfzm54rVygc
+h77ct984kIxuPOZXoHj3dcKi/vVqbvYATyjb3miGbESTtrFj/RQSa78f0uoxmyF+
+0TM8ukj13Xnfs7j/EvEhmkvBioZxaUpmZmyPfjxwv60pIgbz5MDmgK7iS4+3mX6U
+A5/TR5d8mUgjU+g4rk8Kb4Mu0UlXjIB0ttov0DiNewNwIRt18jA8+o+u3dpjq+sW
+T8KOEUt+zwvo/7V3LvSye0rgTBIlDHCNAymg4VMk7BPZ7hm/ELNKjD+Jo2FR3qyH
+B5T0Y3HsLuJvW5iB4YlcNHlsdu87kGJ55tukmi8mxdAQ4Q7e2RCOFvu396j3x+UC
+B5iPNgiV5+I3lg02dZ77DnKxHZu8A/lJBdiB3QW0KtZB6awBdpUKD9jf1b0SHzUv
+KBds0pjBqAlkd25HN7rOrFleaJ1/ctaJxQZBKT5ZPt0m9STJEadao0xAH0ahmbWn
+OlFuhjuefXKnEgV4We0+UXgVCwOPjdAvBbI+e0ocS3MFEvzG6uBQE3xDk3SzynTn
+jh8BCNAw1FtxNrQHusEwMFxIt4I7mKZ9YIqioymCzLq9gwQbooMDQaHWBfEbwrbw
+qHyGO0aoSCqI3Haadr8faqU9GY/rOPNk3sgrDQoo//fb4hVC1CLQJ13hef4Y53CI
+rU7m2Ys6xt0nUW7/vGT1M0NPAgMBAAGjQjBAMA4GA1UdDwEB/wQEAwIBBjAPBgNV
+HRMBAf8EBTADAQH/MB0GA1UdDgQWBBR5tFnme7bl5AFzgAiIyBpY9umbbjANBgkq
+hkiG9w0BAQsFAAOCAgEAVR9YqbyyqFDQDLHYGmkgJykIrGF1XIpu+ILlaS/V9lZL
+ubhzEFnTIZd+50xx+7LSYK05qAvqFyFWhfFQDlnrzuBZ6brJFe+GnY+EgPbk6ZGQ
+3BebYhtF8GaV0nxvwuo77x/Py9auJ/GpsMiu/X1+mvoiBOv/2X/qkSsisRcOj/KK
+NFtY2PwByVS5uCbMiogziUwthDyC3+6WVwW6LLv3xLfHTjuCvjHIInNzktHCgKQ5
+ORAzI4JMPJ+GslWYHb4phowim57iaztXOoJwTdwJx4nLCgdNbOhdjsnvzqvHu7Ur
+TkXWStAmzOVyyghqpZXjFaH3pO3JLF+l+/+sKAIuvtd7u+Nxe5AW0wdeRlN8NwdC
+jNPElpzVmbUq4JUagEiuTDkHzsxHpFKVK7q4+63SM1N95R1NbdWhscdCb+ZAJzVc
+oyi3B43njTOQ5yOf+1CceWxG1bQVs5ZufpsMljq4Ui0/1lvh+wjChP4kqKOJ2qxq
+4RgqsahDYVvTH9w7jXbyLeiNdd8XM2w9U/t7y0Ff/9yi0GE44Za4rF2LN9d11TPA
+mRGunUHBcnWEvgJBQl9nJEiU0Zsnvgc/ubhPgXRR4Xq37Z0j4r7g1SgEEzwxA57d
+emyPxgcYxn/eR44/KJ4EBs+lVDR3veyJm+kXQ99b21/+jh5Xos1AnX5iItreGCc=
+-----END CERTIFICATE-----`
+	// Invalid certificate
+	TestCertificateInvalid7 = `-----BEGIN CERTIFICATE-----
+MIIFazCCA1OgAwIBAgIRAIIQz7DSQONZRGPgu2OCiwAwDQYJKoZIhvcNAQELBQAw
+TzELMAkGA1UEBhMCVVMxKTAnBgNVBAoTIEludGVybmV0IFNlY3VyaXR5IFJlc2Vh
+cmNoIEdyb3VwMRUwEwYDVQQDEwxJU1JHIFJvb3QgWDEwHhcNMTUwNjA0MTEwNDM4
+WhcNMzUwNjA0MTEwNDM4WjBPMQswCQYDVQQGEwJVUzEpMCcGA1UEChMgSW50ZXJu
+ZXQgU2VjdXJpdHkgUmVzZWFyY2ggR3JvdXAxFTATBgNVBAMTDElTUkcgUm9vdCBY
+MTCCAiIwDQYJKoZIhvcNAQEBBQADggIPADCCAgoCggIBAK3oJHP0FDfzm54rVygc
+h77ct984kIxuPOZXoHj3dcKi/vVqbvYATyjb3miGbESTtrFj/RQSa78f0uoxmyF+
+0TM8ukj13Xnfs7j/EvEhmkvBioZxaUpmZmyPfjxwv60pIgbz5MDmgK7iS4+3mX6U
+A5/TR5d8mUgjU+g4rk8Kb4Mu0UlXjIB0ttov0DiNewNwIRt18jA8+o+u3dpjq+sW`
 )
 
 func DefaultJoinedCerts() string {


### PR DESCRIPTION
This PR is related to the issue `de-duplicate CA from the trust bundle` #155 
It add feature of certificates de-duplication, meaning to exclude certificates which were already added to a certificates bundle, thus save memory. 