### PR TITLE
refactor: fix name and import alias collisions

### DIFF
--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -37,7 +37,7 @@ import (
 	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
 	"github.com/cert-manager/trust-manager/pkg/bundle/internal/truststore"
@@ -1292,7 +1292,7 @@ func Test_Reconcile(t *testing.T) {
 		test := test
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			fakeclient := fakeclient.NewClientBuilder().
+			fakeClient := fake.NewClientBuilder().
 				WithScheme(trustapi.GlobalScheme).
 				WithObjects(deepCopyArray(test.existingConfigMaps)...).
 				WithObjects(deepCopyArray(test.existingBundles)...).
@@ -1302,7 +1302,7 @@ func Test_Reconcile(t *testing.T) {
 				WithStatusSubresource(deepCopyArray(test.existingBundles)...).
 				Build()
 
-			fakerecorder := record.NewFakeRecorder(1)
+			fakeRecorder := record.NewFakeRecorder(1)
 
 			var (
 				logMutex        sync.Mutex
@@ -1311,9 +1311,9 @@ func Test_Reconcile(t *testing.T) {
 
 			log, ctx := ktesting.NewTestContext(t)
 			b := &bundle{
-				client:      fakeclient,
-				targetCache: fakeclient,
-				recorder:    fakerecorder,
+				client:      fakeClient,
+				targetCache: fakeClient,
+				recorder:    fakeRecorder,
 				clock:       fixedclock,
 				Options: Options{
 					Log:                  log,
@@ -1346,7 +1346,7 @@ func Test_Reconcile(t *testing.T) {
 
 			var event string
 			select {
-			case event = <-fakerecorder.Events:
+			case event = <-fakeRecorder.Events:
 			default:
 			}
 			assert.Equal(t, test.expEvent, event)

--- a/pkg/bundle/source_test.go
+++ b/pkg/bundle/source_test.go
@@ -307,13 +307,13 @@ func Test_buildSourceBundle(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			fakeclient := fake.NewClientBuilder().
+			fakeClient := fake.NewClientBuilder().
 				WithRuntimeObjects(test.objects...).
 				WithScheme(trustapi.GlobalScheme).
 				Build()
 
 			b := &bundle{
-				client: fakeclient,
+				client: fakeClient,
 				defaultPackage: &fspkg.Package{
 					Name:    "testpkg",
 					Version: "123",

--- a/pkg/bundle/target_test.go
+++ b/pkg/bundle/target_test.go
@@ -32,7 +32,7 @@ import (
 	"k8s.io/client-go/tools/record"
 	"k8s.io/klog/v2/ktesting"
 	"k8s.io/utils/ptr"
-	fakeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/structured-merge-diff/fieldpath"
 
 	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
@@ -584,14 +584,14 @@ func Test_syncConfigMapTarget(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			clientBuilder := fakeclient.NewClientBuilder().
+			clientBuilder := fake.NewClientBuilder().
 				WithScheme(trustapi.GlobalScheme)
 			if test.object != nil {
 				clientBuilder.WithRuntimeObjects(test.object)
 			}
 
-			fakeclient := clientBuilder.Build()
-			fakerecorder := record.NewFakeRecorder(1)
+			fakeClient := clientBuilder.Build()
+			fakeRecorder := record.NewFakeRecorder(1)
 
 			var (
 				logMutex        sync.Mutex
@@ -599,9 +599,9 @@ func Test_syncConfigMapTarget(t *testing.T) {
 			)
 
 			b := &bundle{
-				client:      fakeclient,
-				targetCache: fakeclient,
-				recorder:    fakerecorder,
+				client:      fakeClient,
+				targetCache: fakeClient,
+				recorder:    fakeRecorder,
 				patchResourceOverwrite: func(ctx context.Context, obj interface{}) error {
 					logMutex.Lock()
 					defer logMutex.Unlock()
@@ -689,7 +689,7 @@ func Test_syncConfigMapTarget(t *testing.T) {
 
 			var event string
 			select {
-			case event = <-fakerecorder.Events:
+			case event = <-fakeRecorder.Events:
 			default:
 			}
 			assert.Equal(t, test.expEvent, event)
@@ -1204,7 +1204,7 @@ func Test_syncSecretTarget(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			clientBuilder := fakeclient.NewClientBuilder().
+			clientBuilder := fake.NewClientBuilder().
 				WithScheme(trustapi.GlobalScheme)
 			if test.object != nil {
 				clientBuilder.WithRuntimeObjects(test.object)

--- a/test/env/data.go
+++ b/test/env/data.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
-	"github.com/cert-manager/trust-manager/pkg/bundle"
+	bundlectrl "github.com/cert-manager/trust-manager/pkg/bundle"
 	"github.com/cert-manager/trust-manager/pkg/util"
 	"github.com/cert-manager/trust-manager/test/dummy"
 
@@ -78,7 +78,7 @@ func DefaultTrustData() TestData {
 
 // newTestBundle creates a new Bundle in the API using the input test data.
 // Returns the create Bundle object.
-func newTestBundle(ctx context.Context, cl client.Client, opts bundle.Options, td TestData, targetType string) *trustapi.Bundle {
+func newTestBundle(ctx context.Context, cl client.Client, opts bundlectrl.Options, td TestData, targetType string) *trustapi.Bundle {
 	By("creating trust Bundle")
 
 	configMap := corev1.ConfigMap{
@@ -148,13 +148,13 @@ func newTestBundle(ctx context.Context, cl client.Client, opts bundle.Options, t
 
 // NewTestBundleSecretTarget creates a new Bundle in the API using the input test data.
 // Returns the create Bundle object.
-func NewTestBundleSecretTarget(ctx context.Context, cl client.Client, opts bundle.Options, td TestData) *trustapi.Bundle {
+func NewTestBundleSecretTarget(ctx context.Context, cl client.Client, opts bundlectrl.Options, td TestData) *trustapi.Bundle {
 	return newTestBundle(ctx, cl, opts, td, "Secret")
 }
 
 // newTestBundleConfigMapTarget creates a new Bundle in the API using the input test data with target set to ConfigMap.
 // Returns the create Bundle object.
-func NewTestBundleConfigMapTarget(ctx context.Context, cl client.Client, opts bundle.Options, td TestData) *trustapi.Bundle {
+func NewTestBundleConfigMapTarget(ctx context.Context, cl client.Client, opts bundlectrl.Options, td TestData) *trustapi.Bundle {
 	return newTestBundle(ctx, cl, opts, td, "ConfigMap")
 }
 


### PR DESCRIPTION
When an identifier name collides with an import alias, my IDE gets confused, making me less effective when coding. This PR fixes all current collisions, but I wonder if golangci-lint might have a linter that can detect this? For one of the collisions, I found it more convenient to fix this by extracting a reusable function avoiding duplicated code.