### PR TITLE
Do more of the container build process locally

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,10 @@
 # limitations under the License.
 
 # Build the trust binary
-FROM docker.io/library/golang:1.21 as builder
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.21 as builder
 
 ARG GOPROXY
+ARG TARGETARCH
 
 WORKDIR /workspace
 # Copy the Go Modules manifests
@@ -34,13 +35,16 @@ COPY hack/ hack/
 RUN GOPROXY=$GOPROXY go mod download
 
 # Build
-RUN make build
+RUN make build-linux-$TARGETARCH
 
 FROM scratch
+
+ARG TARGETARCH
+
 LABEL description="trust-manager is an operator for distributing trust bundles across a Kubernetes cluster"
 
 WORKDIR /
 USER 1001
-COPY --from=builder /workspace/bin/trust-manager /usr/bin/trust-manager
+COPY --from=builder /workspace/bin/trust-manager-linux-$TARGETARCH /usr/bin/trust-manager
 
 ENTRYPOINT ["/usr/bin/trust-manager"]

--- a/trust-packages/debian/Containerfile
+++ b/trust-packages/debian/Containerfile
@@ -12,9 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM docker.io/library/golang:1.21 as gobuild
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.21 as gobuild
 
 ARG GOPROXY
+ARG TARGETARCH
 
 WORKDIR /work
 
@@ -22,9 +23,9 @@ COPY go.mod go.mod
 COPY go.sum go.sum
 COPY main.go main.go
 
-RUN GOPROXY=$GOPROXY CGO_ENABLED=0 go build -o copyandmaybepause main.go
+RUN GOPROXY=$GOPROXY CGO_ENABLED=0 GOARCH=$TARGETARCH go build -o copyandmaybepause main.go
 
-RUN GOPROXY=$GOPROXY CGO_ENABLED=0 go install github.com/cert-manager/trust-manager/cmd/validate-trust-package@main
+RUN GOPROXY=$GOPROXY go get github.com/cert-manager/trust-manager/cmd/validate-trust-package && GOPROXY=$GOPROXY CGO_ENABLED=0 GOARCH=$TARGETARCH go build -o /go/bin/validate-trust-package github.com/cert-manager/trust-manager/cmd/validate-trust-package
 
 FROM docker.io/library/debian:11-slim as debbase
 


### PR DESCRIPTION
See https://www.docker.com/blog/faster-multi-platform-builds-dockerfile-cross-compilation-guide/

This PR adds that blogpost for this repo. It also allows me to build trust-manager on macOS, when I currently cannot because of bugs in emulation when building for different platforms.

This will also improve performance as well as fixing the build on macOS.

We might want to use a different process down the road, but I'm confident this is an improvement to the status quo.