### PR TITLE
fix: should encode additional target format just once per bundle reconcile

### DIFF
--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -354,7 +354,7 @@ func (b *bundle) reconcileBundle(ctx context.Context, req ctrl.Request) (result 
 		var err error
 
 		if target.Kind == configMapTarget {
-			cmSynced, err = b.syncConfigMapTarget(ctx, targetLog, &bundle, target.Name, target.Namespace, resolvedBundle.data, shouldExist)
+			cmSynced, err = b.syncConfigMapTarget(ctx, targetLog, &bundle, target.Name, target.Namespace, resolvedBundle, shouldExist)
 			if err != nil {
 				targetLog.Error(err, "failed sync bundle to ConfigMap target namespace")
 				b.recorder.Eventf(&bundle, corev1.EventTypeWarning, "SyncConfigMapTargetFailed", "Failed to sync target in Namespace %q: %s", target.Namespace, err)
@@ -376,7 +376,7 @@ func (b *bundle) reconcileBundle(ctx context.Context, req ctrl.Request) (result 
 		}
 
 		if target.Kind == secretTarget {
-			secretSynced, err = b.syncSecretTarget(ctx, targetLog, &bundle, target.Name, target.Namespace, resolvedBundle.data, shouldExist)
+			secretSynced, err = b.syncSecretTarget(ctx, targetLog, &bundle, target.Name, target.Namespace, resolvedBundle, shouldExist)
 			if err != nil {
 				targetLog.Error(err, "failed sync bundle to Secret target namespace")
 				b.recorder.Eventf(&bundle, corev1.EventTypeWarning, "SyncSecretTargetFailed", "Failed to sync target in Namespace %q: %s", target.Namespace, err)


### PR DESCRIPTION
While working on something else, I discovered that if a bundle specifies any additional format in targets, the JKS/PKCS12 is encoded for each and every target configmap/secret. This seems wrong to me, as encoding in these binary trust store formats is a quite heavy operation.

This PR moves the encoding of any additional target formats into `buildSourceBundle` method - which is executed once per bundle reconciliation. I tried to make this fix/refactoring as minimal as possible to not affect the WIP on https://github.com/cert-manager/trust-manager/pull/235 too much. We could eventually improve this even more in a follow-up PR - especially the tests, which have a lot of duplication at present.