### PR TITLE
fix: add missing RBAC for CSA->SSA migration of bundles/status

### DIFF
--- a/deploy/charts/trust-manager/templates/clusterrole.yaml
+++ b/deploy/charts/trust-manager/templates/clusterrole.yaml
@@ -23,7 +23,8 @@ rules:
   - "trust.cert-manager.io"
   resources:
   - "bundles/status"
-  verbs: ["patch"]
+  # We also need update here so we can perform migrations from old CSA to SSA.
+  verbs: ["update", "patch"]
 
 - apiGroups:
   - ""


### PR DESCRIPTION
When verifying v0.7.0-alpha.1 in our clusters, I notice the following error:

````
E1006 16:12:20.394650       1 bundle.go:134] trust/bundle "msg"="failed to migrate bundle status" "error"="bundles.trust.cert-manager.io \"my-bundle\" is forbidden: User \"system:serviceaccount:cert-manager:trust-manager\" cannot update resource \"bundles\" in API group \"trust.cert-manager.io\" at the cluster scope" "bundle"="my-bundle"
````

I believe this patch should fix this.

/cc @inteon 