### PR TITLE
allow setting namespace for helm chart

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -56,6 +56,7 @@ Kubernetes: `>= 1.25.0-0`
 | image.repository | string | `"quay.io/jetstack/trust-manager"` | Target image repository. |
 | image.tag | string | `nil` | Target image version tag. Defaults to the chart's appVersion. |
 | imagePullSecrets | list | `[]` | For Private docker registries, authentication is needed. Registry secrets are applied to the service account |
+| namespace | string | `""` | The namespace to install trust-manager into. If not set, the namespace of the release will be used. This is helpful when installing trust-manager as a chart dependency (sub chart) |
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Configure the nodeSelector; defaults to any Linux node (trust-manager doesn't support Windows nodes) |
 | replicaCount | int | `1` | Number of replicas of trust-manager to run. |
 | resources | object | `{}` |  |

--- a/deploy/charts/trust-manager/templates/_helpers.tpl
+++ b/deploy/charts/trust-manager/templates/_helpers.tpl
@@ -39,3 +39,15 @@ See https://github.com/cert-manager/cert-manager/issues/6329 for a list of linke
 {{- if .digest -}}{{ printf "@%s" .digest }}{{- else -}}{{ printf ":%s" (default $defaultTag .tag) }}{{- end -}}
 {{- end }}
 {{- end }}
+
+{{/*
+Namespace for all resources to be installed into
+If not defined in values file then the helm release namespace is used
+By default this is not set so the helm release namespace will be used
+
+This gets around an problem within helm discussed here
+https://github.com/helm/helm/issues/5358
+*/}}
+{{- define "trust-manager.namespace" -}}
+    {{ .Values.namespace | default .Release.Namespace }}
+{{- end -}}

--- a/deploy/charts/trust-manager/templates/certificate.yaml
+++ b/deploy/charts/trust-manager/templates/certificate.yaml
@@ -2,7 +2,7 @@ apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
   name: {{ include "trust-manager.name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "trust-manager.namespace" . }}
   labels:
 {{ include "trust-manager.labels" . | indent 4 }}
 spec:
@@ -14,12 +14,12 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: {{ include "trust-manager.name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "trust-manager.namespace" . }}
   labels:
 {{ include "trust-manager.labels" . | indent 4 }}
 spec:
   dnsNames:
-  - "{{ include "trust-manager.name" . }}.{{ .Release.Namespace }}.svc"
+  - "{{ include "trust-manager.name" . }}.{{ include "trust-manager.namespace" . }}.svc"
   secretName: {{ include "trust-manager.name" . }}-tls
   revisionHistoryLimit: 1
   issuerRef:
@@ -38,7 +38,7 @@ metadata:
 spec:
   allowed:
     dnsNames:
-      values: ["{{ include "trust-manager.name" . }}.{{ .Release.Namespace }}.svc"]
+      values: ["{{ include "trust-manager.name" . }}.{{ include "trust-manager.namespace" . }}.svc"]
       required: true
   selector:
     issuerRef:

--- a/deploy/charts/trust-manager/templates/clusterrolebinding.yaml
+++ b/deploy/charts/trust-manager/templates/clusterrolebinding.yaml
@@ -11,4 +11,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "trust-manager.name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "trust-manager.namespace" . }}

--- a/deploy/charts/trust-manager/templates/deployment.yaml
+++ b/deploy/charts/trust-manager/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "trust-manager.name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "trust-manager.namespace" . }}
   labels:
 {{ include "trust-manager.labels" . | indent 4 }}
 spec:

--- a/deploy/charts/trust-manager/templates/metrics-service.yaml
+++ b/deploy/charts/trust-manager/templates/metrics-service.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "trust-manager.name" . }}-metrics
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "trust-manager.namespace" . }}
   labels:
     app: {{ include "trust-manager.name" . }}
 {{ include "trust-manager.labels" . | indent 4 }}

--- a/deploy/charts/trust-manager/templates/metrics-servicemonitor.yaml
+++ b/deploy/charts/trust-manager/templates/metrics-servicemonitor.yaml
@@ -3,7 +3,7 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: {{ include "trust-manager.name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "trust-manager.namespace" . }}
   labels:
     app: {{ include "trust-manager.name" . }}
 {{ include "trust-manager.labels" . | indent 4 }}
@@ -18,7 +18,7 @@ spec:
       app: {{ include "trust-manager.name" . }}
   namespaceSelector:
     matchNames:
-      - {{ .Release.Namespace }}
+      - {{ include "trust-manager.namespace" . }}
   endpoints:
   - targetPort: {{ .Values.app.metrics.port }}
     path: "/metrics"

--- a/deploy/charts/trust-manager/templates/rolebinding.yaml
+++ b/deploy/charts/trust-manager/templates/rolebinding.yaml
@@ -12,4 +12,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "trust-manager.name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "trust-manager.namespace" . }}

--- a/deploy/charts/trust-manager/templates/serviceaccount.yaml
+++ b/deploy/charts/trust-manager/templates/serviceaccount.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "trust-manager.name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "trust-manager.namespace" . }}
   labels:
 {{ include "trust-manager.labels" . | indent 4 }}
 {{- with .Values.imagePullSecrets }}

--- a/deploy/charts/trust-manager/templates/webhook.yaml
+++ b/deploy/charts/trust-manager/templates/webhook.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ include "trust-manager.name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "trust-manager.namespace" . }}
   labels:
     app: {{ include "trust-manager.name" . }}
 {{ include "trust-manager.labels" . | indent 4 }}
@@ -27,7 +27,7 @@ metadata:
     app: {{ include "trust-manager.name" . }}
 {{ include "trust-manager.labels" . | indent 4 }}
   annotations:
-    cert-manager.io/inject-ca-from: "{{ .Release.Namespace }}/{{ include "trust-manager.name" . }}"
+    cert-manager.io/inject-ca-from: "{{ include "trust-manager.namespace" . }}/{{ include "trust-manager.name" . }}"
 
 webhooks:
   - name: trust.cert-manager.io

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -1,6 +1,11 @@
 # -- Number of replicas of trust-manager to run.
 replicaCount: 1
 
+# -- The namespace to install trust-manager into.
+# If not set, the namespace of the release will be used.
+# This is helpful when installing trust-manager as a chart dependency (sub chart)
+namespace: ""
+
 # -- For Private docker registries, authentication is needed. Registry secrets are applied to the service account
 imagePullSecrets: []
 


### PR DESCRIPTION
This is based on cert-manager's helm chart override and resolves #145