### PR TITLE
add option for deployment annotations to helm chart

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -366,6 +366,13 @@ Pod labels to add to trust-manager pods.
 > ```
 
 Pod annotations to add to trust-manager pods.
+#### **app.deploymentAnnotations** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+Deployment annotations to add to the trust-manager deployment.
 ### Webhook
 
 #### **app.webhook.host** ~ `string`

--- a/deploy/charts/trust-manager/templates/deployment.yaml
+++ b/deploy/charts/trust-manager/templates/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ include "trust-manager.namespace" . }}
   labels:
     {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- if .Values.app.deploymentAnnotations }}
+  annotations:
+    {{- toYaml .Values.app.deploymentAnnotations | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -212,6 +212,9 @@ app:
   # Pod annotations to add to trust-manager pods.
   podAnnotations: {}
 
+  # Deployment annotations to add to the trust-manager deployment.
+  deploymentAnnotations: {}
+
   # +docs:section=Webhook
 
   webhook:


### PR DESCRIPTION
Hi!

This PR adds the option to add annotations to the trust-manager deployment. In our specific use case we need it to apply custom annotations to exclude the deployment from kyverno policy validation.

The cert-manager chart allows the same [configuration option](https://github.com/cert-manager/cert-manager/blob/7d797a45d7040eaad420d04dc829e2ae9457bb35/deploy/charts/cert-manager/values.yaml#L325-L327), but for trust-manager it is missing.

I have seen that https://github.com/cert-manager/trust-manager/pull/214 contains the same change, but from what I understand only the certificate annotations are under discussion, so I hope my PR can get merged :)