### PR TITLE
Production readiness Helm chart tweaks

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -428,7 +428,7 @@ Additional labels to add to the ServiceMonitor.
 
 Enable or disable the PodDisruptionBudget resource.  
   
-This prevents downtime during voluntary disruptions such as during a Node upgrade. For example, the PodDisruptionBudget will block `kubectl drain` if it is used on the Node where the only remaining cert-manager  
+This prevents downtime during voluntary disruptions such as during a Node upgrade. For example, the PodDisruptionBudget will block `kubectl drain` if it is used on the Node where the only remaining trust-manager  
 Pod is currently running.
 #### **podDisruptionBudget.minAvailable** ~ `unknown`
 

--- a/deploy/charts/trust-manager/templates/NOTES.txt
+++ b/deploy/charts/trust-manager/templates/NOTES.txt
@@ -1,3 +1,11 @@
+{{- if (lt (int .Values.replicaCount) 2) }}
+⚠️  WARNING: Consider increasing the Helm value `replicaCount` to 2 if you require high availability.
+{{- end }}
+
+{{- if (not .Values.podDisruptionBudget.enabled) }}
+⚠️  WARNING: Consider setting the Helm value `podDisruptionBudget.enabled` to true if you require high availability.
+{{- end }}
+
 trust-manager {{ .Chart.AppVersion }} has been deployed successfully!
 
 {{- if .Values.defaultPackage.enabled }}

--- a/deploy/charts/trust-manager/values.schema.json
+++ b/deploy/charts/trust-manager/values.schema.json
@@ -530,7 +530,7 @@
       "additionalProperties": false
     },
     "helm-values.podDisruptionBudget.enabled": {
-      "description": "Enable or disable the PodDisruptionBudget resource.\n\nThis prevents downtime during voluntary disruptions such as during a Node upgrade. For example, the PodDisruptionBudget will block `kubectl drain` if it is used on the Node where the only remaining cert-manager\nPod is currently running.",
+      "description": "Enable or disable the PodDisruptionBudget resource.\n\nThis prevents downtime during voluntary disruptions such as during a Node upgrade. For example, the PodDisruptionBudget will block `kubectl drain` if it is used on the Node where the only remaining trust-manager\nPod is currently running.",
       "type": "boolean",
       "default": false
     },

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -185,7 +185,7 @@ app:
     port: 6443
     # Timeout of webhook HTTP request.
     timeoutSeconds: 5
-    
+
     service:
       # The type of Kubernetes Service used by the Webhook.
       type: ClusterIP
@@ -237,7 +237,7 @@ podDisruptionBudget:
   #
   # This prevents downtime during voluntary disruptions such as during a Node upgrade.
   # For example, the PodDisruptionBudget will block `kubectl drain`
-  # if it is used on the Node where the only remaining cert-manager
+  # if it is used on the Node where the only remaining trust-manager
   # Pod is currently running.
   enabled: false
 


### PR DESCRIPTION
* Fixed a copy-paste typo in the help text for podDisruptionBudget
* Added some warnings to the NOTES.txt file to tell the user about production readiness values they should use


### Warnings
```sh
$ helm upgrade trust-manager bin/chart/trust-manager-v1.14.1.tgz --install --create-namespace --namespace venafi --values values.yaml
Release "trust-manager" has been upgraded. Happy Helming!
NAME: trust-manager
LAST DEPLOYED: Wed Feb 28 17:15:33 2024
NAMESPACE: venafi
STATUS: deployed
REVISION: 3
TEST SUITE: None
NOTES:
⚠️  WARNING: Consider increasing the Helm value `replicaCount` to 2 if you require high availability.
⚠️  WARNING: Consider setting the Helm value `podDisruptionBudget.enabled` to true if you require high availability.

trust-manager v1.14.1 has been deployed successfully!
Your installation includes a default CA package, using the following
default CA package image:

quay.io/jetstack/cert-manager-package-debian:20210119.0

It's imperative that you keep the default CA package image up to date.
To find out more about securely running trust-manager and to get started
with creating your first bundle, check out the documentation on the
cert-manager website:

https://cert-manager.io/docs/projects/trust-manager/
```

### Testing

Given a 3-node cluster with two "platform" nodes with cert-manager and trust-manager deployed with PDBs, I was able to drain node 1, and see node 1 Pods rescheduled to node 2

```sh
$ kubectl drain kind-worker --ignore-daemonsets --delete-emptydir-data
node/kind-worker cordoned
Warning: ignoring DaemonSet-managed Pods: kube-system/kindnet-7hdl6, kube-system/kube-proxy-t8s8h
evicting pod venafi/trust-manager-54dbf9c6c-9p5ns
evicting pod venafi/cert-manager-cainjector-7d77c9dbb9-6rfjw
evicting pod venafi/cert-manager-7d8db8dc5d-wff2z
evicting pod venafi/cert-manager-webhook-b5f7b7977-n7p7j
pod/cert-manager-7d8db8dc5d-wff2z evicted
pod/trust-manager-54dbf9c6c-9p5ns evicted
pod/cert-manager-cainjector-7d77c9dbb9-6rfjw evicted
pod/cert-manager-webhook-b5f7b7977-n7p7j evicted
node/kind-worker drained
```

 then I attempted to drain node 2 and see that it was blocked until I uncordoned node1

