### PR TITLE
FIX: For CSA to SSA migration, we need UPDATE permission on the resource (not the sub-resource)

### DIFF
--- a/deploy/charts/trust-manager/templates/clusterrole.yaml
+++ b/deploy/charts/trust-manager/templates/clusterrole.yaml
@@ -23,8 +23,14 @@ rules:
   - "trust.cert-manager.io"
   resources:
   - "bundles/status"
+  verbs: ["patch"]
+
+- apiGroups:
+  - "trust.cert-manager.io"
+  resources:
+  - "bundles"
   # We also need update here so we can perform migrations from old CSA to SSA.
-  verbs: ["update", "patch"]
+  verbs: ["update"]
 
 - apiGroups:
   - ""


### PR DESCRIPTION
We made a mistake in https://github.com/cert-manager/trust-manager/pull/191.
To migrate from CSA to SSA, we need to be able to UPDATE the resource (not the sub-resource).
The update operation is performed here: https://github.com/cert-manager/trust-manager/blob/0418012f3617d222d0a5ae337e9168534f6f2005/pkg/bundle/bundle.go#L491

To avoid these problems in the future, we should run our integration tests using a non-admin service account (so we also test our RBAC configs).