### PR TITLE
Simplify managed fields upgrade from CSA to SSA

### DIFF
--- a/deploy/charts/trust-manager/templates/clusterrole.yaml
+++ b/deploy/charts/trust-manager/templates/clusterrole.yaml
@@ -9,7 +9,8 @@ rules:
   - "trust.cert-manager.io"
   resources:
   - "bundles"
-  verbs: ["get", "list", "watch"]
+  # We also need patch here so we can perform migrations from old CSA to SSA.
+  verbs: ["get", "list", "watch", "patch"]
 
 # Permissions to update finalizers are required for trust-manager to work correctly
 # on OpenShift, even though we don't directly use finalizers at the time of writing
@@ -26,18 +27,10 @@ rules:
   verbs: ["patch"]
 
 - apiGroups:
-  - "trust.cert-manager.io"
-  resources:
-  - "bundles"
-  # We also need update here so we can perform migrations from old CSA to SSA.
-  verbs: ["update"]
-
-- apiGroups:
   - ""
   resources:
   - "configmaps"
-  # We also need update here so we can perform migrations from old CSA to SSA.
-  verbs: ["get", "list", "create", "update", "patch", "watch", "delete"]
+  verbs: ["get", "list", "create", "patch", "watch", "delete"]
 - apiGroups:
   - ""
   resources:

--- a/pkg/bundle/controller.go
+++ b/pkg/bundle/controller.go
@@ -51,22 +51,12 @@ func AddBundleController(
 	opts Options,
 	targetCache cache.Cache,
 ) error {
-	directClient, err := client.New(mgr.GetConfig(), client.Options{
-		HTTPClient: mgr.GetHTTPClient(),
-		Scheme:     mgr.GetScheme(),
-		Mapper:     mgr.GetRESTMapper(),
-	})
-	if err != nil {
-		return fmt.Errorf("failed to create direct client: %w", err)
-	}
-
 	b := &bundle{
-		client:       mgr.GetClient(),
-		directClient: directClient,
-		targetCache:  targetCache,
-		recorder:     mgr.GetEventRecorderFor("bundles"),
-		clock:        clock.RealClock{},
-		Options:      opts,
+		client:      mgr.GetClient(),
+		targetCache: targetCache,
+		recorder:    mgr.GetEventRecorderFor("bundles"),
+		clock:       clock.RealClock{},
+		Options:     opts,
 	}
 
 	if b.Options.DefaultPackageLocation != "" {


### PR DESCRIPTION
This PR simplifies the upgrade from CSA to SSA by using the helper provided by upstream Kubernetes and also used by `kubectl`. There is a theoretical change in behavior when upgrading after this PR, since the helper does not take the target configmap key into account when upgrading. Which means there could potentially be another operator/controller using the c/r regression field manager. I still think the simplification of code and RBAC is worth this minor risk.