### PR TITLE
Use the go version specified in the Makefile tools module

### DIFF
--- a/.github/workflows/debian-trust-package-release.yaml
+++ b/.github/workflows/debian-trust-package-release.yaml
@@ -17,6 +17,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - id: go-version
+        run: |
+          make print-go-version >> "$GITHUB_OUTPUT"
+
       - uses: docker/login-action@v3
         with:
           registry: quay.io
@@ -25,7 +29,7 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: ${{ steps.go-version.outputs.result }}
 
       - id: release
         run: make release-debian-trust-package

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,6 +19,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - id: go-version
+        run: |
+          make print-go-version >> "$GITHUB_OUTPUT"
+
       - uses: docker/login-action@v3
         with:
           registry: quay.io
@@ -27,15 +31,16 @@ jobs:
 
       - uses: actions/setup-go@v5
         with:
-          go-version-file: go.mod
+          go-version: ${{ steps.go-version.outputs.result }}
 
       - id: release
         run: make release
 
       - uses: actions/upload-artifact@v4
         with:
-          name: trust-manager-${{ env.VERSION }}.tgz
+          name: ${{ steps.release.outputs.RELEASE_HELM_CHART_NAME }}-${{ steps.release.outputs.RELEASE_HELM_CHART_VERSION }}.tgz
           path: ${{ steps.release.outputs.RELEASE_HELM_CHART_TAR }}
+          if-no-files-found: error
 
     outputs:
       RELEASE_OCI_MANAGER_IMAGE: ${{ steps.release.outputs.RELEASE_OCI_MANAGER_IMAGE }}
@@ -67,18 +72,18 @@ jobs:
       - id: chart_download
         uses: actions/download-artifact@v4
         with:
-          name: trust-manager-${{ env.VERSION }}.tgz
+          name: ${{ needs.build_images.outputs.RELEASE_HELM_CHART_NAME }}-${{ needs.build_images.outputs.RELEASE_HELM_CHART_VERSION }}.tgz
 
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release create "$VERSION" \
             --repo="$GITHUB_REPOSITORY" \
-            --title="${GITHUB_REPOSITORY#*/} ${VERSION#v}" \
+            --title="${VERSION}" \
             --draft \
             --verify-tag \
             --notes-file .notes-file
           
           gh release upload "$VERSION" \
             --repo="$GITHUB_REPOSITORY" \
-            "${{ steps.chart_download.outputs.download-path }}/trust-manager-$VERSION.tgz"
+            "${{ steps.chart_download.outputs.download-path }}/${{ needs.build_images.outputs.RELEASE_HELM_CHART_NAME }}-${{ needs.build_images.outputs.RELEASE_HELM_CHART_VERSION }}.tgz"


### PR DESCRIPTION
We noticed that the go version used to release trust-manager v0.10.0 did not match the go version specified in the `tools` Makefile module.

This is due to an oversight in the release.yaml GH action definition. This PR updates those yaml files to match the logic we are using in other projects (eg. approver-policy, see https://github.com/cert-manager/approver-policy/blob/main/.github/workflows/release.yaml).