### PR TITLE
Add erikgb to project approvers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -7,6 +7,7 @@ approvers:
 - irbekrm
 - sgtcodfish
 - inteon
+- erikgb
 reviewers:
 - munnerz
 - joshvanl


### PR DESCRIPTION
Ref. the [cert-manager governance document](https://github.com/cert-manager/community/blob/main/GOVERNANCE.md#approver), I would like to apply for the approver role in trust-manager.

Since becoming a reviewer, I have reviewed several PRs in this project. Many small ones, but also some larger ones. In the last category I would like to mention: https://github.com/cert-manager/trust-manager/pull/89 https://github.com/cert-manager/trust-manager/pull/161 https://github.com/cert-manager/trust-manager/pull/178 https://github.com/cert-manager/trust-manager/pull/184 https://github.com/cert-manager/trust-manager/pull/198

Sponsor: @inteon 