### PR TITLE
feat(helm): add secretTemplate-ing to certificate

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -442,6 +442,11 @@ The namespace in which cert-manager was installed. Only used if `app.webhook.tls
 > ```
 
 The name of cert-manager's Service Account. Only used if `app.webhook.tls.approverPolicy.enabled` is true.
+#### **app.webhook.tls.certificate.secretTemplate** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
 #### **app.webhook.hostNetwork** ~ `bool`
 > Default value:
 > ```yaml

--- a/deploy/charts/trust-manager/templates/certificate.yaml
+++ b/deploy/charts/trust-manager/templates/certificate.yaml
@@ -24,6 +24,10 @@ spec:
   dnsNames:
   - "{{ include "trust-manager.name" . }}.{{ include "trust-manager.namespace" . }}.svc"
   secretName: {{ include "trust-manager.name" . }}-tls
+  {{- with .Values.app.webhook.tls.certificate.secretTemplate }}
+  secretTemplate:
+    {{- toYaml .| nindent 4 }}
+  {{- end }}
   revisionHistoryLimit: 1
   issuerRef:
     name: {{ include "trust-manager.name" . }}

--- a/deploy/charts/trust-manager/values.schema.json
+++ b/deploy/charts/trust-manager/values.schema.json
@@ -392,6 +392,9 @@
         "approverPolicy": {
           "$ref": "#/$defs/helm-values.app.webhook.tls.approverPolicy"
         },
+        "certificate": {
+          "$ref": "#/$defs/helm-values.app.webhook.tls.certificate"
+        },
         "helmCert": {
           "$ref": "#/$defs/helm-values.app.webhook.tls.helmCert"
         }
@@ -427,6 +430,19 @@
       "default": false,
       "description": "Whether to create an approver-policy CertificateRequestPolicy allowing auto-approval of the trust-manager webhook certificate. If you have approver-policy installed, you almost certainly want to enable this.",
       "type": "boolean"
+    },
+    "helm-values.app.webhook.tls.certificate": {
+      "additionalProperties": false,
+      "properties": {
+        "secretTemplate": {
+          "$ref": "#/$defs/helm-values.app.webhook.tls.certificate.secretTemplate"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.app.webhook.tls.certificate.secretTemplate": {
+      "default": {},
+      "type": "object"
     },
     "helm-values.app.webhook.tls.helmCert": {
       "additionalProperties": false,

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -251,6 +251,17 @@ app:
 
         # The name of cert-manager's Service Account. Only used if `app.webhook.tls.approverPolicy.enabled` is true.
         certManagerServiceAccount: "cert-manager"
+
+      # Add labels/annotations to secrets created by Certificate resources when using cert-manager provisioned TLS certificate.
+      certificate:
+        secretTemplate: {}
+          # For example:
+          #   annotations:
+          #     my-secret-annotation-1: "foo"
+          #     my-secret-annotation-2: "bar"
+          #   labels:
+          #     my-secret-label: foo
+
     # This value specifies if the app should be started in hostNetwork mode. It is required for use in some managed Kubernetes clusters (such as AWS EKS) with custom CNI.
     hostNetwork: false
 


### PR DESCRIPTION
**Pull Request Motivation**
Some environments have admission webhooks that might mandate specific labels or annotations. This change allows chart users to set labels and/or annotations in the Secret created by the Certificate resources.

Close https://github.com/cert-manager/trust-manager/issues/453