```sh
$ kubectl drain kind-worker2 --ignore-daemonsets --delete-emptydir-data
node/kind-worker2 cordoned
Warning: ignoring DaemonSet-managed Pods: kube-system/kindnet-7tcnd, kube-system/kube-proxy-6w9n2
evicting pod venafi/cert-manager-7d8db8dc5d-c8rvp
evicting pod venafi/cert-manager-webhook-b5f7b7977-xmhzk
evicting pod venafi/cert-manager-cainjector-7d77c9dbb9-2fc9j
evicting pod venafi/cert-manager-7d8db8dc5d-56vvt
evicting pod venafi/trust-manager-54dbf9c6c-zvggr
evicting pod venafi/trust-manager-54dbf9c6c-5pngb
evicting pod venafi/cert-manager-cainjector-7d77c9dbb9-fwkfm
evicting pod venafi/cert-manager-webhook-b5f7b7977-cwmz6
evicting pod venafi/cert-manager-webhook-b5f7b7977-dljlg
error when evicting pods/"cert-manager-cainjector-7d77c9dbb9-fwkfm" -n "venafi" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
error when evicting pods/"cert-manager-7d8db8dc5d-56vvt" -n "venafi" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
error when evicting pods/"cert-manager-webhook-b5f7b7977-xmhzk" -n "venafi" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
error when evicting pods/"trust-manager-54dbf9c6c-zvggr" -n "venafi" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
pod/cert-manager-webhook-b5f7b7977-cwmz6 evicted
pod/cert-manager-cainjector-7d77c9dbb9-2fc9j evicted
pod/cert-manager-7d8db8dc5d-c8rvp evicted
pod/trust-manager-54dbf9c6c-5pngb evicted
pod/cert-manager-webhook-b5f7b7977-dljlg evicted
evicting pod venafi/cert-manager-cainjector-7d77c9dbb9-fwkfm
error when evicting pods/"cert-manager-cainjector-7d77c9dbb9-fwkfm" -n "venafi" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
evicting pod venafi/cert-manager-webhook-b5f7b7977-xmhzk
evicting pod venafi/cert-manager-7d8db8dc5d-56vvt
error when evicting pods/"cert-manager-7d8db8dc5d-56vvt" -n "venafi" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
error when evicting pods/"cert-manager-webhook-b5f7b7977-xmhzk" -n "venafi" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
evicting pod venafi/trust-manager-54dbf9c6c-zvggr
error when evicting pods/"trust-manager-54dbf9c6c-zvggr" -n "venafi" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
evicting pod venafi/cert-manager-cainjector-7d77c9dbb9-fwkfm
error when evicting pods/"cert-manager-cainjector-7d77c9dbb9-fwkfm" -n "venafi" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
evicting pod venafi/cert-manager-7d8db8dc5d-56vvt
evicting pod venafi/cert-manager-webhook-b5f7b7977-xmhzk
error when evicting pods/"cert-manager-webhook-b5f7b7977-xmhzk" -n "venafi" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
error when evicting pods/"cert-manager-7d8db8dc5d-56vvt" -n "venafi" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
evicting pod venafi/trust-manager-54dbf9c6c-zvggr
error when evicting pods/"trust-manager-54dbf9c6c-zvggr" -n "venafi" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
evicting pod venafi/cert-manager-cainjector-7d77c9dbb9-fwkfm
evicting pod venafi/cert-manager-webhook-b5f7b7977-xmhzk
evicting pod venafi/cert-manager-7d8db8dc5d-56vvt
error when evicting pods/"cert-manager-webhook-b5f7b7977-xmhzk" -n "venafi" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
evicting pod venafi/trust-manager-54dbf9c6c-zvggr
error when evicting pods/"trust-manager-54dbf9c6c-zvggr" -n "venafi" (will retry after 5s): Cannot evict pod as it would violate the pod's disruption budget.
pod/cert-manager-cainjector-7d77c9dbb9-fwkfm evicted
pod/cert-manager-7d8db8dc5d-56vvt evicted
evicting pod venafi/cert-manager-webhook-b5f7b7977-xmhzk
evicting pod venafi/trust-manager-54dbf9c6c-zvggr
pod/cert-manager-webhook-b5f7b7977-xmhzk evicted
pod/trust-manager-54dbf9c6c-zvggr evicted
node/kind-worker2 drained
```