### PR TITLE
Set a size limit on emptyDir

### DIFF
--- a/deploy/charts/trust-manager/templates/deployment.yaml
+++ b/deploy/charts/trust-manager/templates/deployment.yaml
@@ -124,7 +124,8 @@ spec:
       {{- end }}
       volumes:
       - name: packages
-        emptyDir: {}
+        emptyDir:
+          sizeLimit: 50M
       - name: tls
         secret:
           defaultMode: 420


### PR DESCRIPTION
This helps to avoid disk exhaustion attack; 50MB seems to be a reasonable level to start at