### PR TITLE
Replace deprecated klog.New in tests with ktesting.NewTestContext

### DIFF
--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -32,7 +32,7 @@ import (
 	coreapplyconfig "k8s.io/client-go/applyconfigurations/core/v1"
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/klog/v2/klogr"
+	"k8s.io/klog/v2/ktesting"
 	fakeclock "k8s.io/utils/clock/testing"
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -1302,13 +1302,14 @@ func Test_Reconcile(t *testing.T) {
 				resourcePatches []interface{}
 			)
 
+			log, ctx := ktesting.NewTestContext(t)
 			b := &bundle{
 				client:      fakeclient,
 				targetCache: fakeclient,
 				recorder:    fakerecorder,
 				clock:       fixedclock,
 				Options: Options{
-					Log:                  klogr.New(),
+					Log:                  log,
 					Namespace:            trustNamespace,
 					SecretTargetsEnabled: !test.disableSecretTargets,
 					FilterExpiredCerts:   true,
@@ -1325,7 +1326,7 @@ func Test_Reconcile(t *testing.T) {
 			if test.configureDefaultPackage {
 				b.defaultPackage = testDefaultPackage.Clone()
 			}
-			resp, result, err := b.reconcileBundle(context.TODO(), ctrl.Request{NamespacedName: types.NamespacedName{Name: bundleName}})
+			resp, result, err := b.reconcileBundle(ctx, ctrl.Request{NamespacedName: types.NamespacedName{Name: bundleName}})
 			if (err != nil) != test.expError {
 				t.Errorf("unexpected error, exp=%t got=%v", test.expError, err)
 			}

--- a/pkg/bundle/sync_test.go
+++ b/pkg/bundle/sync_test.go
@@ -35,7 +35,7 @@ import (
 	coreapplyconfig "k8s.io/client-go/applyconfigurations/core/v1"
 	metav1applyconfig "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/client-go/tools/record"
-	"k8s.io/klog/v2/klogr"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/ptr"
 	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/structured-merge-diff/fieldpath"
@@ -642,7 +642,8 @@ func Test_syncConfigMapTarget(t *testing.T) {
 				resolvedBundle.binaryData[pkcs12Key] = pkcs12Data
 			}
 
-			needsUpdate, err := b.syncConfigMapTarget(context.TODO(), klogr.New(), &trustapi.Bundle{
+			log, ctx := ktesting.NewTestContext(t)
+			needsUpdate, err := b.syncConfigMapTarget(ctx, log, &trustapi.Bundle{
 				ObjectMeta: metav1.ObjectMeta{Name: bundleName},
 				Spec:       spec,
 			}, bundleName, test.namespace.Name, resolvedBundle, test.shouldExist)
@@ -1261,7 +1262,8 @@ func Test_syncSecretTarget(t *testing.T) {
 				resolvedBundle.binaryData[pkcs12Key] = pkcs12Data
 			}
 
-			needsUpdate, err := b.syncSecretTarget(context.TODO(), klogr.New(), &trustapi.Bundle{
+			log, ctx := ktesting.NewTestContext(t)
+			needsUpdate, err := b.syncSecretTarget(ctx, log, &trustapi.Bundle{
 				ObjectMeta: metav1.ObjectMeta{Name: bundleName},
 				Spec:       spec,
 			}, bundleName, test.namespace.Name, resolvedBundle, test.shouldExist)

--- a/pkg/webhook/validation_test.go
+++ b/pkg/webhook/validation_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package webhook
 
 import (
-	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -25,7 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
-	"k8s.io/klog/v2/klogr"
+	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
@@ -395,8 +394,9 @@ func Test_validate(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := &validator{log: klogr.New()}
-			gotWarnings, gotErr := v.validate(context.TODO(), test.bundle)
+			log, ctx := ktesting.NewTestContext(t)
+			v := &validator{log: log}
+			gotWarnings, gotErr := v.validate(ctx, test.bundle)
 			if test.expErr == nil && gotErr != nil {
 				t.Errorf("got an unexpected error: %v", gotErr)
 			} else if test.expErr != nil && (gotErr == nil || *test.expErr != gotErr.Error()) {
@@ -447,8 +447,9 @@ func Test_validate_update(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			v := &validator{log: klogr.New()}
-			gotWarnings, gotErr := v.ValidateUpdate(context.TODO(), test.oldBundle, test.newBundle)
+			log, ctx := ktesting.NewTestContext(t)
+			v := &validator{log: log}
+			gotWarnings, gotErr := v.ValidateUpdate(ctx, test.oldBundle, test.newBundle)
 			if test.expErr == nil && gotErr != nil {
 				t.Errorf("got an unexpected error: %v", gotErr)
 			} else if test.expErr != nil && (gotErr == nil || *test.expErr != gotErr.Error()) {


### PR DESCRIPTION
The function [klogr,New](https://pkg.go.dev/k8s.io/klog/v2/klogr#New) has been deprecated. Instead of migrating to the suggested replacement, I propose to use [ktesting.NewTestContext](https://pkg.go.dev/k8s.io/klog/v2@v2.120.1/ktesting#NewTestContext) in tests instead - which is already in use in this project.

For trust-manager (main) I would suggest migrating to the relatively new GO stdlib log (slog) - with a target to address https://github.com/cert-manager/trust-manager/issues/282. I will try to do this in a follow up PR.