### PR TITLE
Add two new variables to the Helm chart

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -82,6 +82,23 @@ The number of replicas of trust-manager to run.
 </tr>
 <tr>
 
+<td>revisionHistoryLimit</td>
+<td>
+
+The number of revisions to keep.
+
+</td>
+<td>number</td>
+<td>
+
+```yaml
+10
+```
+
+</td>
+</tr>
+<tr>
+
 <td>namespace</td>
 <td>
 
@@ -532,6 +549,21 @@ Whether to filter expired certificates from the trust bundle.
 
 ```yaml
 false
+```
+
+</td>
+</tr>
+<tr>
+
+<td>packagesVolume.emptyDir</td>
+<td>
+
+</td>
+<td>object</td>
+<td>
+
+```yaml
+{}
 ```
 
 </td>

--- a/deploy/charts/trust-manager/templates/deployment.yaml
+++ b/deploy/charts/trust-manager/templates/deployment.yaml
@@ -7,6 +7,9 @@ metadata:
 {{ include "trust-manager.labels" . | indent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if ne (quote .Values.revisionHistoryLimit) (quote "") }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ include "trust-manager.name" . }}
@@ -123,7 +126,7 @@ spec:
       {{- end }}
       volumes:
       - name: packages
-        emptyDir: {}
+        {{- toYaml .Values.packagesVolume | nindent 8 }}
       - name: tls
         secret:
           defaultMode: 420

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -9,6 +9,9 @@ crds:
 # The number of replicas of trust-manager to run.
 replicaCount: 1
 
+# The number of revisions to keep.
+revisionHistoryLimit: 10
+
 # The namespace to install trust-manager into.
 # If not set, the namespace of the release is used.
 # This is helpful when installing trust-manager as a chart dependency (sub chart).
@@ -130,6 +133,10 @@ topologySpreadConstraints: []
 filterExpiredCertificates:
   # Whether to filter expired certificates from the trust bundle.
   enabled: false
+
+# Volume to be mounted in Pods for loading default trust package.
+packagesVolume:
+  emptyDir: {}
 
 
 app:


### PR DESCRIPTION
* Allow customising the `revisionHistoryLimit` field in the Deployment, defaulting to the Kubernetes default of 10.
* Allow customising the volume used for storing the default trust package, defaulting to the original `emptyDir: {}` value.