### PR TITLE
[release-0.9] Bump builder go to 1.22

### DIFF
--- a/trust-packages/debian/Containerfile
+++ b/trust-packages/debian/Containerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.21 as gobuild
+FROM --platform=$BUILDPLATFORM docker.io/library/golang:1.22 as gobuild
 
 ARG GOPROXY
 ARG TARGETARCH


### PR DESCRIPTION
Backport of #321 (reqiured for other PRs to pass CI)