### PR TITLE
Fix SSA migration field managers

### DIFF
--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -339,7 +339,9 @@ func (b *bundle) migrateBundleStatusToApply(ctx context.Context, obj client.Obje
 	// subresource. We need to check for this as we need to migrate the entry to the new
 	// fieldManager.
 	isOldBundleStatusManagedFieldsEntry := func(mf *metav1.ManagedFieldsEntry) bool {
-		return mf.Manager == oldFieldManager && mf.Operation == metav1.ManagedFieldsOperationUpdate && mf.Subresource == "status"
+		return (mf.Manager == fieldManager || mf.Manager == crRegressionFieldManager) &&
+			mf.Operation == metav1.ManagedFieldsOperationUpdate &&
+			mf.Subresource == "status"
 	}
 
 	needsUpdate := false


### PR DESCRIPTION
This PR adapts the SSA migration code to the controller-runtime regression introduced in c/r version 0.15.0 and fixed by https://github.com/kubernetes-sigs/controller-runtime/pull/2435.

/cc @inteon 