### PR TITLE
Helm: Uniformize all label include statements & add labels to pod template

### DIFF
--- a/deploy/charts/trust-manager/templates/certificate.yaml
+++ b/deploy/charts/trust-manager/templates/certificate.yaml
@@ -36,6 +36,8 @@ apiVersion: policy.cert-manager.io/v1alpha1
 kind: CertificateRequestPolicy
 metadata:
   name: trust-manager-policy
+  labels:
+    {{- include "trust-manager.labels" . | nindent 4 }}
 spec:
   allowed:
     commonName:
@@ -56,6 +58,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: trust-manager-policy-role
+  labels:
+    {{- include "trust-manager.labels" . | nindent 4 }}
 rules:
   - apiGroups: ["policy.cert-manager.io"]
     resources: ["certificaterequestpolicies"]
@@ -68,6 +72,8 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: trust-manager-policy-binding
+  labels:
+    {{- include "trust-manager.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deploy/charts/trust-manager/templates/certificate.yaml
+++ b/deploy/charts/trust-manager/templates/certificate.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "trust-manager.name" . }}
   namespace: {{ include "trust-manager.namespace" . }}
   labels:
-{{ include "trust-manager.labels" . | indent 4 }}
+    {{- include "trust-manager.labels" . | nindent 4 }}
 spec:
   selfSigned: {}
 
@@ -16,7 +16,7 @@ metadata:
   name: {{ include "trust-manager.name" . }}
   namespace: {{ include "trust-manager.namespace" . }}
   labels:
-{{ include "trust-manager.labels" . | indent 4 }}
+    {{- include "trust-manager.labels" . | nindent 4 }}
 spec:
   commonName: "{{ include "trust-manager.name" . }}.{{ include "trust-manager.namespace" . }}.svc"
   dnsNames:

--- a/deploy/charts/trust-manager/templates/clusterrole.yaml
+++ b/deploy/charts/trust-manager/templates/clusterrole.yaml
@@ -2,7 +2,7 @@ kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-{{ include "trust-manager.labels" . | indent 4 }}
+    {{- include "trust-manager.labels" . | nindent 4 }}
   name: {{ include "trust-manager.name" . }}
 rules:
 - apiGroups:

--- a/deploy/charts/trust-manager/templates/clusterrolebinding.yaml
+++ b/deploy/charts/trust-manager/templates/clusterrolebinding.yaml
@@ -2,7 +2,7 @@ kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
-{{ include "trust-manager.labels" . | indent 4 }}
+    {{- include "trust-manager.labels" . | nindent 4 }}
   name: {{ include "trust-manager.name" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/charts/trust-manager/templates/deployment.yaml
+++ b/deploy/charts/trust-manager/templates/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "trust-manager.name" . }}
   namespace: {{ include "trust-manager.namespace" . }}
   labels:
-{{ include "trust-manager.labels" . | indent 4 }}
+    {{- include "trust-manager.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
@@ -18,6 +18,7 @@ spec:
       {{- end }}
       labels:
         app: {{ include "trust-manager.name" . }}
+        {{- include "trust-manager.labels" . | nindent 8 }}
         {{- with .Values.app.podLabels }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/deploy/charts/trust-manager/templates/metrics-service.yaml
+++ b/deploy/charts/trust-manager/templates/metrics-service.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ include "trust-manager.namespace" . }}
   labels:
     app: {{ include "trust-manager.name" . }}
-{{ include "trust-manager.labels" . | indent 4 }}
+    {{- include "trust-manager.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.app.metrics.service.type }}
   ports:

--- a/deploy/charts/trust-manager/templates/metrics-servicemonitor.yaml
+++ b/deploy/charts/trust-manager/templates/metrics-servicemonitor.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: {{ include "trust-manager.namespace" . }}
   labels:
     app: {{ include "trust-manager.name" . }}
-{{ include "trust-manager.labels" . | indent 4 }}
+    {{- include "trust-manager.labels" . | nindent 4 }}
     prometheus: {{ .Values.app.metrics.service.servicemonitor.prometheusInstance }}
 {{- if .Values.app.metrics.service.servicemonitor.labels }}
 {{ toYaml .Values.app.metrics.service.servicemonitor.labels | indent 4}}

--- a/deploy/charts/trust-manager/templates/role.yaml
+++ b/deploy/charts/trust-manager/templates/role.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "trust-manager.name" . }}
   namespace: {{ .Values.app.trust.namespace }}
   labels:
-{{ include "trust-manager.labels" . | indent 4 }}
+    {{- include "trust-manager.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - ""
@@ -21,7 +21,7 @@ metadata:
   name: {{ include "trust-manager.name" . }}:leaderelection
   namespace: {{ include "trust-manager.namespace" . }}
   labels:
-{{ include "trust-manager.labels" . | indent 4 }}
+    {{- include "trust-manager.labels" . | nindent 4 }}
 rules:
 - apiGroups:
   - "coordination.k8s.io"

--- a/deploy/charts/trust-manager/templates/rolebinding.yaml
+++ b/deploy/charts/trust-manager/templates/rolebinding.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "trust-manager.name" . }}
   namespace: {{ .Values.app.trust.namespace }}
   labels:
-{{ include "trust-manager.labels" . | indent 4 }}
+    {{- include "trust-manager.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -20,7 +20,7 @@ metadata:
   name: {{ include "trust-manager.name" . }}:leaderelection
   namespace: {{ include "trust-manager.namespace" . }}
   labels:
-{{ include "trust-manager.labels" . | indent 4 }}
+    {{- include "trust-manager.labels" . | nindent 4 }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/deploy/charts/trust-manager/templates/serviceaccount.yaml
+++ b/deploy/charts/trust-manager/templates/serviceaccount.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ include "trust-manager.name" . }}
   namespace: {{ include "trust-manager.namespace" . }}
   labels:
-{{ include "trust-manager.labels" . | indent 4 }}
+    {{- include "trust-manager.labels" . | nindent 4 }}
 {{- with .Values.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}

--- a/deploy/charts/trust-manager/templates/webhook.yaml
+++ b/deploy/charts/trust-manager/templates/webhook.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{ include "trust-manager.namespace" . }}
   labels:
     app: {{ include "trust-manager.name" . }}
-{{ include "trust-manager.labels" . | indent 4 }}
+    {{- include "trust-manager.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.app.webhook.service.type }}
   ports:
@@ -25,7 +25,7 @@ metadata:
   name: {{ include "trust-manager.name" . }}
   labels:
     app: {{ include "trust-manager.name" . }}
-{{ include "trust-manager.labels" . | indent 4 }}
+    {{- include "trust-manager.labels" . | nindent 4 }}
   annotations:
     cert-manager.io/inject-ca-from: "{{ include "trust-manager.namespace" . }}/{{ include "trust-manager.name" . }}"
 


### PR DESCRIPTION
- use the same include label statements everywhere & same as cert-manager uses
- adds the common labels to the pod template
- adds the common labels to resource that were missing them