### PR TITLE
refactor: dedicated target data struct

### DIFF
--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -303,12 +303,12 @@ func (b *bundle) reconcileBundle(ctx context.Context, req ctrl.Request) (result 
 
 		if target.Kind == configMapTarget {
 			syncFunc = func(targetLog logr.Logger, target targetResource, shouldExist bool) (bool, error) {
-				return b.syncConfigMapTarget(ctx, targetLog, &bundle, target.Name, target.Namespace, resolvedBundle, shouldExist)
+				return b.syncConfigMapTarget(ctx, targetLog, &bundle, target.Name, target.Namespace, resolvedBundle.targetData, shouldExist)
 			}
 		}
 		if target.Kind == secretTarget {
 			syncFunc = func(targetLog logr.Logger, target targetResource, shouldExist bool) (bool, error) {
-				return b.syncSecretTarget(ctx, targetLog, &bundle, target.Name, target.Namespace, resolvedBundle, shouldExist)
+				return b.syncSecretTarget(ctx, targetLog, &bundle, target.Name, target.Namespace, resolvedBundle.targetData, shouldExist)
 			}
 		}
 

--- a/pkg/bundle/target_test.go
+++ b/pkg/bundle/target_test.go
@@ -617,7 +617,7 @@ func Test_syncConfigMapTarget(t *testing.T) {
 					AdditionalFormats: &trustapi.AdditionalFormats{},
 				},
 			}
-			resolvedBundle := bundleData{data: data, binaryData: make(map[string][]byte)}
+			resolvedBundle := targetData{data: data, binaryData: make(map[string][]byte)}
 			if test.withJKS {
 				spec.Target.AdditionalFormats.JKS = &trustapi.JKS{
 					KeySelector: trustapi.KeySelector{
@@ -1237,7 +1237,7 @@ func Test_syncSecretTarget(t *testing.T) {
 					AdditionalFormats: &trustapi.AdditionalFormats{},
 				},
 			}
-			resolvedBundle := bundleData{data: data, binaryData: make(map[string][]byte)}
+			resolvedBundle := targetData{data: data, binaryData: make(map[string][]byte)}
 			if test.withJKS {
 				spec.Target.AdditionalFormats.JKS = &trustapi.JKS{
 					KeySelector: trustapi.KeySelector{


### PR DESCRIPTION
Extracted from https://github.com/cert-manager/trust-manager/pull/378, and obtaining a cleaner separation of source and target is required to move the target logic to a dedicated package.