### PR TITLE
Better handling of local arch differences

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,8 @@ CONTAINER_REGISTRY_API_URL ?= https://quay.io/v2/jetstack/cert-manager-package-d
 
 GOPROXY ?= https://proxy.golang.org,direct
 
+GO_SOURCES := $(shell find . -name "*.go") go.mod go.sum
+
 CI ?=
 
 # can't use a comma in an argument to a make function, so define a variable instead
@@ -94,7 +96,9 @@ vet:
 	go vet ./...
 
 .PHONY: build
-build: | $(BINDIR) ## build trust-manager
+build: $(BINDIR)/trust-manager | $(BINDIR) ## build trust-manager for the host system architecture
+
+$(BINDIR)/trust-manager: $(GO_SOURCES) | $(BINDIR)
 	CGO_ENABLED=0 go build -o $(BINDIR)/trust-manager ./cmd/trust-manager
 
 .PHONY: generate

--- a/make/trust-manager-build.mk
+++ b/make/trust-manager-build.mk
@@ -28,7 +28,7 @@ trust-manager-save:
 
 .PHONY: trust-manager-load
 trust-manager-load:
-	$(call build_trust_manager,type=docker,latest,linux/amd64)
+	$(call build_trust_manager,type=docker,latest,linux/$(ARCH))
 
 .PHONY: trust-manager-push
 trust-manager-push:

--- a/make/trust-package-debian.mk
+++ b/make/trust-package-debian.mk
@@ -37,7 +37,7 @@ endif
 
 .PHONY: trust-package-debian-load
 trust-package-debian-load:
-	$(call build_debian_trust_package,type=docker,latest,linux/amd64)
+	$(call build_debian_trust_package,type=docker,latest,linux/$(ARCH))
 
 .PHONY: trust-package-debian-push
 trust-package-debian-push:


### PR DESCRIPTION
These commits help when developing on non-amd64 architectures.