### PR TITLE
Fix build on macOS / values.yaml wording tweaks 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,7 +111,12 @@ generate-manifests: $(BINDIR)/controller-tools-$(CONTROLLER_TOOLS_VERSION)/contr
 # See wait-for-buildx.sh for an explanation of why it's needed
 .PHONY: provision-buildx
 provision-buildx:  ## set up docker buildx for multiarch building
+ifeq ($(OS), linux)
+	# This step doesn't work on macOS and doesn't seem to be required (at least with docker desktop)
+	# It did seem to be needed in Linux, at least in certain configurations when running on amd64
+	# TODO: it might be preferable to move away from docker buildx in the long term to avoid the dependency on Docker
 	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
+endif
 	docker buildx rm $(BUILDX_BUILDER) &>/dev/null || :
 	./hack/wait-for-buildx.sh $(BUILDX_BUILDER) gone
 	docker buildx create --name $(BUILDX_BUILDER) --driver docker-container --use

--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -60,8 +60,8 @@ Kubernetes: `>= 1.25.0-0`
 | nodeSelector | object | `{"kubernetes.io/os":"linux"}` | Configure the nodeSelector; defaults to any Linux node (trust-manager doesn't support Windows nodes) |
 | replicaCount | int | `1` | Number of replicas of trust-manager to run. |
 | resources | object | `{}` |  |
-| secretTargets.authorizedSecrets | list | `[]` | A list of secret names which trust-manager will be permitted to read and write across all namespaces.     These will be the only allowable Secrets that can be used as targets.     If the list is empty, trust-manager will not be able to write to secrets and will only be able to    read secrets in the trust namespace for use as sources. |
-| secretTargets.authorizedSecretsAll | bool | `false` | If set to true, grant read/write permission to all secrets across the cluster. Use with caution!    When set, ignores authorizedSecrets list setting. |
-| secretTargets.enabled | bool | `false` | If set to true, enable writing trust bundles to Kubernetes Secrets as a target.    trust-manager can only write to secrets which are explicitly allowed.    - see either authorizedSecrets or authorizedSecretsAll. |
+| secretTargets.authorizedSecrets | list | `[]` | A list of secret names which trust-manager will be permitted to read and write across all namespaces. These will be the only allowable Secrets that can be used as targets. If the list is empty (and authorizedSecretsAll is false), trust-manager will not be able to write to secrets and will only be able to read secrets in the trust namespace for use as sources. |
+| secretTargets.authorizedSecretsAll | bool | `false` | If set to true, grant read/write permission to all secrets across the cluster. Use with caution! If set, ignores the authorizedSecrets list. |
+| secretTargets.enabled | bool | `false` | If set to true, enable writing trust bundles to Kubernetes Secrets as a target. trust-manager can only write to secrets which are explicitly allowed via either authorizedSecrets or authorizedSecretsAll. |
 | tolerations | list | `[]` | List of Kubernetes Tolerations; see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core |
 | topologySpreadConstraints | list | `[]` | List of Kubernetes TopologySpreadConstraints; see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#topologyspreadconstraint-v1-core |

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -110,16 +110,14 @@ app:
 
 secretTargets:
   # -- If set to true, enable writing trust bundles to Kubernetes Secrets as a target.
-  #    trust-manager can only write to secrets which are explicitly allowed.
-  #    - see either authorizedSecrets or authorizedSecretsAll.
+  # trust-manager can only write to secrets which are explicitly allowed via either authorizedSecrets or authorizedSecretsAll.
   enabled: false
   # -- If set to true, grant read/write permission to all secrets across the cluster. Use with caution!
-  #    When set, ignores authorizedSecrets list setting.
+  # If set, ignores the authorizedSecrets list.
   authorizedSecretsAll: false
-  # -- A list of secret names which trust-manager will be permitted to read and write across all namespaces. 
-  #    These will be the only allowable Secrets that can be used as targets. 
-  #    If the list is empty, trust-manager will not be able to write to secrets and will only be able to
-  #    read secrets in the trust namespace for use as sources.
+  # -- A list of secret names which trust-manager will be permitted to read and write across all namespaces.
+  # These will be the only allowable Secrets that can be used as targets. If the list is empty (and authorizedSecretsAll is false),
+  # trust-manager will not be able to write to secrets and will only be able to read secrets in the trust namespace for use as sources.
   authorizedSecrets: []
 
 resources: {}


### PR DESCRIPTION
I fully accept that the `provision-buildx` stuff is weird and we should change it or document it better - but this seems to work for now, and I can run the build commands succesfully locally while they still (usually 😂 ) pass in CI