### PR TITLE
Allow replicaCount to be set to int or string

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -25,13 +25,35 @@ This option makes it so that the "helm.sh/resource-policy": keep annotation is a
 (Certificates, Issuers, ...) will be removed too by the garbage collector.
 ### Trust Manager
 
-#### **replicaCount** ~ `number`
+#### **replicaCount** ~ `number,string,null`
 > Default value:
 > ```yaml
 > 1
 > ```
 
-The number of replicas of trust-manager to run.
+The number of replicas of trust-manager to run.  
+  
+For example:  
+ Use integer to set a fixed number of replicas
+
+```yaml
+replicaCount: 2
+```
+
+Use null, if you want to omit the replicas field and use the Kubernetes default value.
+
+```yaml
+replicaCount: null
+```
+
+Use a string if you want to insert a variable for post-processing of the rendered template.
+
+```yaml
+replicaCount: ${REPLICAS_OVERRIDE:=3}
+```
+
+
+
 #### **namespace** ~ `string`
 > Default value:
 > ```yaml

--- a/deploy/charts/trust-manager/values.schema.json
+++ b/deploy/charts/trust-manager/values.schema.json
@@ -560,8 +560,7 @@
       "default": ""
     },
     "helm-values.replicaCount": {
-      "description": "The number of replicas of trust-manager to run.",
-      "type": "number",
+      "description": "The number of replicas of trust-manager to run.\n\nFor example:\n Use integer to set a fixed number of replicas\nreplicaCount: 2\nUse null, if you want to omit the replicas field and use the Kubernetes default value.\nreplicaCount: null\nUse a string if you want to insert a variable for post-processing of the rendered template.\nreplicaCount: ${REPLICAS_OVERRIDE:=3}",
       "default": 1
     },
     "helm-values.resources": {

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -15,6 +15,18 @@ crds:
 # +docs:section=Trust Manager
 
 # The number of replicas of trust-manager to run.
+#
+# For example:
+#  Use integer to set a fixed number of replicas
+#   replicaCount: 2
+#
+#  Use null, if you want to omit the replicas field and use the Kubernetes default value.
+#   replicaCount: null
+#
+#  Use a string if you want to insert a variable for post-processing of the rendered template.
+#   replicaCount: ${REPLICAS_OVERRIDE:=3}
+#
+# +docs:type=number,string,null
 replicaCount: 1
 
 # The namespace to install trust-manager into.


### PR DESCRIPTION
This fix is more or less a copy of https://github.com/cert-manager/approver-policy/pull/388 fixing the same issue here. We are using FluxCD post-build substitutions to override replicas in our single-node review clusters. This used to work fine but broke with version 0.9.0 of trust-manager. Many thanks to @wallrj for finding an acceptable solution to this.

````
$ helm template deploy/charts/trust-manager/ --set replicaCount='${REPLICAS_OVERRIDE:=3}' | grep replicas
  replicas: ${REPLICAS_OVERRIDE:=3}
````

````
$ helm template deploy/charts/trust-manager/ --set replicaCount=2 | grep replicas
  replicas: 2
````

/cc @SgtCoDFish @wallrj @inteon 