### PR TITLE
refactor: establish target.Reconciler

### DIFF
--- a/pkg/bundle/controller.go
+++ b/pkg/bundle/controller.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
 	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
+	"github.com/cert-manager/trust-manager/pkg/bundle/internal/target"
 	"github.com/cert-manager/trust-manager/pkg/fspkg"
 )
 
@@ -52,11 +53,14 @@ func AddBundleController(
 	targetCache cache.Cache,
 ) error {
 	b := &bundle{
-		client:      mgr.GetClient(),
-		targetCache: targetCache,
-		recorder:    mgr.GetEventRecorderFor("bundles"),
-		clock:       clock.RealClock{},
-		Options:     opts,
+		client:   mgr.GetClient(),
+		recorder: mgr.GetEventRecorderFor("bundles"),
+		clock:    clock.RealClock{},
+		Options:  opts,
+		targetReconciler: &target.Reconciler{
+			Client: mgr.GetClient(),
+			Cache:  targetCache,
+		},
 	}
 
 	if b.Options.DefaultPackageLocation != "" {

--- a/pkg/bundle/source.go
+++ b/pkg/bundle/source.go
@@ -28,6 +28,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
+	"github.com/cert-manager/trust-manager/pkg/bundle/internal/target"
 	"github.com/cert-manager/trust-manager/pkg/util"
 )
 
@@ -39,7 +40,7 @@ type selectsNothingError struct{ error }
 // certificate data from concatenating all the sources together, binary data for any additional formats and
 // any metadata from the sources which needs to be exposed on the Bundle resource's status field.
 type bundleData struct {
-	targetData
+	target.Data
 
 	defaultCAPackageStringID string
 }
@@ -100,7 +101,7 @@ func (b *bundle) buildSourceBundle(ctx context.Context, sources []trustapi.Bundl
 		return bundleData{}, fmt.Errorf("couldn't find any valid certificates in bundle")
 	}
 
-	if err := resolvedBundle.populate(certPool, formats); err != nil {
+	if err := resolvedBundle.Data.Populate(certPool, formats); err != nil {
 		return bundleData{}, err
 	}
 

--- a/pkg/bundle/source_test.go
+++ b/pkg/bundle/source_test.go
@@ -39,6 +39,12 @@ import (
 	"github.com/cert-manager/trust-manager/test/dummy"
 )
 
+const (
+	jksKey    = "trust.jks"
+	pkcs12Key = "trust.p12"
+	data      = dummy.TestCertificate1
+)
+
 func Test_buildSourceBundle(t *testing.T) {
 	tests := map[string]struct {
 		sources          []trustapi.BundleSource
@@ -369,11 +375,11 @@ func Test_buildSourceBundle(t *testing.T) {
 				t.Errorf("unexpected notFoundError, exp=%t got=%v", test.expNotFoundError, err)
 			}
 
-			if resolvedBundle.data != test.expData {
-				t.Errorf("unexpected data, exp=%q got=%q", test.expData, resolvedBundle.data)
+			if resolvedBundle.Data.Data != test.expData {
+				t.Errorf("unexpected data, exp=%q got=%q", test.expData, resolvedBundle.Data.Data)
 			}
 
-			binData, jksExists := resolvedBundle.binaryData[jksKey]
+			binData, jksExists := resolvedBundle.Data.BinaryData[jksKey]
 			assert.Equal(t, test.expJKS, jksExists)
 
 			if test.expJKS {
@@ -397,7 +403,7 @@ func Test_buildSourceBundle(t *testing.T) {
 				assert.Equal(t, p.Bytes, cert.Certificate.Content)
 			}
 
-			binData, pkcs12Exists := resolvedBundle.binaryData[pkcs12Key]
+			binData, pkcs12Exists := resolvedBundle.Data.BinaryData[pkcs12Key]
 			assert.Equal(t, test.expPKCS12, pkcs12Exists)
 
 			if test.expPKCS12 {


### PR DESCRIPTION
This is a major refactor of the bundle target area. The main motivation is to prepare the grounds for https://github.com/cert-manager/trust-manager/issues/58 and https://github.com/cert-manager/trust-manager/issues/222.

~~The refactoring became larger because I had to move some fields and functions to avoid circular package dependencies. I would be happy to split these changes out in pre-PRs if desired.~~ Multiple pre-PRs merged now.