### PR TITLE
chore: reconcile Bundle status unconditionally

### DIFF
--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -913,11 +913,22 @@ func Test_Reconcile(t *testing.T) {
 				),
 			},
 
-			expResult:      ctrl.Result{},
-			expError:       false,
-			expPatches:     nil,
-			expBundlePatch: nil,
-			expEvent:       "",
+			expResult:  ctrl.Result{},
+			expError:   false,
+			expPatches: nil,
+			expBundlePatch: &trustapi.BundleStatus{
+				Conditions: []trustapi.BundleCondition{
+					{
+						Type:               trustapi.BundleConditionSynced,
+						Status:             metav1.ConditionTrue,
+						LastTransitionTime: fixedmetatime,
+						Reason:             "Synced",
+						Message:            "Successfully synced Bundle to all namespaces",
+						ObservedGeneration: bundleGeneration,
+					},
+				},
+			},
+			expEvent: "Normal Synced Successfully synced Bundle to all namespaces",
 		},
 		"if Bundle references default CAs but it wasn't configured at startup, update with error": {
 			existingNamespaces: namespaces,

--- a/pkg/bundle/util_test.go
+++ b/pkg/bundle/util_test.go
@@ -20,61 +20,11 @@ import (
 	"testing"
 	"time"
 
+	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakeclock "k8s.io/utils/clock/testing"
-	"k8s.io/utils/ptr"
-
-	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
 )
-
-func Test_bundleHasCondition(t *testing.T) {
-	const bundleGeneration int64 = 2
-	var (
-		fixedTime = time.Date(2021, 01, 01, 01, 0, 0, 0, time.UTC)
-	)
-
-	tests := map[string]struct {
-		existingConditions []trustapi.BundleCondition
-		newCondition       trustapi.BundleCondition
-		expectHasCondition bool
-	}{
-		"no existing conditions returns no matching condition": {
-			existingConditions: []trustapi.BundleCondition{},
-			newCondition:       trustapi.BundleCondition{Reason: "A", ObservedGeneration: bundleGeneration},
-			expectHasCondition: false,
-		},
-		"an existing condition which doesn't match the current condition should return false": {
-			existingConditions: []trustapi.BundleCondition{{Reason: "B"}},
-			newCondition:       trustapi.BundleCondition{Reason: "A", ObservedGeneration: bundleGeneration},
-			expectHasCondition: false,
-		},
-		"an existing condition which shares the same condition but is an older generation should return false": {
-			existingConditions: []trustapi.BundleCondition{{Reason: "A", ObservedGeneration: bundleGeneration - 1}},
-			newCondition:       trustapi.BundleCondition{Reason: "A", ObservedGeneration: bundleGeneration},
-			expectHasCondition: false,
-		},
-		"an existing condition which shares the same condition and generation should return true": {
-			existingConditions: []trustapi.BundleCondition{{Reason: "A", ObservedGeneration: bundleGeneration}},
-			newCondition:       trustapi.BundleCondition{Reason: "A", ObservedGeneration: bundleGeneration},
-			expectHasCondition: true,
-		},
-		"an existing condition with a different LastTransitionTime should return true still": {
-			existingConditions: []trustapi.BundleCondition{{Reason: "A", ObservedGeneration: bundleGeneration, LastTransitionTime: &metav1.Time{Time: fixedTime.Add(-time.Second)}}},
-			newCondition:       trustapi.BundleCondition{Reason: "A", ObservedGeneration: bundleGeneration},
-			expectHasCondition: true,
-		},
-	}
-
-	for name, test := range tests {
-		t.Run(name, func(t *testing.T) {
-			hasCondition := bundleHasCondition(test.existingConditions, test.newCondition)
-			if hasCondition != test.expectHasCondition {
-				t.Errorf("unexpected has condition, exp=%t got=%t", test.expectHasCondition, hasCondition)
-			}
-		})
-	}
-}
 
 func Test_setBundleCondition(t *testing.T) {
 	const bundleGeneration int64 = 2
@@ -216,102 +166,6 @@ func Test_setBundleCondition(t *testing.T) {
 
 			if !apiequality.Semantic.DeepEqual(bundle.Status.Conditions, test.expectedConditions) {
 				t.Errorf("unexpected resulting conditions, exp=%v got=%v", test.expectedConditions, bundle.Status.Conditions)
-			}
-		})
-	}
-}
-
-func Test_setBundleStatusDefaultCAVersion(t *testing.T) {
-	var (
-		fixedTime  = time.Date(2021, 01, 01, 01, 0, 0, 0, time.UTC)
-		fixedclock = fakeclock.NewFakeClock(fixedTime)
-	)
-
-	tests := map[string]struct {
-		inputBundle                     trustapi.Bundle
-		requiredID                      string
-		expectedDefaultCAPackageVersion *string
-		expectUpdate                    bool
-	}{
-		"requiredID empty but status populated; should update": {
-			inputBundle: trustapi.Bundle{
-				Status: trustapi.BundleStatus{
-					DefaultCAPackageVersion: ptr.To("abc123"),
-				},
-			},
-			requiredID:                      "",
-			expectedDefaultCAPackageVersion: nil,
-			expectUpdate:                    true,
-		},
-		"requiredID empty but status populated but empty; should update": {
-			inputBundle: trustapi.Bundle{
-				Status: trustapi.BundleStatus{
-					DefaultCAPackageVersion: ptr.To(""),
-				},
-			},
-			requiredID:                      "",
-			expectedDefaultCAPackageVersion: nil,
-			expectUpdate:                    true,
-		},
-		"requiredID empty and status nil; should not update": {
-			inputBundle: trustapi.Bundle{
-				Status: trustapi.BundleStatus{
-					DefaultCAPackageVersion: nil,
-				},
-			},
-			requiredID:                      "",
-			expectedDefaultCAPackageVersion: nil,
-			expectUpdate:                    false,
-		},
-		"requiredID not empty and status nil; should update": {
-			inputBundle: trustapi.Bundle{
-				Status: trustapi.BundleStatus{
-					DefaultCAPackageVersion: nil,
-				},
-			},
-			requiredID:                      "abc123",
-			expectedDefaultCAPackageVersion: ptr.To("abc123"),
-			expectUpdate:                    true,
-		},
-		"requiredID not empty and status populated but incorrect; should update": {
-			inputBundle: trustapi.Bundle{
-				Status: trustapi.BundleStatus{
-					DefaultCAPackageVersion: ptr.To("def456"),
-				},
-			},
-			requiredID:                      "abc123",
-			expectedDefaultCAPackageVersion: ptr.To("abc123"),
-			expectUpdate:                    true,
-		},
-		"requiredID not empty and status populated currectly; should not update": {
-			inputBundle: trustapi.Bundle{
-				Status: trustapi.BundleStatus{
-					DefaultCAPackageVersion: ptr.To("abc123"),
-				},
-			},
-			requiredID:                      "abc123",
-			expectedDefaultCAPackageVersion: ptr.To("abc123"),
-			expectUpdate:                    false,
-		},
-	}
-
-	for name, test := range tests {
-		test := test
-		t.Run(name, func(t *testing.T) {
-			t.Parallel()
-
-			b := &bundle{clock: fixedclock}
-
-			shouldUpdate := b.setBundleStatusDefaultCAVersion(&test.inputBundle.Status, test.requiredID)
-
-			if shouldUpdate != test.expectUpdate {
-				t.Errorf("expected shouldUpdate=%v got=%v", test.expectUpdate, shouldUpdate)
-			}
-
-			finalVersion := test.inputBundle.Status.DefaultCAPackageVersion
-
-			if !apiequality.Semantic.DeepEqual(finalVersion, test.expectedDefaultCAPackageVersion) {
-				t.Errorf("expected DefaultCAPackageVersion=%v, got=%v", test.expectedDefaultCAPackageVersion, finalVersion)
 			}
 		})
 	}


### PR DESCRIPTION
This is my next step towards simpler code after our SSA-migration. The main change in this PR is that an already synced Bundle now will submit a probable no-op patch of Bundle status to the api-server. The number of bundle resources in a cluster is likely limited, and the simplifications of controller code should justify the slightly additional load on the api-server. Already in this PR, I propose deleting two utility functions with tests, but there is probably more that could be cleaned up around the sync of target configmaps and secrets. Please let me know if this could/should be done in this PR. If not, I will submit a follow-up PR.

/cc @inteon @SgtCoDFish 