### PR TITLE
fix use of system trust bundle when building package

### DIFF
--- a/make/debian-trust-package-fetch.sh
+++ b/make/debian-trust-package-fetch.sh
@@ -134,7 +134,7 @@ if [[ "$ACTION" == "latest" && "$installed_version" == "$target_ca_certificates_
 fi
 
 echo "{}" | jq \
-	--rawfile bundle /etc/ssl/certs/ca-certificates.crt \
+	--rawfile bundle $TMP_DIR/ca-certificates.crt \
 	--arg name "cert-manager-debian" \
 	--arg version "$installed_version$version_suffix" \
 	'.name = $name | .bundle = $bundle | .version = $version' \


### PR DESCRIPTION
I missed this during the review of #195 . I shouldn't have missed such a huge bug - my bad!

Today this script uses the _system's_ trust-bundle, not the one from the container.

It breaks development on all platforms which aren't Debian-based linux (e.g. macOS, RHEL, etc)

It shouldn't lead to an incorrect bundle being pushed upstream and we're safe there I think, but it needs fixing as a matter of urgency in case our workflows or the bundle changes in the future.