### PR TITLE
Remove patch versions from go directives

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/trust-manager
 
-go 1.21.3
+go 1.21
 
 require (
 	github.com/go-logr/logr v1.2.4

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/cert-manager/tools/hack/tools
 
-go 1.21.3
+go 1.21
 
 require (
 	github.com/cert-manager/boilersuite v0.1.0

--- a/trust-packages/debian/go.mod
+++ b/trust-packages/debian/go.mod
@@ -1,3 +1,3 @@
 module github.com/cert-manager/trust-manager/debian-bundle-static
 
-go 1.21.3
+go 1.21


### PR DESCRIPTION
This helps older versions of go parse these directives

Specifically, our build process for the default trust package locally depends on trust-manager@main, but older releases (the release-0.6 branch) use go 1.20 and won't be able to parse them.

This tangle isn't ideal, but for future versions (i.e. when we can retire the release-0.6 branch and all supported versions use go 1.21) we can move past this and add the patch releases to our go directives again.

Motivation: [This test failure](https://prow.build-infra.jetstack.net/view/gs/jetstack-logs/pr-logs/pull/cert-manager_trust-manager/208/pull-trust-manager-smoke/1716817463552774144) for the release-0.6 branch. Specifically:

>  #15 20.52 go: github.com/cert-manager/trust-manager/cmd/validate-trust-package@main (in github.com/cert-manager/trust-manager@v0.7.0-alpha.2.0.20231024102130-94e8d110291e): go.mod:3: invalid go version '1.21.3': must match format 1.23 