### PR TITLE
Bump toolchain to latest to address CVE-2024-24783

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/cert-manager/trust-manager
 
 go 1.22
 
-toolchain go1.22.0
+toolchain go1.22.1
 
 require (
 	github.com/go-logr/logr v1.4.1


### PR DESCRIPTION
We should build with 1.22.1 for a release since we use the 1.22 tag: https://github.com/cert-manager/trust-manager/blob/b4a5572d0d17f6b7d80f43aee5b4254bd476d9e8/Dockerfile#L16

This will ensure we're using the 1.22.1 toolchain though!