### PR TITLE
Add support for JSON logging format

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -297,6 +297,13 @@ topologySpreadConstraints:
 > ```
 
 Whether to filter expired certificates from the trust bundle.
+#### **app.logFormat** ~ `string`
+> Default value:
+> ```yaml
+> text
+> ```
+
+The format of trust-manager logging. Accepted values are text or json.
 #### **app.logLevel** ~ `number`
 > Default value:
 > ```yaml

--- a/deploy/charts/trust-manager/templates/deployment.yaml
+++ b/deploy/charts/trust-manager/templates/deployment.yaml
@@ -67,6 +67,7 @@ spec:
           initialDelaySeconds: 3
           periodSeconds: 7
         args:
+          - "--log-format={{.Values.app.logFormat}}"
           - "--log-level={{.Values.app.logLevel}}"
           - "--metrics-port={{.Values.app.metrics.port}}"
           - "--readiness-probe-port={{.Values.app.readinessProbe.port}}"

--- a/deploy/charts/trust-manager/values.schema.json
+++ b/deploy/charts/trust-manager/values.schema.json
@@ -74,6 +74,9 @@
     "helm-values.app": {
       "additionalProperties": false,
       "properties": {
+        "logFormat": {
+          "$ref": "#/$defs/helm-values.app.logFormat"
+        },
         "logLevel": {
           "$ref": "#/$defs/helm-values.app.logLevel"
         },
@@ -100,6 +103,11 @@
         }
       },
       "type": "object"
+    },
+    "helm-values.app.logFormat": {
+      "default": "text",
+      "description": "The format of trust-manager logging. Accepted values are text or json.",
+      "type": "string"
     },
     "helm-values.app.logLevel": {
       "default": 1,

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -176,6 +176,9 @@ filterExpiredCertificates:
   enabled: false
 
 app:
+  # The format of trust-manager logging. Accepted values are text or json.
+  logFormat: text
+
   # The verbosity of trust-manager logging. This takes a value from 1-5, with the higher value being more verbose.
   logLevel: 1
 


### PR DESCRIPTION
In this PR I propose to introduce slog.Handler as a backend for logr (and klog) - as documented [here](https://github.com/go-logr/logr?tab=readme-ov-file#using-a-sloghandler-as-backend-for-logr).

I am doing a minimal change in this PR where my primary goal is to add support for a structured log format (ref.  https://github.com/cert-manager/trust-manager/issues/282).

**NOTE**: This might break for some users, depending on if/how they parse trust-manager log output. I cannot imagine the slog text format (the new default) is the same as the deprecated klog format. We always try to avoid breaking changes, but I think a change is required here anyway - since the currently used klog format is deprecated.

Fixes https://github.com/cert-manager/trust-manager/issues/282