### PR TITLE
Allow permissions to put the leases in the trust-manager namespace, not the trust namespace

### DIFF
--- a/cmd/trust-manager/app/app.go
+++ b/cmd/trust-manager/app/app.go
@@ -78,7 +78,6 @@ func NewCommand() *cobra.Command {
 				Scheme:                        trustapi.GlobalScheme,
 				EventBroadcaster:              eventBroadcaster,
 				LeaderElection:                true,
-				LeaderElectionNamespace:       opts.Bundle.Namespace,
 				LeaderElectionID:              "trust-manager-leader-election",
 				LeaderElectionReleaseOnCancel: true,
 				ReadinessEndpointName:         opts.ReadyzPath,

--- a/deploy/charts/trust-manager/templates/role.yaml
+++ b/deploy/charts/trust-manager/templates/role.yaml
@@ -14,6 +14,14 @@ rules:
   - "get"
   - "list"
   - "watch"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "trust-manager.name" . }}
+  namespace: {{ include "trust-manager.namespace" . }}
+  labels:
+{{ include "trust-manager.labels" . | indent 4 }}
+rules:
 - apiGroups:
   - "coordination.k8s.io"
   resources:

--- a/deploy/charts/trust-manager/templates/role.yaml
+++ b/deploy/charts/trust-manager/templates/role.yaml
@@ -15,6 +15,7 @@ rules:
   - "list"
   - "watch"
 ---
+kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: {{ include "trust-manager.name" . }}:leaderelection

--- a/deploy/charts/trust-manager/templates/role.yaml
+++ b/deploy/charts/trust-manager/templates/role.yaml
@@ -17,7 +17,7 @@ rules:
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "trust-manager.name" . }}
+  name: {{ include "trust-manager.name" . }}:leaderelection
   namespace: {{ include "trust-manager.namespace" . }}
   labels:
 {{ include "trust-manager.labels" . | indent 4 }}

--- a/deploy/charts/trust-manager/templates/rolebinding.yaml
+++ b/deploy/charts/trust-manager/templates/rolebinding.yaml
@@ -17,14 +17,14 @@ subjects:
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: {{ include "trust-manager.name" . }}
+  name: {{ include "trust-manager.name" . }}:leaderelection
   namespace: {{ include "trust-manager.namespace" . }}
   labels:
 {{ include "trust-manager.labels" . | indent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: {{ include "trust-manager.name" . }}
+  name: {{ include "trust-manager.name" . }}:leaderelection
 subjects:
 - kind: ServiceAccount
   name: {{ include "trust-manager.name" . }}

--- a/deploy/charts/trust-manager/templates/rolebinding.yaml
+++ b/deploy/charts/trust-manager/templates/rolebinding.yaml
@@ -13,3 +13,19 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "trust-manager.name" . }}
   namespace: {{ include "trust-manager.namespace" . }}
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "trust-manager.name" . }}
+  namespace: {{ include "trust-manager.namespace" . }}
+  labels:
+{{ include "trust-manager.labels" . | indent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ include "trust-manager.name" . }}
+subjects:
+- kind: ServiceAccount
+  name: {{ include "trust-manager.name" . }}
+  namespace: {{ include "trust-manager.namespace" . }}


### PR DESCRIPTION
This pull request separates the lease permissions to their own role and role binding in the namespace where trust-manager will be installed. See #224 for more details.