### PR TITLE
refactor: move default truststore passwords to API

### DIFF
--- a/docs/api/api.md
+++ b/docs/api/api.md
@@ -58,10 +58,19 @@ import "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
 
 ## Constants
 
-<a name="BundleConditionSynced"></a>
+<a name="DefaultJKSPassword"></a>
 
 ```go
 const (
+    // DefaultJKSPassword is the default password that Java uses; it's a Java convention to use this exact password.
+    // Since we're not storing anything secret in the JKS files we generate, this password is not a meaningful security measure
+    // but seems often to be expected by applications consuming JKS files
+    DefaultJKSPassword = "changeit"
+    // DefaultPKCS12Password is the empty string, that will create a password-less PKCS12 truststore.
+    // Password-less PKCS is the new default Java truststore from Java 18.
+    // By password-less, it means the certificates are not encrypted, and it contains no MacData for integrity check.
+    DefaultPKCS12Password = ""
+
     // BundleConditionSynced indicates that the Bundle has successfully synced
     // all source bundle data to the Bundle target in all Namespaces.
     BundleConditionSynced string = "Synced"

--- a/pkg/apis/trust/v1alpha1/types_bundle.go
+++ b/pkg/apis/trust/v1alpha1/types_bundle.go
@@ -239,6 +239,15 @@ type BundleCondition struct {
 }
 
 const (
+	// DefaultJKSPassword is the default password that Java uses; it's a Java convention to use this exact password.
+	// Since we're not storing anything secret in the JKS files we generate, this password is not a meaningful security measure
+	// but seems often to be expected by applications consuming JKS files
+	DefaultJKSPassword = "changeit"
+	// DefaultPKCS12Password is the empty string, that will create a password-less PKCS12 truststore.
+	// Password-less PKCS is the new default Java truststore from Java 18.
+	// By password-less, it means the certificates are not encrypted, and it contains no MacData for integrity check.
+	DefaultPKCS12Password = ""
+
 	// BundleConditionSynced indicates that the Bundle has successfully synced
 	// all source bundle data to the Bundle target in all Namespaces.
 	BundleConditionSynced string = "Synced"

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -48,7 +48,7 @@ import (
 func testEncodeJKS(t *testing.T, data string) []byte {
 	t.Helper()
 
-	encoded, err := jksEncoder{password: DefaultJKSPassword}.encode(data)
+	encoded, err := jksEncoder{password: trustapi.DefaultJKSPassword}.encode(data)
 	if err != nil {
 		t.Error(err)
 	}
@@ -493,7 +493,7 @@ func Test_Reconcile(t *testing.T) {
 							KeySelector: trustapi.KeySelector{
 								Key: "target.jks",
 							},
-							Password: ptr.To(DefaultJKSPassword),
+							Password: ptr.To(trustapi.DefaultJKSPassword),
 						},
 					}),
 				)},
@@ -566,7 +566,7 @@ func Test_Reconcile(t *testing.T) {
 							KeySelector: trustapi.KeySelector{
 								Key: "target.jks",
 							},
-							Password: ptr.To(DefaultJKSPassword),
+							Password: ptr.To(trustapi.DefaultJKSPassword),
 						},
 					}),
 				),

--- a/pkg/bundle/source.go
+++ b/pkg/bundle/source.go
@@ -37,17 +37,6 @@ import (
 	"github.com/cert-manager/trust-manager/pkg/util"
 )
 
-const (
-	// DefaultJKSPassword is the default password that Java uses; it's a Java convention to use this exact password.
-	// Since we're not storing anything secret in the JKS files we generate, this password is not a meaningful security measure
-	// but seems often to be expected by applications consuming JKS files
-	DefaultJKSPassword = "changeit"
-	// DefaultPKCS12Password is the empty string, that will create a password-less PKCS12 truststore.
-	// Password-less PKCS is the new default Java truststore from Java 18.
-	// By password-less, it means the certificates are not encrypted, and it contains no MacData for integrity check.
-	DefaultPKCS12Password = ""
-)
-
 type notFoundError struct{ error }
 
 // bundleData holds the result of a call to buildSourceBundle. It contains the resulting PEM-encoded

--- a/pkg/bundle/source_test.go
+++ b/pkg/bundle/source_test.go
@@ -230,7 +230,7 @@ func Test_buildSourceBundle(t *testing.T) {
 					KeySelector: trustapi.KeySelector{
 						Key: jksKey,
 					},
-					Password: ptr.To(DefaultJKSPassword),
+					Password: ptr.To(trustapi.DefaultJKSPassword),
 				},
 			},
 			objects: []runtime.Object{&corev1.ConfigMap{
@@ -269,7 +269,7 @@ func Test_buildSourceBundle(t *testing.T) {
 					KeySelector: trustapi.KeySelector{
 						Key: pkcs12Key,
 					},
-					Password: ptr.To(DefaultPKCS12Password),
+					Password: ptr.To(trustapi.DefaultPKCS12Password),
 				},
 			},
 			objects: []runtime.Object{&corev1.ConfigMap{
@@ -326,14 +326,14 @@ func Test_buildSourceBundle(t *testing.T) {
 				if test.expPassword != nil {
 					password = *test.expPassword
 				} else {
-					password = DefaultJKSPassword
+					password = trustapi.DefaultJKSPassword
 				}
 			}
 			if test.expPKCS12 {
 				if test.expPassword != nil {
 					password = *test.expPassword
 				} else {
-					password = DefaultPKCS12Password
+					password = trustapi.DefaultPKCS12Password
 				}
 			}
 
@@ -398,7 +398,7 @@ func Test_encodeJKSAliases(t *testing.T) {
 	// Using different dummy certs would allow this test to pass but wouldn't actually test anything useful!
 	bundle := dummy.JoinCerts(dummy.TestCertificate1, dummy.TestCertificate2)
 
-	jksFile, err := jksEncoder{password: DefaultJKSPassword}.encode(bundle)
+	jksFile, err := jksEncoder{password: trustapi.DefaultJKSPassword}.encode(bundle)
 	if err != nil {
 		t.Fatalf("didn't expect an error but got: %s", err)
 	}
@@ -407,7 +407,7 @@ func Test_encodeJKSAliases(t *testing.T) {
 
 	ks := jks.New()
 
-	err = ks.Load(reader, []byte(DefaultJKSPassword))
+	err = ks.Load(reader, []byte(trustapi.DefaultJKSPassword))
 	if err != nil {
 		t.Fatalf("failed to parse generated JKS file: %s", err)
 	}

--- a/test/integration/bundle/suite.go
+++ b/test/integration/bundle/suite.go
@@ -352,7 +352,7 @@ var _ = Describe("Integration", func() {
 			jksData, exists := configMap.BinaryData["myfile.jks"]
 			Expect(exists).To(BeTrue(), "should find an entry called myfile.jks")
 
-			Expect(testenv.CheckJKSFileSynced(jksData, bundle.DefaultJKSPassword, dummy.DefaultJoinedCerts())).ToNot(HaveOccurred())
+			Expect(testenv.CheckJKSFileSynced(jksData, trustapi.DefaultJKSPassword, dummy.DefaultJoinedCerts())).ToNot(HaveOccurred())
 		}
 	})
 


### PR DESCRIPTION
This minor refactoring is extracted from https://github.com/cert-manager/trust-manager/pull/378, and the motivation is to solve circular package dependency issues.

Moving the constants to the API package seems like a good option, as the default passwords used for truststores is highly user-facing.

/cc @inteon 