### PR TITLE
Fix apply configuration generation on macOS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,8 +105,8 @@ generate-deepcopy: ## Generate code containing DeepCopy, DeepCopyInto, and DeepC
 generate-deepcopy: | $(BINDIR)/controller-tools-$(CONTROLLER_TOOLS_VERSION)/controller-gen
 	$(BINDIR)/controller-tools-$(CONTROLLER_TOOLS_VERSION)/controller-gen object:headerFile="hack/boilerplate/boilerplate.go.txt" paths="./..."
 
-GO_MODULE = $(shell go list -m)
-API_DIRS = $(shell find pkg/apis -mindepth 2 -type d | sed "s|^|$(shell go list -m)/|" | paste -sd "," -)
+GO_MODULE := $(shell go list -m)
+API_DIRS := $(shell find pkg/apis -mindepth 2 -type d | sed "s|^|$(GO_MODULE)/|" | paste -sd "," -)
 
 .PHONY: generate-applyconfigurations
 generate-applyconfigurations: ## Generate applyconfigurations to support typesafe SSA.

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,8 @@ generate-deepcopy: | $(BINDIR)/controller-tools-$(CONTROLLER_TOOLS_VERSION)/cont
 	$(BINDIR)/controller-tools-$(CONTROLLER_TOOLS_VERSION)/controller-gen object:headerFile="hack/boilerplate/boilerplate.go.txt" paths="./..."
 
 GO_MODULE = $(shell go list -m)
-API_DIRS = $(shell find pkg/apis -mindepth 2 -type d | sed "s|^|$(shell go list -m)/|" | paste -sd ",")
+API_DIRS = $(shell find pkg/apis -mindepth 2 -type d | sed "s|^|$(shell go list -m)/|" | paste -sd "," -)
+
 .PHONY: generate-applyconfigurations
 generate-applyconfigurations: ## Generate applyconfigurations to support typesafe SSA.
 generate-applyconfigurations: | $(BINDIR)/code-generator-$(CODE_GENERATOR_VERSION)/applyconfiguration-gen


### PR DESCRIPTION
I noticed this while looking into #240

## Commit 1

On at least macos 14.1 (sonoma) the paste utility seems to require a filename to be specified; before this change, the `API_DIRS` variable fails with the following error:

> usage: paste [-s] [-d delimiters] file ...

## Commit 2

This avoids us spinning up a separate shell when evaluating `API_DIRS`, since `GO_MODULE` already contains the value we want.

This change also changes the variable assignments; make variables are very confusing, but `:=` should only evaluate at startup while `=` will evaluate every time the variable is used.

See [these docs](https://www.gnu.org/software/make/manual/html_node/Recursive-Assignment.html) for how `=` works, and [these](https://www.gnu.org/software/make/manual/html_node/Simple-Assignment.html) for `:=`. From the first link:

> Another disadvantage is that any functions referenced in the definition will be executed every time the variable is expanded. This makes make run slower; worse, it causes the wildcard and shell functions to give unpredictable results because you cannot easily control when they are called, or even how many times.