### PR TITLE
Enable dependabot updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,17 @@
+# Update Go dependencies and GitHub Actions dependencies weekly.
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: /
+  schedule:
+    interval: weekly
+  groups:
+    all:
+      patterns: ["*"]
+- package-ecosystem: github-actions
+  directory: /
+  schedule:
+    interval: weekly
+  groups:
+    all:
+      patterns: ["*"]


### PR DESCRIPTION
Enable dependabot & make it bundle all upgrades in a single PR. (example: https://github.com/cert-manager/approver-policy/blob/main/.github/dependabot.yaml)