### PR TITLE
Fix passwordless pkcs12 files for Java

### DIFF
--- a/pkg/bundle/sync.go
+++ b/pkg/bundle/sync.go
@@ -320,7 +320,13 @@ func (e pkcs12Encoder) encode(trustBundle string) ([]byte, error) {
 		})
 	}
 
-	return pkcs12.LegacyRC2.EncodeTrustStoreEntries(entries, e.password)
+	encoder := pkcs12.LegacyRC2
+
+	if e.password == "" {
+		encoder = pkcs12.Passwordless
+	}
+
+	return encoder.EncodeTrustStoreEntries(entries, e.password)
 }
 
 // syncConfigMapTarget syncs the given data to the target ConfigMap in the given namespace.


### PR DESCRIPTION
In #296  user discovered that Java's keytool was unable to read PKCS#12 files generated by trust-manager which had no password set. We've not dug into why, but presumably keytool's implementation treats an empty password the same as a missing password somehow.

This wasn't caught in tests because our PKCS#12 library can parse the resulting files just fine.

By changing to use the "passwordless" encoder when no password is present, we can create files which both our tests and keytool can read. It's possible that some other tools can't handle the passwordless encoder and could break, but Java is (anecdotally) what we'd expect to be the largest consumer of PKCS#12 trust stores, so we'll optimise for that.

No test is provided here because keytool requires a JRE and it feels like too much to add a JRE to our test environment just for this. Instead, I've attached [fixed-pkcs12.zip](https://github.com/cert-manager/trust-manager/files/14406187/fixed-pkcs12.zip) which contains examples of fixed PKCS#12 files created using this branch. The password for the password-protected example is `abc123`

Closes #296