### PR TITLE
Add 'crds.keep' options to generated CRDs

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -14,7 +14,15 @@
 > true
 > ```
 
-Whether or not to install the CRDs.
+This option decides if the CRDs should be installed as part of the Helm installation.
+#### **crds.keep** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+This option makes it so that the "helm.sh/resource-policy": keep annotation is added to the CRD. This will prevent Helm from uninstalling the CRD when the Helm release is uninstalled. WARNING: when the CRDs are removed, all cert-manager custom resources  
+(Certificates, Issuers, ...) will be removed too by the garbage collector.
 ### Trust Manager
 
 #### **replicaCount** ~ `number`

--- a/deploy/charts/trust-manager/templates/trust.cert-manager.io_bundles.yaml
+++ b/deploy/charts/trust-manager/templates/trust.cert-manager.io_bundles.yaml
@@ -1,10 +1,14 @@
-{{ if .Values.crds.enabled }}
+{{- if .Values.crds.enabled }}
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  name: "bundles.trust.cert-manager.io"
+  {{- if .Values.crds.keep }}
   annotations:
-    controller-gen.kubebuilder.io/version: v0.14.0
-  name: bundles.trust.cert-manager.io
+    helm.sh/resource-policy: keep
+  {{- end }}
+  labels:
+    {{- include "trust-manager.labels" . | nindent 4 }}
 spec:
   group: trust.cert-manager.io
   names:
@@ -359,4 +363,4 @@ spec:
       storage: true
       subresources:
         status: {}
-{{ end }}
+{{- end }}

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -1,8 +1,16 @@
 # +docs:section=CRDs
 
 crds:
-  # Whether or not to install the CRDs.
+  # This option decides if the CRDs should be installed
+  # as part of the Helm installation.
   enabled: true
+
+  # This option makes it so that the "helm.sh/resource-policy": keep
+  # annotation is added to the CRD. This will prevent Helm from uninstalling
+  # the CRD when the Helm release is uninstalled.
+  # WARNING: when the CRDs are removed, all cert-manager custom resources
+  # (Certificates, Issuers, ...) will be removed too by the garbage collector.
+  keep: true
 
 # +docs:section=Trust Manager
 


### PR DESCRIPTION
Adds the new `crds.keep` option which prevents us from incidentally removing the CRDs when uninstalling the chart.
See https://github.com/cert-manager/cert-manager/pull/6719 for more info.
