### PR TITLE
Vendor dependencies correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,7 @@ COPY make/ make/
 # Copy the go source files
 COPY cmd/ cmd/
 COPY pkg/ pkg/
+COPY hack/ hack/
 
 RUN GOPROXY=$GOPROXY go mod download
 

--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -20,11 +20,15 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-SCRIPT_ROOT=$(dirname "${BASH_SOURCE[0]}")/..
-BIN_DIR=${SCRIPT_ROOT}/bin
+if [[ -z "${1:-}"  ]]; then
+	echo "usage: $0 <path-to-controller-gen>" >&2
+	exit 1
+fi
+
+CONTROLLER_GEN=$(realpath "$1")
 
 echo "Generating CRDs in ./deploy/crds"
-${BIN_DIR}/controller-gen crd schemapatch:manifests=./deploy/crds output:dir=./deploy/crds paths=./pkg/apis/...
+$CONTROLLER_GEN crd schemapatch:manifests=./deploy/crds output:dir=./deploy/crds paths=./pkg/apis/...
 
 echo "Updating CRDs with helm templating, writing to ./deploy/charts/trust-manager/templates"
 for i in $(ls ./deploy/crds); do


### PR DESCRIPTION
Make won't update files when a variable changes unless that variable is somehow included as a dependency for a target or in the path of the name of the target.

This commit adds versions to the paths of all tools we depend on, so that when one user bumps version numbers, everyone else won't need to run `make clean`.