### PR TITLE
feat(helm): Allow external TLS provider for webhook

### DIFF
--- a/deploy/charts/trust-manager/templates/certificate.yaml
+++ b/deploy/charts/trust-manager/templates/certificate.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.app.webhook.tls.helmCert.enabled -}}
+{{- if .Values.app.webhook.tls.certManager.enabled -}}
 
 apiVersion: cert-manager.io/v1
 kind: Issuer

--- a/deploy/charts/trust-manager/templates/webhook.yaml
+++ b/deploy/charts/trust-manager/templates/webhook.yaml
@@ -1,5 +1,5 @@
-{{- if and .Values.app.webhook.tls.helmCert.enabled .Values.app.webhook.tls.approverPolicy.enabled -}}
-{{- fail "cannot set .app.webhook.tls.helmCert.enabled and .Values.app.webhook.tls.approverPolicy.enabled" }}
+{{- if and .Values.app.webhook.tls.helmCert.enabled .Values.app.webhook.tls.certManager.enabled -}}
+{{- fail "cannot set .app.webhook.tls.helmCert.enabled and .Values.app.webhook.tls.certManager.enabled" }}
 {{- end -}}
 
 {{- /*
@@ -55,6 +55,10 @@ metadata:
   labels:
     app: {{ include "trust-manager.name" . }}
     {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- if .Values.app.webhook.service.annotations }}
+  annotations:
+  {{- tpl (toYaml .Values.app.webhook.service.annotations) . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.app.webhook.service.type }}
   {{- if .Values.app.webhook.service.ipFamilyPolicy }}
@@ -83,10 +87,15 @@ metadata:
   labels:
     app: {{ include "trust-manager.name" . }}
     {{- include "trust-manager.labels" . | nindent 4 }}
-{{ if not .Values.app.webhook.tls.helmCert.enabled }}
+{{ if or .Values.app.webhook.tls.certManager.enabled .Values.app.webhook.annotations }}
   annotations:
+    {{- if .Values.app.webhook.tls.certManager.enabled }}
     cert-manager.io/inject-ca-from: "{{ include "trust-manager.namespace" . }}/{{ include "trust-manager.name" . }}"
 {{ end }}
+    {{- if .Values.app.webhook.annotations }}
+    {{- tpl (toYaml .Values.app.webhook.annotations) . | nindent 4 }}
+    {{- end }}
+    {{- end }}
 
 webhooks:
   - name: trust.cert-manager.io

--- a/deploy/charts/trust-manager/values.schema.json
+++ b/deploy/charts/trust-manager/values.schema.json
@@ -1,7 +1,9 @@
 {
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$ref": "#/$defs/helm-values",
   "$defs": {
     "helm-values": {
-      "additionalProperties": false,
+      "type": "object",
       "properties": {
         "affinity": {
           "$ref": "#/$defs/helm-values.affinity"
@@ -64,15 +66,15 @@
           "$ref": "#/$defs/helm-values.topologySpreadConstraints"
         }
       },
-      "type": "object"
+      "additionalProperties": false
     },
     "helm-values.affinity": {
-      "default": {},
       "description": "Kubernetes Affinity. For more information, see [Affinity v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#affinity-v1-core).\nFor example:\naffinity:\n  nodeAffinity:\n   requiredDuringSchedulingIgnoredDuringExecution:\n     nodeSelectorTerms:\n     - matchExpressions:\n       - key: foo.bar.com/role\n         operator: In\n         values:\n         - master",
-      "type": "object"
+      "type": "object",
+      "default": {}
     },
     "helm-values.app": {
-      "additionalProperties": false,
+      "type": "object",
       "properties": {
         "leaderElection": {
           "$ref": "#/$defs/helm-values.app.leaderElection"
@@ -105,10 +107,10 @@
           "$ref": "#/$defs/helm-values.app.webhook"
         }
       },
-      "type": "object"
+      "additionalProperties": false
     },
     "helm-values.app.leaderElection": {
-      "additionalProperties": false,
+      "type": "object",
       "properties": {
         "leaseDuration": {
           "$ref": "#/$defs/helm-values.app.leaderElection.leaseDuration"
@@ -117,30 +119,30 @@
           "$ref": "#/$defs/helm-values.app.leaderElection.renewDeadline"
         }
       },
-      "type": "object"
+      "additionalProperties": false
     },
     "helm-values.app.leaderElection.leaseDuration": {
-      "default": "15s",
       "description": "The duration that non-leader candidates will wait to force acquire leadership. The default should be sufficient in a healthy cluster but can be slightly increased to prevent trust-manager from restart-looping when the API server is overloaded.",
-      "type": "string"
+      "type": "string",
+      "default": "15s"
     },
     "helm-values.app.leaderElection.renewDeadline": {
-      "default": "10s",
       "description": "The interval between attempts by the acting leader to renew a leadership slot before it stops leading. This MUST be less than or equal to the lease duration. The default should be sufficient in a healthy cluster but can be slightly increased to prevent trust-manager from restart-looping when the API server is overloaded.",
-      "type": "string"
+      "type": "string",
+      "default": "10s"
     },
     "helm-values.app.logFormat": {
-      "default": "text",
       "description": "The format of trust-manager logging. Accepted values are text or json.",
-      "type": "string"
+      "type": "string",
+      "default": "text"
     },
     "helm-values.app.logLevel": {
-      "default": 1,
       "description": "The verbosity of trust-manager logging. This takes a value from 1-5, with the higher value being more verbose.",
-      "type": "number"
+      "type": "number",
+      "default": 1
     },
     "helm-values.app.metrics": {
-      "additionalProperties": false,
+      "type": "object",
       "properties": {
         "port": {
           "$ref": "#/$defs/helm-values.app.metrics.port"
@@ -149,15 +151,15 @@
           "$ref": "#/$defs/helm-values.app.metrics.service"
         }
       },
-      "type": "object"
+      "additionalProperties": false
     },
     "helm-values.app.metrics.port": {
-      "default": 9402,
       "description": "The port for exposing Prometheus metrics on 0.0.0.0 on path '/metrics'.",
-      "type": "number"
+      "type": "number",
+      "default": 9402
     },
     "helm-values.app.metrics.service": {
-      "additionalProperties": false,
+      "type": "object",
       "properties": {
         "enabled": {
           "$ref": "#/$defs/helm-values.app.metrics.service.enabled"
@@ -175,26 +177,26 @@
           "$ref": "#/$defs/helm-values.app.metrics.service.type"
         }
       },
-      "type": "object"
+      "additionalProperties": false
     },
     "helm-values.app.metrics.service.enabled": {
-      "default": true,
       "description": "Create a Service resource to expose the metrics endpoint.",
-      "type": "boolean"
+      "type": "boolean",
+      "default": true
     },
     "helm-values.app.metrics.service.ipFamilies": {
-      "default": [],
       "description": "Sets the families that should be supported and the order in which they should be applied to ClusterIP as well. Can be IPv4 and/or IPv6.",
-      "items": {},
-      "type": "array"
+      "type": "array",
+      "default": [],
+      "items": {}
     },
     "helm-values.app.metrics.service.ipFamilyPolicy": {
-      "default": "",
       "description": "Set the ip family policy to configure dual-stack see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services)",
-      "type": "string"
+      "type": "string",
+      "default": ""
     },
     "helm-values.app.metrics.service.servicemonitor": {
-      "additionalProperties": false,
+      "type": "object",
       "properties": {
         "enabled": {
           "$ref": "#/$defs/helm-values.app.metrics.service.servicemonitor.enabled"
@@ -212,50 +214,50 @@
           "$ref": "#/$defs/helm-values.app.metrics.service.servicemonitor.scrapeTimeout"
         }
       },
-      "type": "object"
+      "additionalProperties": false
     },
     "helm-values.app.metrics.service.servicemonitor.enabled": {
-      "default": false,
       "description": "Create a Prometheus ServiceMonitor for trust-manager.",
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     },
     "helm-values.app.metrics.service.servicemonitor.interval": {
-      "default": "10s",
       "description": "The interval to scrape the metrics.",
-      "type": "string"
+      "type": "string",
+      "default": "10s"
     },
     "helm-values.app.metrics.service.servicemonitor.labels": {
-      "default": {},
       "description": "Additional labels to add to the ServiceMonitor.",
-      "type": "object"
+      "type": "object",
+      "default": {}
     },
     "helm-values.app.metrics.service.servicemonitor.prometheusInstance": {
-      "default": "default",
       "description": "Sets the value of the \"prometheus\" label on the ServiceMonitor. This is used so that separate Prometheus instances can select different ServiceMonitors using labels.",
-      "type": "string"
+      "type": "string",
+      "default": "default"
     },
     "helm-values.app.metrics.service.servicemonitor.scrapeTimeout": {
-      "default": "5s",
       "description": "The timeout for a metrics scrape.",
-      "type": "string"
+      "type": "string",
+      "default": "5s"
     },
     "helm-values.app.metrics.service.type": {
-      "default": "ClusterIP",
       "description": "The Service type to expose metrics.",
-      "type": "string"
+      "type": "string",
+      "default": "ClusterIP"
     },
     "helm-values.app.podAnnotations": {
-      "default": {},
       "description": "Pod annotations to add to trust-manager pods.",
-      "type": "object"
+      "type": "object",
+      "default": {}
     },
     "helm-values.app.podLabels": {
-      "default": {},
       "description": "Pod labels to add to trust-manager pods.",
-      "type": "object"
+      "type": "object",
+      "default": {}
     },
     "helm-values.app.readinessProbe": {
-      "additionalProperties": false,
+      "type": "object",
       "properties": {
         "path": {
           "$ref": "#/$defs/helm-values.app.readinessProbe.path"
@@ -264,49 +266,52 @@
           "$ref": "#/$defs/helm-values.app.readinessProbe.port"
         }
       },
-      "type": "object"
+      "additionalProperties": false
     },
     "helm-values.app.readinessProbe.path": {
-      "default": "/readyz",
       "description": "The path on which to expose the trust-manager HTTP readiness probe using the default network interface.",
-      "type": "string"
+      "type": "string",
+      "default": "/readyz"
     },
     "helm-values.app.readinessProbe.port": {
-      "default": 6060,
       "description": "The container port on which to expose the trust-manager HTTP readiness probe using the default network interface.",
-      "type": "number"
+      "type": "number",
+      "default": 6060
     },
     "helm-values.app.securityContext": {
-      "additionalProperties": false,
+      "type": "object",
       "properties": {
         "seccompProfileEnabled": {
           "$ref": "#/$defs/helm-values.app.securityContext.seccompProfileEnabled"
         }
       },
-      "type": "object"
+      "additionalProperties": false
     },
     "helm-values.app.securityContext.seccompProfileEnabled": {
-      "default": true,
       "description": "If false, disables the default seccomp profile, which might be required to run on certain platforms.",
-      "type": "boolean"
+      "type": "boolean",
+      "default": true
     },
     "helm-values.app.trust": {
-      "additionalProperties": false,
+      "type": "object",
       "properties": {
         "namespace": {
           "$ref": "#/$defs/helm-values.app.trust.namespace"
         }
       },
-      "type": "object"
+      "additionalProperties": false
     },
     "helm-values.app.trust.namespace": {
-      "default": "cert-manager",
       "description": "The namespace used as the trust source. Note that the namespace _must_ exist before installing trust-manager.",
-      "type": "string"
+      "type": "string",
+      "default": "cert-manager"
     },
     "helm-values.app.webhook": {
-      "additionalProperties": false,
+      "type": "object",
       "properties": {
+        "annotations": {
+          "$ref": "#/$defs/helm-values.app.webhook.annotations"
+        },
         "host": {
           "$ref": "#/$defs/helm-values.app.webhook.host"
         },
@@ -326,26 +331,34 @@
           "$ref": "#/$defs/helm-values.app.webhook.tls"
         }
       },
-      "type": "object"
+      "additionalProperties": false
+    },
+    "helm-values.app.webhook.annotations": {
+      "description": "Annotations for the ValidatingWebhookConfiguration",
+      "type": "object",
+      "default": {}
     },
     "helm-values.app.webhook.host": {
-      "default": "0.0.0.0",
       "description": "Host that the webhook listens on.",
-      "type": "string"
+      "type": "string",
+      "default": "0.0.0.0"
     },
     "helm-values.app.webhook.hostNetwork": {
-      "default": false,
       "description": "This value specifies if the app should be started in hostNetwork mode. It is required for use in some managed Kubernetes clusters (such as AWS EKS) with custom CNI.",
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     },
     "helm-values.app.webhook.port": {
-      "default": 6443,
       "description": "Port that the webhook listens on.",
-      "type": "number"
+      "type": "number",
+      "default": 6443
     },
     "helm-values.app.webhook.service": {
-      "additionalProperties": false,
+      "type": "object",
       "properties": {
+        "annotations": {
+          "$ref": "#/$defs/helm-values.app.webhook.service.annotations"
+        },
         "ipFamilies": {
           "$ref": "#/$defs/helm-values.app.webhook.service.ipFamilies"
         },
@@ -359,47 +372,55 @@
           "$ref": "#/$defs/helm-values.app.webhook.service.type"
         }
       },
-      "type": "object"
+      "additionalProperties": false
+    },
+    "helm-values.app.webhook.service.annotations": {
+      "description": "Annotations for the webhook service",
+      "type": "object",
+      "default": {}
     },
     "helm-values.app.webhook.service.ipFamilies": {
-      "default": [],
       "description": "Sets the families that should be supported and the order in which they should be applied to ClusterIP as well. Can be IPv4 and/or IPv6.",
-      "items": {},
-      "type": "array"
+      "type": "array",
+      "default": [],
+      "items": {}
     },
     "helm-values.app.webhook.service.ipFamilyPolicy": {
-      "default": "",
       "description": "Set the ip family policy to configure dual-stack see [Configure dual-stack](https://kubernetes.io/docs/concepts/services-networking/dual-stack/#services)",
-      "type": "string"
+      "type": "string",
+      "default": ""
     },
     "helm-values.app.webhook.service.nodePort": {
       "description": "The nodePort set on the Service used by the webhook.",
       "type": "number"
     },
     "helm-values.app.webhook.service.type": {
-      "default": "ClusterIP",
       "description": "The type of Kubernetes Service used by the Webhook.",
-      "type": "string"
+      "type": "string",
+      "default": "ClusterIP"
     },
     "helm-values.app.webhook.timeoutSeconds": {
-      "default": 5,
       "description": "Timeout of webhook HTTP request.",
-      "type": "number"
+      "type": "number",
+      "default": 5
     },
     "helm-values.app.webhook.tls": {
-      "additionalProperties": false,
+      "type": "object",
       "properties": {
         "approverPolicy": {
           "$ref": "#/$defs/helm-values.app.webhook.tls.approverPolicy"
+        },
+        "certManager": {
+          "$ref": "#/$defs/helm-values.app.webhook.tls.certManager"
         },
         "helmCert": {
           "$ref": "#/$defs/helm-values.app.webhook.tls.helmCert"
         }
       },
-      "type": "object"
+      "additionalProperties": false
     },
     "helm-values.app.webhook.tls.approverPolicy": {
-      "additionalProperties": false,
+      "type": "object",
       "properties": {
         "certManagerNamespace": {
           "$ref": "#/$defs/helm-values.app.webhook.tls.approverPolicy.certManagerNamespace"
@@ -411,44 +432,58 @@
           "$ref": "#/$defs/helm-values.app.webhook.tls.approverPolicy.enabled"
         }
       },
-      "type": "object"
+      "additionalProperties": false
     },
     "helm-values.app.webhook.tls.approverPolicy.certManagerNamespace": {
-      "default": "cert-manager",
       "description": "The namespace in which cert-manager was installed. Only used if `app.webhook.tls.approverPolicy.enabled` is true.",
-      "type": "string"
+      "type": "string",
+      "default": "cert-manager"
     },
     "helm-values.app.webhook.tls.approverPolicy.certManagerServiceAccount": {
-      "default": "cert-manager",
       "description": "The name of cert-manager's Service Account. Only used if `app.webhook.tls.approverPolicy.enabled` is true.",
-      "type": "string"
+      "type": "string",
+      "default": "cert-manager"
     },
     "helm-values.app.webhook.tls.approverPolicy.enabled": {
-      "default": false,
       "description": "Whether to create an approver-policy CertificateRequestPolicy allowing auto-approval of the trust-manager webhook certificate. If you have approver-policy installed, you almost certainly want to enable this.",
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
+    },
+    "helm-values.app.webhook.tls.certManager": {
+      "type": "object",
+      "properties": {
+        "enabled": {
+          "$ref": "#/$defs/helm-values.app.webhook.tls.certManager.enabled"
+        }
+      },
+      "additionalProperties": false
+    },
+    "helm-values.app.webhook.tls.certManager.enabled": {
+      "description": "Wether to create certificates using cert-manager CRDs. Default way of generating certificates for the webhook",
+      "type": "boolean",
+      "default": true
     },
     "helm-values.app.webhook.tls.helmCert": {
-      "additionalProperties": false,
+      "type": "object",
       "properties": {
         "enabled": {
           "$ref": "#/$defs/helm-values.app.webhook.tls.helmCert.enabled"
         }
       },
-      "type": "object"
+      "additionalProperties": false
     },
     "helm-values.app.webhook.tls.helmCert.enabled": {
-      "default": false,
       "description": "Whether to issue a webhook cert using Helm, which removes the need to install cert-manager. Helm-issued certificates can be challenging to rotate and maintain, and the issued cert will have a duration of 10 years and be modified when trust-manager is updated. It's safer and easier to rely on cert-manager for issuing the webhook cert - avoid using Helm-generated certs in production.",
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     },
     "helm-values.commonLabels": {
-      "default": {},
       "description": "Labels to apply to all resources",
-      "type": "object"
+      "type": "object",
+      "default": {}
     },
     "helm-values.crds": {
-      "additionalProperties": false,
+      "type": "object",
       "properties": {
         "enabled": {
           "$ref": "#/$defs/helm-values.crds.enabled"
@@ -457,20 +492,20 @@
           "$ref": "#/$defs/helm-values.crds.keep"
         }
       },
-      "type": "object"
+      "additionalProperties": false
     },
     "helm-values.crds.enabled": {
-      "default": true,
       "description": "This option decides if the CRDs should be installed as part of the Helm installation.",
-      "type": "boolean"
+      "type": "boolean",
+      "default": true
     },
     "helm-values.crds.keep": {
-      "default": true,
       "description": "This option makes it so that the \"helm.sh/resource-policy\": keep annotation is added to the CRD. This will prevent Helm from uninstalling the CRD when the Helm release is uninstalled. WARNING: when the CRDs are removed, all cert-manager custom resources\n(Certificates, Issuers, ...) will be removed too by the garbage collector.",
-      "type": "boolean"
+      "type": "boolean",
+      "default": true
     },
     "helm-values.defaultPackage": {
-      "additionalProperties": false,
+      "type": "object",
       "properties": {
         "enabled": {
           "$ref": "#/$defs/helm-values.defaultPackage.enabled"
@@ -479,20 +514,20 @@
           "$ref": "#/$defs/helm-values.defaultPackage.resources"
         }
       },
-      "type": "object"
+      "additionalProperties": false
     },
     "helm-values.defaultPackage.enabled": {
-      "default": true,
       "description": "Whether to load the default trust package during pod initialization, and include it in main container args. This container enables the 'useDefaultCAs' source on Bundles.",
-      "type": "boolean"
+      "type": "boolean",
+      "default": true
     },
     "helm-values.defaultPackage.resources": {
-      "default": {},
       "description": "Kubernetes pod resource limits for default package init container.\n\nFor example:\nresources:\n  limits:\n    cpu: 100m\n    memory: 128Mi\n  requests:\n    cpu: 100m\n    memory: 128Mi",
-      "type": "object"
+      "type": "object",
+      "default": {}
     },
     "helm-values.defaultPackageImage": {
-      "additionalProperties": false,
+      "type": "object",
       "properties": {
         "digest": {
           "$ref": "#/$defs/helm-values.defaultPackageImage.digest"
@@ -510,50 +545,50 @@
           "$ref": "#/$defs/helm-values.defaultPackageImage.tag"
         }
       },
-      "type": "object"
+      "additionalProperties": false
     },
     "helm-values.defaultPackageImage.digest": {
       "description": "Target image digest. Override any tag, if set.\nFor example:\ndigest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20",
       "type": "string"
     },
     "helm-values.defaultPackageImage.pullPolicy": {
-      "default": "IfNotPresent",
       "description": "imagePullPolicy for the default package image.",
-      "type": "string"
+      "type": "string",
+      "default": "IfNotPresent"
     },
     "helm-values.defaultPackageImage.registry": {
       "description": "Target image registry. This value is prepended to the target image repository, if set.\nFor example:\nregistry: quay.io\nrepository: jetstack/cert-manager-package-debian",
       "type": "string"
     },
     "helm-values.defaultPackageImage.repository": {
-      "default": "quay.io/jetstack/cert-manager-package-debian",
       "description": "The repository for the default package image. This image enables the 'useDefaultCAs' source on Bundles.",
-      "type": "string"
+      "type": "string",
+      "default": "quay.io/jetstack/cert-manager-package-debian"
     },
     "helm-values.defaultPackageImage.tag": {
-      "default": "20210119.0",
       "description": "Override the image tag of the default package image. If no value is set, the chart's appVersion is used.",
-      "type": "string"
+      "type": "string",
+      "default": "20210119.0"
     },
     "helm-values.filterExpiredCertificates": {
-      "additionalProperties": false,
+      "type": "object",
       "properties": {
         "enabled": {
           "$ref": "#/$defs/helm-values.filterExpiredCertificates.enabled"
         }
       },
-      "type": "object"
+      "additionalProperties": false
     },
     "helm-values.filterExpiredCertificates.enabled": {
-      "default": false,
       "description": "Whether to filter expired certificates from the trust bundle.",
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     },
     "helm-values.global": {
       "description": "Global values shared across all (sub)charts"
     },
     "helm-values.image": {
-      "additionalProperties": false,
+      "type": "object",
       "properties": {
         "digest": {
           "$ref": "#/$defs/helm-values.image.digest"
@@ -571,54 +606,54 @@
           "$ref": "#/$defs/helm-values.image.tag"
         }
       },
-      "type": "object"
+      "additionalProperties": false
     },
     "helm-values.image.digest": {
       "description": "Target image digest. Override any tag, if set.\nFor example:\ndigest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20",
       "type": "string"
     },
     "helm-values.image.pullPolicy": {
-      "default": "IfNotPresent",
       "description": "Kubernetes imagePullPolicy on Deployment.",
-      "type": "string"
+      "type": "string",
+      "default": "IfNotPresent"
     },
     "helm-values.image.registry": {
       "description": "Target image registry. This value is prepended to the target image repository, if set.\nFor example:\nregistry: quay.io\nrepository: jetstack/trust-manager",
       "type": "string"
     },
     "helm-values.image.repository": {
-      "default": "quay.io/jetstack/trust-manager",
       "description": "Target image repository.",
-      "type": "string"
+      "type": "string",
+      "default": "quay.io/jetstack/trust-manager"
     },
     "helm-values.image.tag": {
       "description": "Override the image tag to deploy by setting this variable. If no value is set, the chart's appVersion is used.",
       "type": "string"
     },
     "helm-values.imagePullSecrets": {
-      "default": [],
       "description": "For Private docker registries, authentication is needed. Registry secrets are applied to the service account.",
-      "items": {},
-      "type": "array"
+      "type": "array",
+      "default": [],
+      "items": {}
     },
     "helm-values.nameOverride": {
-      "default": "",
-      "type": "string"
+      "type": "string",
+      "default": ""
     },
     "helm-values.namespace": {
-      "default": "",
       "description": "The namespace to install trust-manager into.\nIf not set, the namespace of the release is used.\nThis is helpful when installing trust-manager as a chart dependency (sub chart).",
-      "type": "string"
+      "type": "string",
+      "default": ""
     },
     "helm-values.nodeSelector": {
+      "description": "Configure the nodeSelector; defaults to any Linux node (trust-manager doesn't support Windows nodes)",
+      "type": "object",
       "default": {
         "kubernetes.io/os": "linux"
-      },
-      "description": "Configure the nodeSelector; defaults to any Linux node (trust-manager doesn't support Windows nodes)",
-      "type": "object"
+      }
     },
     "helm-values.podDisruptionBudget": {
-      "additionalProperties": false,
+      "type": "object",
       "properties": {
         "enabled": {
           "$ref": "#/$defs/helm-values.podDisruptionBudget.enabled"
@@ -630,12 +665,12 @@
           "$ref": "#/$defs/helm-values.podDisruptionBudget.minAvailable"
         }
       },
-      "type": "object"
+      "additionalProperties": false
     },
     "helm-values.podDisruptionBudget.enabled": {
-      "default": false,
       "description": "Enable or disable the PodDisruptionBudget resource.\n\nThis prevents downtime during voluntary disruptions such as during a Node upgrade. For example, the PodDisruptionBudget will block `kubectl drain` if it is used on the Node where the only remaining trust-manager\nPod is currently running.",
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     },
     "helm-values.podDisruptionBudget.maxUnavailable": {
       "description": "This configures the maximum unavailable pods for disruptions. It can either be set to an integer (e.g. 1) or a percentage value (e.g. 25%). it cannot be used if `minAvailable` is set."
@@ -644,21 +679,21 @@
       "description": "This configures the minimum available pods for disruptions. It can either be set to an integer (e.g. 1) or a percentage value (e.g. 25%).\nIt cannot be used if `maxUnavailable` is set."
     },
     "helm-values.priorityClassName": {
-      "default": "",
       "description": "Configure the priority class of the pod. For more information, see [PriorityClass](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/#priorityclass).",
-      "type": "string"
+      "type": "string",
+      "default": ""
     },
     "helm-values.replicaCount": {
-      "default": 1,
-      "description": "The number of replicas of trust-manager to run.\n\nFor example:\n Use integer to set a fixed number of replicas\nreplicaCount: 2\nUse null, if you want to omit the replicas field and use the Kubernetes default value.\nreplicaCount: null\nUse a string if you want to insert a variable for post-processing of the rendered template.\nreplicaCount: ${REPLICAS_OVERRIDE:=3}"
+      "description": "The number of replicas of trust-manager to run.\n\nFor example:\n Use integer to set a fixed number of replicas\nreplicaCount: 2\nUse null, if you want to omit the replicas field and use the Kubernetes default value.\nreplicaCount: null\nUse a string if you want to insert a variable for post-processing of the rendered template.\nreplicaCount: ${REPLICAS_OVERRIDE:=3}",
+      "default": 1
     },
     "helm-values.resources": {
-      "default": {},
       "description": "Kubernetes pod resource limits for trust.\n\nFor example:\nresources:\n  limits:\n    cpu: 100m\n    memory: 128Mi\n  requests:\n    cpu: 100m\n    memory: 128Mi",
-      "type": "object"
+      "type": "object",
+      "default": {}
     },
     "helm-values.secretTargets": {
-      "additionalProperties": false,
+      "type": "object",
       "properties": {
         "authorizedSecrets": {
           "$ref": "#/$defs/helm-values.secretTargets.authorizedSecrets"
@@ -670,37 +705,35 @@
           "$ref": "#/$defs/helm-values.secretTargets.enabled"
         }
       },
-      "type": "object"
+      "additionalProperties": false
     },
     "helm-values.secretTargets.authorizedSecrets": {
-      "default": [],
       "description": "A list of secret names which trust-manager will be permitted to read and write across all namespaces. These are the only allowable Secrets that can be used as targets. If the list is empty (and authorizedSecretsAll is false), trust-manager can't write to secrets and can only read secrets in the trust namespace for use as sources.",
-      "items": {},
-      "type": "array"
+      "type": "array",
+      "default": [],
+      "items": {}
     },
     "helm-values.secretTargets.authorizedSecretsAll": {
-      "default": false,
       "description": "If set to true, grant read/write permission to all secrets across the cluster. Use with caution!\nIf set, ignores the authorizedSecrets list.",
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     },
     "helm-values.secretTargets.enabled": {
-      "default": false,
       "description": "If set to true, enable writing trust bundles to Kubernetes Secrets as a target. trust-manager can only write to secrets which are explicitly allowed via either authorizedSecrets or authorizedSecretsAll. Note that enabling secret targets will grant trust-manager read access to all secrets in the cluster.",
-      "type": "boolean"
+      "type": "boolean",
+      "default": false
     },
     "helm-values.tolerations": {
-      "default": [],
       "description": "List of Kubernetes Tolerations, if required. For more information, see [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core).\nFor example:\ntolerations:\n- key: foo.bar.com/role\n  operator: Equal\n  value: master\n  effect: NoSchedule",
-      "items": {},
-      "type": "array"
+      "type": "array",
+      "default": [],
+      "items": {}
     },
     "helm-values.topologySpreadConstraints": {
-      "default": [],
       "description": "List of Kubernetes TopologySpreadConstraints. For more information, see [TopologySpreadConstraint v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#topologyspreadconstraint-v1-core).\nFor example:\ntopologySpreadConstraints:\n- maxSkew: 2\n  topologyKey: topology.kubernetes.io/zone\n  whenUnsatisfiable: ScheduleAnyway\n  labelSelector:\n    matchLabels:\n      app.kubernetes.io/name: trust-manager",
-      "items": {},
-      "type": "array"
+      "type": "array",
+      "default": [],
+      "items": {}
     }
-  },
-  "$ref": "#/$defs/helm-values",
-  "$schema": "http://json-schema.org/draft-07/schema#"
+  }
 }

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -221,6 +221,8 @@ app:
     port: 6443
     # Timeout of webhook HTTP request.
     timeoutSeconds: 5
+    # Annotations for the ValidatingWebhookConfiguration
+    annotations: {}
 
     service:
       # The type of Kubernetes Service used by the Webhook.
@@ -230,6 +232,8 @@ app:
       ipFamilyPolicy: ""
       # Sets the families that should be supported and the order in which they should be applied to ClusterIP as well. Can be IPv4 and/or IPv6.
       ipFamilies: []
+      # Annotations for the webhook service
+      annotations: {}
 
       # The nodePort set on the Service used by the webhook.
       # +docs:property
@@ -241,6 +245,11 @@ app:
         # Helm-issued certificates can be challenging to rotate and maintain, and the issued cert will have a duration of 10 years and be modified when trust-manager is updated.
         # It's safer and easier to rely on cert-manager for issuing the webhook cert - avoid using Helm-generated certs in production.
         enabled: false
+
+      certManager:
+        # Wether to create certificates using cert-manager CRDs.
+        # Default way of generating certificates for the webhook
+        enabled: true
 
       approverPolicy:
         # Whether to create an approver-policy CertificateRequestPolicy allowing auto-approval of the trust-manager webhook certificate. If you have approver-policy installed, you almost certainly want to enable this.


### PR DESCRIPTION
closes: https://github.com/cert-manager/trust-manager/issues/407

Added a new parameter  `app.webhook.tls.certManager.enabled=true` that keeps the default config to create certmanager certificates, but that can be disabled.

Added new parameters `app.webhook.annotations` and `app.webhook.service.annotations` to set annotations for the `ValidatingWebhookConfiguration` and Webhook `Service` respectively.

This allows for having another way to provide TLS certificates like for instance wih the [Openshift service serving certificates](https://docs.openshift.com/container-platform/4.15/security/certificates/service-serving-certificate.html)

Example values:

```yaml
app:
  webhook:
    annotations:
      service.beta.openshift.io/inject-cabundle: "true"
    service:
      annotations:
        service.beta.openshift.io/serving-cert-secret-name: '{{ include "trust-manager.name" . }}-tls'
    tls:
      helmCert:
        enabled: false
      certManager:
        enabled: false
```

