### PR TITLE
Deduplicate code for syncing target configmaps and secrets

### DIFF
--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -246,7 +246,11 @@ func (b *bundle) reconcileBundle(ctx context.Context, req ctrl.Request) (result 
 	}
 
 	// Find all old existing target resources.
-	for _, kind := range []targetKind{configMapTarget, secretTarget} {
+	targetKinds := []targetKind{configMapTarget}
+	if b.Options.SecretTargetsEnabled {
+		targetKinds = append(targetKinds, secretTarget)
+	}
+	for _, kind := range targetKinds {
 		targetLog := log.WithValues("kind", kind)
 
 		targetList := &metav1.PartialObjectMetadataList{


### PR DESCRIPTION
Currently, the code for syncing target configmaps and secrets is separate - even if the logic should be the same. This doesn't make it tempting to add new features to bundle targets. In this PR I made an attempt to duplicate some of the code. We could probably do more, but let me know what you think before I spend more time on this! ☺️ 