### PR TITLE
fix: apply-configuration gen for Bundle (cluster-scoped)

### DIFF
--- a/pkg/apis/trust/v1alpha1/types_bundle.go
+++ b/pkg/apis/trust/v1alpha1/types_bundle.go
@@ -33,6 +33,7 @@ var BundleHashAnnotationKey = "trust.cert-manager.io/hash"
 // +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster
 // +genclient
+// +genclient:nonNamespaced
 
 type Bundle struct {
 	metav1.TypeMeta   `json:",inline"`

--- a/pkg/applyconfigurations/trust/v1alpha1/bundle.go
+++ b/pkg/applyconfigurations/trust/v1alpha1/bundle.go
@@ -35,10 +35,9 @@ type BundleApplyConfiguration struct {
 
 // Bundle constructs an declarative configuration of the Bundle type for use with
 // apply.
-func Bundle(name, namespace string) *BundleApplyConfiguration {
+func Bundle(name string) *BundleApplyConfiguration {
 	b := &BundleApplyConfiguration{}
 	b.WithName(name)
-	b.WithNamespace(namespace)
 	b.WithKind("Bundle")
 	b.WithAPIVersion("trust.cert-manager.io/v1alpha1")
 	return b


### PR DESCRIPTION
While trying to migrate one of our operators to SSA, I realized a bug in https://github.com/cert-manager/trust-manager/pull/217. Bundle is a cluster-scoped resource, and needs an additional marker to generate a correct AC constructor. Please see https://kubernetes.slack.com/archives/C02MRBMN00Z/p1702911424438589 for details.