### PR TITLE
Fix Bundle target print column

### DIFF
--- a/deploy/charts/trust-manager/templates/trust.cert-manager.io_bundles.yaml
+++ b/deploy/charts/trust-manager/templates/trust.cert-manager.io_bundles.yaml
@@ -19,9 +19,13 @@ spec:
   scope: Cluster
   versions:
     - additionalPrinterColumns:
-        - description: Bundle Target Key
-          jsonPath: .status.target.configMap.key
-          name: Target
+        - description: Bundle ConfigMap Target Key
+          jsonPath: .spec.target.configMap.key
+          name: ConfigMap Target
+          type: string
+        - description: Bundle Secret Target Key
+          jsonPath: .spec.target.secret.key
+          name: Secret Target
           type: string
         - description: Bundle has been synced
           jsonPath: .status.conditions[?(@.type == "Synced")].status

--- a/deploy/crds/trust.cert-manager.io_bundles.yaml
+++ b/deploy/crds/trust.cert-manager.io_bundles.yaml
@@ -14,9 +14,13 @@ spec:
   scope: Cluster
   versions:
     - additionalPrinterColumns:
-        - description: Bundle Target Key
-          jsonPath: .status.target.configMap.key
-          name: Target
+        - description: Bundle ConfigMap Target Key
+          jsonPath: .spec.target.configMap.key
+          name: ConfigMap Target
+          type: string
+        - description: Bundle Secret Target Key
+          jsonPath: .spec.target.secret.key
+          name: Secret Target
           type: string
         - description: Bundle has been synced
           jsonPath: .status.conditions[?(@.type == "Synced")].status

--- a/pkg/apis/trust/v1alpha1/types_bundle.go
+++ b/pkg/apis/trust/v1alpha1/types_bundle.go
@@ -26,7 +26,8 @@ var BundleLabelKey = "trust.cert-manager.io/bundle"
 var BundleHashAnnotationKey = "trust.cert-manager.io/hash"
 
 // +kubebuilder:object:root=true
-// +kubebuilder:printcolumn:name="Target",type="string",JSONPath=".status.target.configMap.key",description="Bundle Target Key"
+// +kubebuilder:printcolumn:name="ConfigMap Target",type="string",JSONPath=".spec.target.configMap.key",description="Bundle ConfigMap Target Key"
+// +kubebuilder:printcolumn:name="Secret Target",type="string",JSONPath=".spec.target.secret.key",description="Bundle Secret Target Key"
 // +kubebuilder:printcolumn:name="Synced",type="string",JSONPath=`.status.conditions[?(@.type == "Synced")].status`,description="Bundle has been synced"
 // +kubebuilder:printcolumn:name="Reason",type="string",JSONPath=`.status.conditions[?(@.type == "Synced")].reason`,description="Reason Bundle has Synced status"
 // +kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Timestamp Bundle was created"


### PR DESCRIPTION
It seems like the print columns were left behind when removing the copy of `target` under `status` in https://github.com/cert-manager/trust-manager/pull/230 and when introducing the opt-in for secrets as targets in https://github.com/cert-manager/trust-manager/pull/193.

I tried to figure out a better way to show _either_ the configmap or the secret target key, but I don't know if JSONPath supports it. But a bundle could potentially specify both a configmap and secret as target, so two columns are probably best anyway.

Fixes https://github.com/cert-manager/trust-manager/issues/343