### PR TITLE
Eliminate dedicated ConfigMap target cache

### DIFF
--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -64,10 +64,6 @@ type bundle struct {
 	// a direct Kubernetes client (only used for CSA to CSA migration)
 	directClient client.Client
 
-	// targetCache is a cache.Cache that holds cached ConfigMap
-	// resources that are used as targets for Bundles.
-	targetCache client.Reader
-
 	// defaultPackage holds the loaded 'default' certificate package, if one was specified
 	// at startup.
 	defaultPackage *fspkg.Package
@@ -211,7 +207,7 @@ func (b *bundle) reconcileBundle(ctx context.Context, req ctrl.Request) (result 
 				Kind:       "ConfigMap",
 			},
 		}
-		err := b.targetCache.List(ctx, configMapList, &client.ListOptions{
+		err := b.client.List(ctx, configMapList, &client.ListOptions{
 			LabelSelector: labels.SelectorFromSet(map[string]string{
 				trustapi.BundleLabelKey: bundle.Name,
 			}),

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -1020,10 +1020,9 @@ func Test_Reconcile(t *testing.T) {
 			)
 
 			b := &bundle{
-				client:      fakeclient,
-				targetCache: fakeclient,
-				recorder:    fakerecorder,
-				clock:       fixedclock,
+				client:   fakeclient,
+				recorder: fakerecorder,
+				clock:    fixedclock,
 				Options: Options{
 					Log:       klogr.New(),
 					Namespace: trustNamespace,

--- a/pkg/bundle/sync.go
+++ b/pkg/bundle/sync.go
@@ -281,7 +281,7 @@ func (b *bundle) syncTarget(
 			APIVersion: "v1",
 		},
 	}
-	err := b.targetCache.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, configMap)
+	err := b.client.Get(ctx, client.ObjectKey{Namespace: namespace, Name: name}, configMap)
 	if err != nil && !apierrors.IsNotFound(err) {
 		return false, fmt.Errorf("failed to get ConfigMap %s/%s: %w", namespace, name, err)
 	}

--- a/pkg/bundle/sync_test.go
+++ b/pkg/bundle/sync_test.go
@@ -599,9 +599,8 @@ func Test_syncTarget(t *testing.T) {
 			)
 
 			b := &bundle{
-				client:      fakeclient,
-				targetCache: fakeclient,
-				recorder:    fakerecorder,
+				client:   fakeclient,
+				recorder: fakerecorder,
 				patchResourceOverwrite: func(ctx context.Context, obj interface{}) error {
 					logMutex.Lock()
 					defer logMutex.Unlock()

--- a/test/integration/bundle/suite.go
+++ b/test/integration/bundle/suite.go
@@ -111,7 +111,7 @@ var _ = Describe("Integration", func() {
 
 		mgrStopped = make(chan struct{})
 
-		Expect(bundle.AddBundleController(ctx, mgr, opts, mgr.GetCache())).NotTo(HaveOccurred())
+		Expect(bundle.AddBundleController(ctx, mgr, opts)).NotTo(HaveOccurred())
 
 		By("Running Bundle controller")
 		go func() {


### PR DESCRIPTION
This PR eliminates the dedicated target cache and fixes the TODO related to source/target ConfigMap caches. Now the cache should only cache full configmaps in source namespace and cache configmap metadata cluster-wide.

I wished to simplify this a bit before anyone tries to add secrets as targets.

I am pretty sure that ConfigMap and PartialMetadata (for configmaps) should be treated independently in caches now. But feel free to check this @inteon - if you think the tests are not covering this area well enough. I asked about this in controller-runtime channel on Slack: https://kubernetes.slack.com/archives/C02MRBMN00Z/p1695564370173869. And also had a look at https://github.com/kubernetes-sigs/controller-runtime/pull/1174. So if this isn't working as expected, I think we should create an issue in controller-runtime.

/cc @inteon 