### PR TITLE
Don't build trust bundle images using make image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ endif
 	docker buildx inspect --bootstrap --builder $(BUILDX_BUILDER)
 
 .PHONY: image
-image: trust-manager-save trust-package-debian-save | $(BINDIR) ## build docker images targeting all supported platforms and save to disk. Requires `make provision-buildx`
+image: trust-manager-save | $(BINDIR) ## build trust-manager container images targeting all supported platforms and save to disk. Requires `make provision-buildx`
 
 .PHONY: local-images
 local-images: trust-manager-load trust-package-debian-load  ## build container images for only the local architecture and load into docker. Requires `make provision-buildx`


### PR DESCRIPTION
`make image` is not as well defined as `make trust-package-debian-save` or `make trust-manager-load`, but it seems reasonable to have it available as a test when developing trust-manager.

If `make image` also applies to the trust package, it requires that users come up with a value for `DEBIAN_TRUST_PACKAGE_VERSION` which most users won't be able to guess.

Most users should be using the provided commands for loading trust-manager into a kind cluster when developing, which sidesteps this problem entirely.

It feels like the simplest thing here is to have `make image` be an alias for `make trust-manager-save`.