### PR TITLE
re-add support for s390x

### DIFF
--- a/make/00_mod.mk
+++ b/make/00_mod.mk
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+oci_platforms := linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
+
 include make/00_debian_version.mk
 
 repo_name := github.com/cert-manager/trust-manager


### PR DESCRIPTION
In #315 we added support for s390x, but this was unintentionally removed in v0.10.0 due to the makefile modules changes. This PR re-adds support for s390x.

It depended on a new base image being built for s390x (via https://github.com/cert-manager/base-images/pull/5), which wasn't previously available.

Confirmed locally that `make oci-build-manager oci-build-package_debian` builds s390x versions of both.