### PR TITLE
Add helm values for annotations

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -34,6 +34,8 @@ Kubernetes: `>= 1.25.0-0`
 | app.readinessProbe.path | string | `"/readyz"` | Path on which to expose trust-manager HTTP readiness probe using default network interface. |
 | app.readinessProbe.port | int | `6060` | Container port on which to expose trust-manager HTTP readiness probe using default network interface. |
 | app.securityContext.seccompProfileEnabled | bool | `true` | If false, disables the default seccomp profile, which might be required to run on certain platforms |
+| app.deploymentAnnotations | object | `{}` | Annotations for the trust-manager Deployment |
+| app.certificateAnnotations | object | `{}` | Annotations for the Certificate/Issuer resources created by trust-manager |
 | app.trust.namespace | string | `"cert-manager"` | Namespace used as trust source. Note that the namespace _must_ exist before installing trust-manager. |
 | app.webhook.host | string | `"0.0.0.0"` | Host that the webhook listens on. |
 | app.webhook.hostNetwork | bool | `false` | Specifies if the app should be started in hostNetwork mode. Required for use in some managed kubernetes clusters (such as AWS EKS) with custom CNI. |

--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -25,6 +25,8 @@ Kubernetes: `>= 1.25.0-0`
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Kubernetes Affinty; see https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#affinity-v1-core |
+| app.certificateAnnotations | object | `{}` | Annotations for the Certificate/Issuer resources created by trust-manager |
+| app.deploymentAnnotations | object | `{}` | Annotations for the trust-manager Deployment |
 | app.logLevel | int | `1` | Verbosity of trust-manager logging; takes a value from 1-5, with higher being more verbose |
 | app.metrics.port | int | `9402` | Port for exposing Prometheus metrics on 0.0.0.0 on path '/metrics'. |
 | app.metrics.service | object | `{"enabled":true,"servicemonitor":{"enabled":false,"interval":"10s","labels":{},"prometheusInstance":"default","scrapeTimeout":"5s"},"type":"ClusterIP"}` | Service to expose metrics endpoint. |
@@ -34,8 +36,6 @@ Kubernetes: `>= 1.25.0-0`
 | app.readinessProbe.path | string | `"/readyz"` | Path on which to expose trust-manager HTTP readiness probe using default network interface. |
 | app.readinessProbe.port | int | `6060` | Container port on which to expose trust-manager HTTP readiness probe using default network interface. |
 | app.securityContext.seccompProfileEnabled | bool | `true` | If false, disables the default seccomp profile, which might be required to run on certain platforms |
-| app.deploymentAnnotations | object | `{}` | Annotations for the trust-manager Deployment |
-| app.certificateAnnotations | object | `{}` | Annotations for the Certificate/Issuer resources created by trust-manager |
 | app.trust.namespace | string | `"cert-manager"` | Namespace used as trust source. Note that the namespace _must_ exist before installing trust-manager. |
 | app.webhook.host | string | `"0.0.0.0"` | Host that the webhook listens on. |
 | app.webhook.hostNetwork | bool | `false` | Specifies if the app should be started in hostNetwork mode. Required for use in some managed kubernetes clusters (such as AWS EKS) with custom CNI. |

--- a/deploy/charts/trust-manager/templates/certificate.yaml
+++ b/deploy/charts/trust-manager/templates/certificate.yaml
@@ -3,6 +3,8 @@ kind: Issuer
 metadata:
   name: {{ include "trust-manager.name" . }}
   namespace: {{ include "trust-manager.namespace" . }}
+  annotations:
+    {{- toYaml .Values.app.certificateAnnotations | nindent 4 }}
   labels:
 {{ include "trust-manager.labels" . | indent 4 }}
 spec:
@@ -15,6 +17,8 @@ kind: Certificate
 metadata:
   name: {{ include "trust-manager.name" . }}
   namespace: {{ include "trust-manager.namespace" . }}
+  annotations:
+    {{- toYaml .Values.app.certificateAnnotations | nindent 4 }}
   labels:
 {{ include "trust-manager.labels" . | indent 4 }}
 spec:

--- a/deploy/charts/trust-manager/templates/deployment.yaml
+++ b/deploy/charts/trust-manager/templates/deployment.yaml
@@ -3,6 +3,8 @@ kind: Deployment
 metadata:
   name: {{ include "trust-manager.name" . }}
   namespace: {{ include "trust-manager.namespace" . }}
+  annotations:
+    {{- toYaml .Values.app.deploymentAnnotations | nindent 4 }}
   labels:
 {{ include "trust-manager.labels" . | indent 4 }}
 spec:

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -108,6 +108,12 @@ app:
     # -- If false, disables the default seccomp profile, which might be required to run on certain platforms
     seccompProfileEnabled: true
 
+  # -- Annotations for the trust-manager Deployment
+  deploymentAnnotations: {}
+
+  # -- Annotations for the Certificate/Issuer resources created by trust-manager
+  certificateAnnotations: {}
+
 secretTargets:
   # -- If set to true, enable writing trust bundles to Kubernetes Secrets as a target.
   # trust-manager can only write to secrets which are explicitly allowed via either authorizedSecrets or authorizedSecretsAll.


### PR DESCRIPTION
closes https://github.com/cert-manager/trust-manager/issues/175

This PR adds two new values to the helm chart:

- `app.deploymentAnnotations`: annotations to be applied to the trust-manager `Deployment` resource
- `app.certificateAnnotations`: annotations to be applied to the `Certificate` and `Issuer` resources

This is primarily so that users can create a combined chart with `cert-manager`, and use [ArgoCD ](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/#how-do-i-configure-waves) to prevent race conditions.

For example, here are the values I am using in [deployKF](https://www.deploykf.org/) for this purpose:

```yaml
app:
  certificateAnnotations:
    ## we must sync cert-manager resources after cert-manager itself
    argocd.argoproj.io/sync-wave: "10"

  deploymentAnnotations:
    ## we must sync the trust-manager deployment after its certificate is ready
    argocd.argoproj.io/sync-wave: "20"
```