### PR TITLE
fix: make PKCS#12 truststores deterministic

### DIFF
--- a/pkg/bundle/internal/insecurerand/insecurerand.go
+++ b/pkg/bundle/internal/insecurerand/insecurerand.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package insecurerand
+
+import "io"
+
+var Rand io.Reader = &insecureRand{}
+
+type insecureRand struct {
+}
+
+func (r insecureRand) Read(p []byte) (n int, err error) {
+	n = len(p)
+	for i := range p {
+		p[i] = 0
+	}
+	return
+}

--- a/pkg/bundle/internal/truststore/types.go
+++ b/pkg/bundle/internal/truststore/types.go
@@ -25,6 +25,7 @@ import (
 	"github.com/pavlo-v-chernykh/keystore-go/v4"
 	"software.sslmate.com/src/go-pkcs12"
 
+	"github.com/cert-manager/trust-manager/pkg/bundle/internal/insecurerand"
 	"github.com/cert-manager/trust-manager/pkg/util"
 )
 
@@ -98,7 +99,11 @@ func (e pkcs12Encoder) Encode(trustBundle *util.CertPool) ([]byte, error) {
 		})
 	}
 
-	encoder := pkcs12.LegacyRC2
+	encoder := pkcs12.LegacyRC2.
+		// Short-circuiting the rand generator to make our PKCS#12 truststores deterministic.
+		// This should allow use of unconditional SSA requests from controller.
+		// See: https://cert-manager.io/docs/faq/#why-are-passwords-on-jks-or-pkcs12-files-not-helpful
+		WithRand(insecurerand.Rand)
 
 	if e.password == "" {
 		encoder = pkcs12.Passwordless

--- a/pkg/bundle/internal/truststore/types_test.go
+++ b/pkg/bundle/internal/truststore/types_test.go
@@ -32,8 +32,7 @@ import (
 
 func Test_Encoder_Deterministic(t *testing.T) {
 	tests := map[string]struct {
-		encoder             Encoder
-		expNonDeterministic bool
+		encoder Encoder
 	}{
 		"JKS default password": {
 			encoder: NewJKSEncoder(v1alpha1.DefaultJKSPassword),
@@ -46,8 +45,6 @@ func Test_Encoder_Deterministic(t *testing.T) {
 		},
 		"PKCS#12 custom password": {
 			encoder: NewPKCS12Encoder("my-password"),
-			// FIXME: We should try to make all encoders deterministic
-			expNonDeterministic: true,
 		},
 	}
 
@@ -72,11 +69,7 @@ func Test_Encoder_Deterministic(t *testing.T) {
 				t.Fatalf("didn't expect an error but got: %s", err)
 			}
 
-			if test.expNonDeterministic {
-				assert.NotEqual(t, store, store2, "expected encoder to be non-deterministic")
-			} else {
-				assert.Equal(t, store, store2, "expected encoder to be deterministic")
-			}
+			assert.Equal(t, store, store2, "expected encoder to be deterministic")
 		})
 	}
 }


### PR DESCRIPTION
This PR might appear a bit controversial, since it short-circuits the random generator for our PKCS#12 truststores. 🤠 But there is a reason! My end goal is to greatly simplify the Bundle controller by removing the `needsUpdate`-logic and replacing it with well-tuned, but unconditional, SSA requests.