### PR TITLE
feat: support secret as a target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -177,7 +177,12 @@ ensure-cert-manager: ensure-kind $(BINDIR)/kubeconfig.yaml | $(BINDIR)/helm-$(HE
 .PHONY: ensure-trust-manager
 ensure-trust-manager: ensure-kind kind-load ensure-cert-manager | $(BINDIR)/helm-$(HELM_VERSION)/helm  ## ensure trust-manager is available on cluster, built from local checkout
 	$(BINDIR)/helm-$(HELM_VERSION)/helm uninstall --kubeconfig $(BINDIR)/kubeconfig.yaml -n cert-manager trust-manager || :
-	$(BINDIR)/helm-$(HELM_VERSION)/helm upgrade --kubeconfig $(BINDIR)/kubeconfig.yaml -i -n cert-manager trust-manager deploy/charts/trust-manager/. --set image.tag=latest --set defaultTrustPackage.tag=latest$(DEBIAN_TRUST_PACKAGE_SUFFIX) --set app.logLevel=2 --wait
+	$(BINDIR)/helm-$(HELM_VERSION)/helm upgrade --kubeconfig $(BINDIR)/kubeconfig.yaml -i -n cert-manager trust-manager deploy/charts/trust-manager/. \
+		--set image.tag=latest \
+		--set defaultTrustPackage.tag=latest$(DEBIAN_TRUST_PACKAGE_SUFFIX) \
+		--set app.logLevel=2 \
+		--set secretTargets.enabled=true --set secretTargets.authorizedSecretsAll=true \
+		--wait
 
 # When running in our CI environment the Docker network's subnet choice
 # causees issues with routing.

--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -58,5 +58,8 @@ Kubernetes: `>= 1.25.0-0`
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Configure the nodeSelector; defaults to any Linux node (trust-manager doesn't support Windows nodes) |
 | replicaCount | int | `1` | Number of replicas of trust-manager to run. |
 | resources | object | `{}` |  |
+| secretTargets.authorizedSecrets | list | `[]` | A list of secret names which trust-manager will be permitted to read and write across all namespaces.     These will be the only allowable Secrets that can be used as targets.     If the list is empty, trust-manager will not be able to write to secrets and will only be able to    read secrets in the trust namespace for use as sources. |
+| secretTargets.authorizedSecretsAll | bool | `false` | If set to true, grant read/write permission to all secrets across the cluster. Use with caution!    When set, ignores authorizedSecrets list setting. |
+| secretTargets.enabled | bool | `false` | If set to true, enable writing trust bundles to Kubernetes Secrets as a target.    trust-manager can only write to secrets which are explicitly allowed.    - see either authorizedSecrets or authorizedSecretsAll. |
 | tolerations | list | `[]` | List of Kubernetes Tolerations; see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core |
 | topologySpreadConstraints | list | `[]` | List of Kubernetes TopologySpreadConstraints; see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#topologyspreadconstraint-v1-core |

--- a/deploy/charts/trust-manager/templates/clusterrole.yaml
+++ b/deploy/charts/trust-manager/templates/clusterrole.yaml
@@ -43,3 +43,25 @@ rules:
   resources:
   - "events"
   verbs: ["create", "patch"]
+
+- apiGroups:
+  - ""
+  resources:
+  - "secrets"
+  verbs: ["create", "list", "watch"]
+{{- if .Values.secretTargets.enabled }}
+{{- if .Values.secretTargets.authorizedSecretsAll }}
+- apiGroups:
+  - ""
+  resources:
+  - "secrets"
+  verbs: ["get", "update", "delete", "patch"]
+{{- else if .Values.secretTargets.authorizedSecrets }}
+- apiGroups:
+  - ""
+  resources:
+  - "secrets"
+  verbs: ["get", "update", "delete", "patch"]
+  resourceNames: {{ .Values.secretTargets.authorizedSecrets | toYaml | nindent 2 }}
+{{- end -}}
+{{- end -}}

--- a/deploy/charts/trust-manager/templates/trust.cert-manager.io_bundles.yaml
+++ b/deploy/charts/trust-manager/templates/trust.cert-manager.io_bundles.yaml
@@ -136,6 +136,15 @@ spec:
                           type: object
                           additionalProperties:
                             type: string
+                    secret:
+                      description: Secret is the target Secret that all Bundle source data will be synced to. Using Secrets as targets is only supported if enabled at trust-manager startup. By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.
+                      type: object
+                      required:
+                        - key
+                      properties:
+                        key:
+                          description: Key is the key of the entry in the object's `data` field to be used.
+                          type: string
             status:
               description: Status of the Bundle. This is set and managed automatically.
               type: object
@@ -220,6 +229,15 @@ spec:
                           type: object
                           additionalProperties:
                             type: string
+                    secret:
+                      description: Secret is the target Secret that all Bundle source data will be synced to. Using Secrets as targets is only supported if enabled at trust-manager startup. By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.
+                      type: object
+                      required:
+                        - key
+                      properties:
+                        key:
+                          description: Key is the key of the entry in the object's `data` field to be used.
+                          type: string
       served: true
       storage: true
       subresources:

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -101,6 +101,20 @@ app:
     # -- If false, disables the default seccomp profile, which might be required to run on certain platforms
     seccompProfileEnabled: true
 
+secretTargets:
+  # -- If set to true, enable writing trust bundles to Kubernetes Secrets as a target.
+  #    trust-manager can only write to secrets which are explicitly allowed.
+  #    - see either authorizedSecrets or authorizedSecretsAll.
+  enabled: false
+  # -- If set to true, grant read/write permission to all secrets across the cluster. Use with caution!
+  #    When set, ignores authorizedSecrets list setting.
+  authorizedSecretsAll: false
+  # -- A list of secret names which trust-manager will be permitted to read and write across all namespaces. 
+  #    These will be the only allowable Secrets that can be used as targets. 
+  #    If the list is empty, trust-manager will not be able to write to secrets and will only be able to
+  #    read secrets in the trust namespace for use as sources.
+  authorizedSecrets: []
+
 resources: {}
   # -- Kubernetes pod resource limits for trust.
   # limits:

--- a/deploy/crds/trust.cert-manager.io_bundles.yaml
+++ b/deploy/crds/trust.cert-manager.io_bundles.yaml
@@ -135,6 +135,15 @@ spec:
                           type: object
                           additionalProperties:
                             type: string
+                    secret:
+                      description: Secret is the target Secret that all Bundle source data will be synced to. Using Secrets as targets is only supported if enabled at trust-manager startup. By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.
+                      type: object
+                      required:
+                        - key
+                      properties:
+                        key:
+                          description: Key is the key of the entry in the object's `data` field to be used.
+                          type: string
             status:
               description: Status of the Bundle. This is set and managed automatically.
               type: object
@@ -219,6 +228,15 @@ spec:
                           type: object
                           additionalProperties:
                             type: string
+                    secret:
+                      description: Secret is the target Secret that all Bundle source data will be synced to. Using Secrets as targets is only supported if enabled at trust-manager startup. By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.
+                      type: object
+                      required:
+                        - key
+                      properties:
+                        key:
+                          description: Key is the key of the entry in the object's `data` field to be used.
+                          type: string
       served: true
       storage: true
       subresources:

--- a/pkg/apis/trust/v1alpha1/types_bundle.go
+++ b/pkg/apis/trust/v1alpha1/types_bundle.go
@@ -98,6 +98,11 @@ type BundleTarget struct {
 	// data will be synced to.
 	ConfigMap *KeySelector `json:"configMap,omitempty"`
 
+	// Secret is the target Secret that all Bundle source data will be synced to.
+	// Using Secrets as targets is only supported if enabled at trust-manager startup.
+	// By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.
+	Secret *KeySelector `json:"secret,omitempty"`
+
 	// AdditionalFormats specifies any additional formats to write to the target
 	// +optional
 	AdditionalFormats *AdditionalFormats `json:"additionalFormats,omitempty"`

--- a/pkg/apis/trust/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/trust/v1alpha1/zz_generated.deepcopy.go
@@ -225,6 +225,11 @@ func (in *BundleTarget) DeepCopyInto(out *BundleTarget) {
 		*out = new(KeySelector)
 		**out = **in
 	}
+	if in.Secret != nil {
+		in, out := &in.Secret, &out.Secret
+		*out = new(KeySelector)
+		**out = **in
+	}
 	if in.AdditionalFormats != nil {
 		in, out := &in.AdditionalFormats, &out.AdditionalFormats
 		*out = new(AdditionalFormats)

--- a/pkg/bundle/controller.go
+++ b/pkg/bundle/controller.go
@@ -98,6 +98,19 @@ func AddBundleController(
 			builder.OnlyMetadata,
 		).
 
+		// Reconcile a Bundle on events against a Secret that it
+		// owns. Only cache Secret metadata.
+		WatchesRawSource(
+			source.Kind(targetCache, &corev1.Secret{}),
+			handler.EnqueueRequestForOwner(
+				mgr.GetScheme(),
+				mgr.GetRESTMapper(),
+				&trustapi.Bundle{},
+				handler.OnlyControllerOwner(),
+			),
+			builder.OnlyMetadata,
+		).
+
 		////// Sources //////
 
 		// Reconcile trust.cert-manager.io Bundles

--- a/pkg/bundle/internal/ssa_client/configmap.go
+++ b/pkg/bundle/internal/ssa_client/configmap.go
@@ -47,3 +47,26 @@ func GenerateConfigMapPatch(
 
 	return configmap, applyPatch{encodedPatch}, nil
 }
+
+func GenerateSecretPatch(
+	secretPatch *coreapplyconfig.SecretApplyConfiguration,
+) (*corev1.Secret, client.Patch, error) {
+	if secretPatch == nil || secretPatch.Name == nil || secretPatch.Namespace == nil {
+		panic("secretPatch must be non-nil and have a name and namespace")
+	}
+
+	// This object is used to deduce the name & namespace + unmarshall the return value in
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      *secretPatch.Name,
+			Namespace: *secretPatch.Namespace,
+		},
+	}
+
+	encodedPatch, err := json.Marshal(secretPatch)
+	if err != nil {
+		return secret, nil, err
+	}
+
+	return secret, applyPatch{encodedPatch}, nil
+}

--- a/test/integration/bundle/suite.go
+++ b/test/integration/bundle/suite.go
@@ -129,7 +129,7 @@ var _ = Describe("Integration", func() {
 
 		By("Creating Bundle for test")
 		testData = testenv.DefaultTrustData()
-		testBundle = testenv.NewTestBundle(ctx, cl, opts, testData)
+		testBundle = testenv.NewTestBundleConfigMapTarget(ctx, cl, opts, testData)
 
 		testenv.EventuallyBundleHasSyncedAllNamespaces(ctx, cl, testBundle.Name, dummy.DefaultJoinedCerts())
 

--- a/test/smoke/suite_test.go
+++ b/test/smoke/suite_test.go
@@ -41,7 +41,7 @@ const (
 )
 
 var _ = Describe("Smoke", func() {
-	It("should create a bundle, sync to target, and then remove all when deleted", func() {
+	It("should create a bundle, sync to ConfigMap target, and then remove all configmap targets when deleted", func() {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
@@ -53,7 +53,7 @@ var _ = Describe("Smoke", func() {
 		By("Creating Bundle for test")
 		testData := env.DefaultTrustData()
 
-		testBundle := env.NewTestBundle(ctx, cl, bundle.Options{
+		testBundle := env.NewTestBundleConfigMapTarget(ctx, cl, bundle.Options{
 			Log:       klogr.New(),
 			Namespace: cnf.TrustNamespace,
 		}, testData)
@@ -61,99 +61,136 @@ var _ = Describe("Smoke", func() {
 		By("Ensuring the Bundle has Synced")
 		env.EventuallyBundleHasSyncedAllNamespaces(ctx, cl, testBundle.Name, dummy.DefaultJoinedCerts())
 
-		By("Ensuring targets update when a ConfigMap source is updated")
-		var configMap corev1.ConfigMap
+		testBundleCommon(ctx, cl, testBundle)
+	})
 
-		Expect(cl.Get(ctx, client.ObjectKey{Namespace: cnf.TrustNamespace, Name: testBundle.Spec.Sources[0].ConfigMap.Name}, &configMap)).NotTo(HaveOccurred())
+	It("should create a bundle, sync to Secret target, and then remove all secret targets when deleted", func() {
+		ctx, cancel := context.WithCancel(context.Background())
+		defer cancel()
 
-		configMap.Data[testData.Sources.ConfigMap.Key] = dummy.TestCertificate4
+		cl, err := client.New(cnf.RestConfig, client.Options{
+			Scheme: trustapi.GlobalScheme,
+		})
+		Expect(err).NotTo(HaveOccurred())
 
-		Expect(cl.Update(ctx, &configMap)).NotTo(HaveOccurred())
+		By("Creating Bundle for test")
+		testData := env.DefaultTrustData()
 
-		env.EventuallyBundleHasSyncedAllNamespaces(ctx, cl, testBundle.Name, dummy.JoinCerts(dummy.TestCertificate4, dummy.TestCertificate2, dummy.TestCertificate3))
+		testBundle := env.NewTestBundleSecretTarget(ctx, cl, bundle.Options{
+			Log:       klogr.New(),
+			Namespace: cnf.TrustNamespace,
+		}, testData)
 
-		By("Ensuring targets update when a Secret source is updated")
-		var secret corev1.Secret
+		By("Ensuring the Bundle has Synced")
+		env.EventuallyBundleHasSyncedAllNamespaces(ctx, cl, testBundle.Name, dummy.DefaultJoinedCerts())
 
-		Expect(cl.Get(ctx, client.ObjectKey{Namespace: cnf.TrustNamespace, Name: testBundle.Spec.Sources[1].Secret.Name}, &secret)).NotTo(HaveOccurred())
-
-		secret.Data[testData.Sources.Secret.Key] = []byte(dummy.TestCertificate1)
-
-		Expect(cl.Update(ctx, &secret)).NotTo(HaveOccurred())
-
-		env.EventuallyBundleHasSyncedAllNamespaces(ctx, cl, testBundle.Name, dummy.JoinCerts(dummy.TestCertificate4, dummy.TestCertificate1, dummy.TestCertificate3))
-
-		By("Ensuring targets update when an InLine source is updated")
-		Expect(cl.Get(ctx, client.ObjectKey{Name: testBundle.Name}, testBundle)).NotTo(HaveOccurred())
-
-		testBundle.Spec.Sources[2].InLine = ptr.To(dummy.TestCertificate2)
-
-		Expect(cl.Update(ctx, testBundle)).NotTo(HaveOccurred())
-
-		newBundle := dummy.JoinCerts(dummy.TestCertificate4, dummy.TestCertificate1, dummy.TestCertificate2)
-
-		env.EventuallyBundleHasSyncedAllNamespaces(ctx, cl, testBundle.Name, newBundle)
-
-		By("Ensuring targets update when default CAs are requested")
-		Expect(cl.Get(ctx, client.ObjectKey{Name: testBundle.Name}, testBundle)).NotTo(HaveOccurred())
-
-		testBundle.Spec.Sources = append(testBundle.Spec.Sources, trustapi.BundleSource{UseDefaultCAs: ptr.To(true)})
-
-		Expect(cl.Update(ctx, testBundle)).NotTo(HaveOccurred())
-
-		env.EventuallyBundleHasSyncedAllNamespacesStartsWith(ctx, cl, testBundle.Name, newBundle)
-
-		By("Ensuring targets update when a Namespace is created")
-		testNamespace := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "trust-test-smoke-random-namespace-"}}
-
-		Expect(cl.Create(ctx, &testNamespace)).NotTo(HaveOccurred())
-
-		env.EventuallyBundleHasSyncedToNamespaceStartsWith(ctx, cl, testBundle.Name, testNamespace.Name, newBundle)
-
-		By("Setting Namespace Selector should remove ConfigMaps from Namespaces that do not have a match")
-		Expect(cl.Get(ctx, client.ObjectKey{Name: testBundle.Name}, testBundle)).NotTo(HaveOccurred())
-
-		testBundle.Spec.Target.NamespaceSelector = &trustapi.NamespaceSelector{
-			MatchLabels: map[string]string{"foo": "bar"},
-		}
-		Expect(cl.Update(ctx, testBundle)).NotTo(HaveOccurred())
-
-		Eventually(func() bool {
-			var cm corev1.ConfigMap
-
-			err := cl.Get(ctx, client.ObjectKey{Namespace: testNamespace.Name, Name: testBundle.Name}, &cm)
-			return apierrors.IsNotFound(err)
-		}, eventuallyTimeout, eventualyPollInterval).Should(BeTrue(), "checking that namespace selector resulted in non-matching namespaces having ConfigMap removed")
-
-		By("Adding matching label on Namespace should sync ConfigMap to namespace")
-		Expect(cl.Get(ctx, client.ObjectKey{Name: testNamespace.Name}, &testNamespace)).NotTo(HaveOccurred())
-
-		testNamespace.Labels["foo"] = "bar"
-
-		Expect(cl.Update(ctx, &testNamespace)).NotTo(HaveOccurred())
-
-		env.EventuallyBundleHasSyncedToNamespaceStartsWith(ctx, cl, testBundle.Name, testNamespace.Name, newBundle)
-
-		By("Deleting test Namespace")
-		Expect(cl.Delete(ctx, &testNamespace)).NotTo(HaveOccurred())
-
-		By("Deleting the created Bundle")
-		Expect(cl.Get(ctx, client.ObjectKeyFromObject(testBundle), testBundle)).ToNot(HaveOccurred())
-
-		Expect(cl.Delete(ctx, testBundle)).NotTo(HaveOccurred())
-
-		Expect(cl.Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: cnf.TrustNamespace, Name: testBundle.Spec.Sources[0].ConfigMap.Name}})).NotTo(HaveOccurred())
-
-		Expect(cl.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: cnf.TrustNamespace, Name: testBundle.Spec.Sources[1].Secret.Name}})).NotTo(HaveOccurred())
-
-		By("Ensuring all targets have been deleted")
-		var namespaceList corev1.NamespaceList
-		Expect(cl.List(ctx, &namespaceList)).ToNot(HaveOccurred())
-
-		for _, namespace := range namespaceList.Items {
-			Eventually(func() error {
-				return cl.Get(ctx, client.ObjectKey{Namespace: namespace.Name, Name: testBundle.Name}, new(corev1.ConfigMap))
-			}, eventuallyTimeout, eventualyPollInterval).ShouldNot(BeNil())
-		}
+		testBundleCommon(ctx, cl, testBundle)
 	})
 })
+
+func testBundleCommon(ctx context.Context, cl client.Client, testBundle *trustapi.Bundle) {
+	testData := env.DefaultTrustData()
+	By("Ensuring targets update when a ConfigMap source is updated")
+	var configMap corev1.ConfigMap
+
+	Expect(cl.Get(ctx, client.ObjectKey{Namespace: cnf.TrustNamespace, Name: testBundle.Spec.Sources[0].ConfigMap.Name}, &configMap)).NotTo(HaveOccurred())
+
+	configMap.Data[testData.Sources.ConfigMap.Key] = dummy.TestCertificate4
+
+	Expect(cl.Update(ctx, &configMap)).NotTo(HaveOccurred())
+
+	env.EventuallyBundleHasSyncedAllNamespaces(ctx, cl, testBundle.Name, dummy.JoinCerts(dummy.TestCertificate4, dummy.TestCertificate2, dummy.TestCertificate3))
+
+	By("Ensuring targets update when a Secret source is updated")
+	var secret corev1.Secret
+
+	Expect(cl.Get(ctx, client.ObjectKey{Namespace: cnf.TrustNamespace, Name: testBundle.Spec.Sources[1].Secret.Name}, &secret)).NotTo(HaveOccurred())
+
+	secret.Data[testData.Sources.Secret.Key] = []byte(dummy.TestCertificate1)
+
+	Expect(cl.Update(ctx, &secret)).NotTo(HaveOccurred())
+
+	env.EventuallyBundleHasSyncedAllNamespaces(ctx, cl, testBundle.Name, dummy.JoinCerts(dummy.TestCertificate4, dummy.TestCertificate1, dummy.TestCertificate3))
+
+	By("Ensuring targets update when an InLine source is updated")
+	Expect(cl.Get(ctx, client.ObjectKey{Name: testBundle.Name}, testBundle)).NotTo(HaveOccurred())
+
+	testBundle.Spec.Sources[2].InLine = ptr.To(dummy.TestCertificate2)
+
+	Expect(cl.Update(ctx, testBundle)).NotTo(HaveOccurred())
+
+	newBundle := dummy.JoinCerts(dummy.TestCertificate4, dummy.TestCertificate1, dummy.TestCertificate2)
+
+	env.EventuallyBundleHasSyncedAllNamespaces(ctx, cl, testBundle.Name, newBundle)
+
+	By("Ensuring targets update when default CAs are requested")
+	Expect(cl.Get(ctx, client.ObjectKey{Name: testBundle.Name}, testBundle)).NotTo(HaveOccurred())
+
+	testBundle.Spec.Sources = append(testBundle.Spec.Sources, trustapi.BundleSource{UseDefaultCAs: ptr.To(true)})
+
+	Expect(cl.Update(ctx, testBundle)).NotTo(HaveOccurred())
+
+	env.EventuallyBundleHasSyncedAllNamespacesStartsWith(ctx, cl, testBundle.Name, newBundle)
+
+	By("Ensuring targets update when a Namespace is created")
+	testNamespace := corev1.Namespace{ObjectMeta: metav1.ObjectMeta{GenerateName: "trust-test-smoke-random-namespace-"}}
+
+	Expect(cl.Create(ctx, &testNamespace)).NotTo(HaveOccurred())
+
+	env.EventuallyBundleHasSyncedToNamespaceStartsWith(ctx, cl, testBundle.Name, testNamespace.Name, newBundle)
+
+	By("Setting Namespace Selector should remove Secrets from Namespaces that do not have a match")
+	Expect(cl.Get(ctx, client.ObjectKey{Name: testBundle.Name}, testBundle)).NotTo(HaveOccurred())
+
+	testBundle.Spec.Target.NamespaceSelector = &trustapi.NamespaceSelector{
+		MatchLabels: map[string]string{"foo": "bar"},
+	}
+	Expect(cl.Update(ctx, testBundle)).NotTo(HaveOccurred())
+
+	Eventually(func() bool {
+		var err error
+		if testBundle.Spec.Target.Secret != nil {
+			var secret corev1.Secret
+			err = cl.Get(ctx, client.ObjectKey{Namespace: testNamespace.Name, Name: testBundle.Name}, &secret)
+		} else if testBundle.Spec.Target.ConfigMap != nil {
+			var cm corev1.ConfigMap
+			err = cl.Get(ctx, client.ObjectKey{Namespace: testNamespace.Name, Name: testBundle.Name}, &cm)
+		}
+		return apierrors.IsNotFound(err)
+	}, eventuallyTimeout, eventualyPollInterval).Should(BeTrue(), "checking that namespace selector resulted in non-matching namespaces having Secret/ConfigMap removed")
+
+	By("Adding matching label on Namespace should sync ConfigMap/Secret to namespace")
+	Expect(cl.Get(ctx, client.ObjectKey{Name: testNamespace.Name}, &testNamespace)).NotTo(HaveOccurred())
+
+	testNamespace.Labels["foo"] = "bar"
+
+	Expect(cl.Update(ctx, &testNamespace)).NotTo(HaveOccurred())
+
+	env.EventuallyBundleHasSyncedToNamespaceStartsWith(ctx, cl, testBundle.Name, testNamespace.Name, newBundle)
+
+	By("Deleting test Namespace")
+	Expect(cl.Delete(ctx, &testNamespace)).NotTo(HaveOccurred())
+
+	By("Deleting the created Bundle")
+	Expect(cl.Get(ctx, client.ObjectKeyFromObject(testBundle), testBundle)).ToNot(HaveOccurred())
+
+	Expect(cl.Delete(ctx, testBundle)).NotTo(HaveOccurred())
+
+	Expect(cl.Delete(ctx, &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: cnf.TrustNamespace, Name: testBundle.Spec.Sources[0].ConfigMap.Name}})).NotTo(HaveOccurred())
+
+	Expect(cl.Delete(ctx, &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: cnf.TrustNamespace, Name: testBundle.Spec.Sources[1].Secret.Name}})).NotTo(HaveOccurred())
+
+	By("Ensuring all targets have been deleted")
+	var namespaceList corev1.NamespaceList
+	Expect(cl.List(ctx, &namespaceList)).ToNot(HaveOccurred())
+
+	for _, namespace := range namespaceList.Items {
+		Eventually(func() error {
+			if err := cl.Get(ctx, client.ObjectKey{Namespace: namespace.Name, Name: testBundle.Name}, new(corev1.ConfigMap)); err != nil {
+				return err
+			}
+
+			return cl.Get(ctx, client.ObjectKey{Namespace: namespace.Name, Name: testBundle.Name}, new(corev1.Secret))
+		}, eventuallyTimeout, eventualyPollInterval).ShouldNot(BeNil())
+	}
+}


### PR DESCRIPTION
Support https://github.com/cert-manager/trust-manager/issues/10

Add a new API Secret under taget to allow creating secret format CA certificates.
This is compatible with existing ConfigMap and can co-exist or exist alone.