### PR TITLE
Fix example of topologySpreadConstraints to reference trust-manager

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -287,8 +287,7 @@ topologySpreadConstraints:
   whenUnsatisfiable: ScheduleAnyway
   labelSelector:
     matchLabels:
-      app.kubernetes.io/instance: cert-manager
-      app.kubernetes.io/component: controller
+      app.kubernetes.io/name: trust-manager
 ```
 #### **filterExpiredCertificates.enabled** ~ `bool`
 > Default value:

--- a/deploy/charts/trust-manager/values.schema.json
+++ b/deploy/charts/trust-manager/values.schema.json
@@ -696,7 +696,7 @@
     },
     "helm-values.topologySpreadConstraints": {
       "default": [],
-      "description": "List of Kubernetes TopologySpreadConstraints. For more information, see [TopologySpreadConstraint v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#topologyspreadconstraint-v1-core).\nFor example:\ntopologySpreadConstraints:\n- maxSkew: 2\n  topologyKey: topology.kubernetes.io/zone\n  whenUnsatisfiable: ScheduleAnyway\n  labelSelector:\n    matchLabels:\n      app.kubernetes.io/instance: cert-manager\n      app.kubernetes.io/component: controller",
+      "description": "List of Kubernetes TopologySpreadConstraints. For more information, see [TopologySpreadConstraint v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#topologyspreadconstraint-v1-core).\nFor example:\ntopologySpreadConstraints:\n- maxSkew: 2\n  topologyKey: topology.kubernetes.io/zone\n  whenUnsatisfiable: ScheduleAnyway\n  labelSelector:\n    matchLabels:\n      app.kubernetes.io/name: trust-manager",
       "items": {},
       "type": "array"
     }

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -167,8 +167,7 @@ tolerations: []
 #     whenUnsatisfiable: ScheduleAnyway
 #     labelSelector:
 #       matchLabels:
-#         app.kubernetes.io/instance: cert-manager
-#         app.kubernetes.io/component: controller
+#         app.kubernetes.io/name: trust-manager
 topologySpreadConstraints: []
 
 filterExpiredCertificates:


### PR DESCRIPTION
Spotted by @wallrj in https://github.com/cert-manager/istio-csr/pull/365 