### PR TITLE
refactor: use NamespacedName instead of positional name/namespace parameters

### DIFF
--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -95,7 +95,7 @@ type bundle struct {
 func (b *bundle) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	result, statusPatch, resultErr := b.reconcileBundle(ctx, req)
 	if statusPatch != nil {
-		con, patch, err := ssa_client.GenerateBundleStatusPatch(req.Name, req.Namespace, statusPatch)
+		con, patch, err := ssa_client.GenerateBundleStatusPatch(req.Name, statusPatch)
 		if err != nil {
 			err = fmt.Errorf("failed to generate bundle status patch: %w", err)
 			return ctrl.Result{}, utilerrors.NewAggregate([]error{resultErr, err})
@@ -303,12 +303,12 @@ func (b *bundle) reconcileBundle(ctx context.Context, req ctrl.Request) (result 
 
 		if target.Kind == configMapTarget {
 			syncFunc = func(targetLog logr.Logger, target targetResource, shouldExist bool) (bool, error) {
-				return b.syncConfigMapTarget(ctx, targetLog, &bundle, target.Name, target.Namespace, resolvedBundle.targetData, shouldExist)
+				return b.syncConfigMapTarget(ctx, targetLog, &bundle, target.NamespacedName, resolvedBundle.targetData, shouldExist)
 			}
 		}
 		if target.Kind == secretTarget {
 			syncFunc = func(targetLog logr.Logger, target targetResource, shouldExist bool) (bool, error) {
-				return b.syncSecretTarget(ctx, targetLog, &bundle, target.Name, target.Namespace, resolvedBundle.targetData, shouldExist)
+				return b.syncSecretTarget(ctx, targetLog, &bundle, target.NamespacedName, resolvedBundle.targetData, shouldExist)
 			}
 		}
 

--- a/pkg/bundle/internal/ssa_client/bundle_status.go
+++ b/pkg/bundle/internal/ssa_client/bundle_status.go
@@ -33,12 +33,12 @@ type bundleStatusApplyConfiguration struct {
 }
 
 func GenerateBundleStatusPatch(
-	name, namespace string,
+	name string,
 	status *trustapi.BundleStatus,
 ) (*trustapi.Bundle, client.Patch, error) {
 	// This object is used to deduce the name & namespace + unmarshall the return value in
 	bundle := &trustapi.Bundle{
-		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
 	}
 
 	// This object is used to render the patch
@@ -46,7 +46,6 @@ func GenerateBundleStatusPatch(
 		ObjectMetaApplyConfiguration: &v1.ObjectMetaApplyConfiguration{},
 	}
 	b.WithName(name)
-	b.WithNamespace(namespace)
 	b.WithKind(trustapi.BundleKind)
 	b.WithAPIVersion(trustapi.SchemeGroupVersion.Identifier())
 	b.Status = status

--- a/pkg/bundle/target_test.go
+++ b/pkg/bundle/target_test.go
@@ -27,6 +27,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
 	coreapplyconfig "k8s.io/client-go/applyconfigurations/core/v1"
 	metav1applyconfig "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/client-go/tools/record"
@@ -610,7 +611,7 @@ func Test_syncConfigMapTarget(t *testing.T) {
 			needsUpdate, err := b.syncConfigMapTarget(ctx, log, &trustapi.Bundle{
 				ObjectMeta: metav1.ObjectMeta{Name: bundleName},
 				Spec:       spec,
-			}, bundleName, test.namespace.Name, resolvedBundle, test.shouldExist)
+			}, types.NamespacedName{Name: bundleName, Namespace: test.namespace.Name}, resolvedBundle, test.shouldExist)
 			assert.NoError(t, err)
 
 			assert.Equalf(t, test.expNeedsUpdate, needsUpdate, "unexpected needsUpdate, exp=%t got=%t", test.expNeedsUpdate, needsUpdate)
@@ -1230,7 +1231,7 @@ func Test_syncSecretTarget(t *testing.T) {
 			needsUpdate, err := b.syncSecretTarget(ctx, log, &trustapi.Bundle{
 				ObjectMeta: metav1.ObjectMeta{Name: bundleName},
 				Spec:       spec,
-			}, bundleName, test.namespace.Name, resolvedBundle, test.shouldExist)
+			}, types.NamespacedName{Name: bundleName, Namespace: test.namespace.Name}, resolvedBundle, test.shouldExist)
 			assert.NoError(t, err)
 
 			assert.Equalf(t, test.expNeedsUpdate, needsUpdate, "unexpected needsUpdate, exp=%t got=%t", test.expNeedsUpdate, needsUpdate)


### PR DESCRIPTION
This minor refactoring is done to avoid some of the error-prone positional function parameters of the same type (`name` and `namespace`). As Bundle is a cluster-scoped resource, we can just ignore the (always empty) namespace in the reconcile request.