### PR TITLE
test: add tests for truststore deterministic

### DIFF
--- a/pkg/bundle/internal/target/target.go
+++ b/pkg/bundle/internal/target/target.go
@@ -103,8 +103,8 @@ func (r *Reconciler) SyncConfigMap(
 		return false, errors.New("target not defined")
 	}
 
-	// Generated JKS is not deterministic - best we can do here is update if the pem cert has
-	// changed (hence not checking if JKS matches)
+	// Generated PKCS #12 is not deterministic - best we can do here is update if the pem cert has
+	// changed (hence not checking if PKCS #12 matches)
 	dataHash := fmt.Sprintf("%x", sha256.Sum256([]byte(resolvedBundle.Data)))
 	configMapData := map[string]string{
 		bundleTarget.ConfigMap.Key: resolvedBundle.Data,
@@ -185,8 +185,8 @@ func (r *Reconciler) SyncSecret(
 		return false, errors.New("target not defined")
 	}
 
-	// Generated JKS is not deterministic - best we can do here is update if the pem cert has
-	// changed (hence not checking if JKS matches)
+	// Generated PKCS #12 is not deterministic - best we can do here is update if the pem cert has
+	// changed (hence not checking if PKCS #12 matches)
 	dataHash := fmt.Sprintf("%x", sha256.Sum256([]byte(resolvedBundle.Data)))
 	secretData := map[string][]byte{
 		bundleTarget.Secret.Key: []byte(resolvedBundle.Data),


### PR DESCRIPTION
I would still prefer if we could perform an unconditional SSA of target resources and avoid the complex and error-prone target "needs update" logic. This could eventually address https://github.com/cert-manager/trust-manager/issues/433 and in general, ensure trust-manager target resources are more up-to-date.

It seems like trust-manager truststores are now deterministic, except PKCS#12 truststores with a custom (non-empty) password. I attempted to fix this but didn't manage to.