### PR TITLE
WIP: Remove incomplete validation from webhook

### DIFF
--- a/pkg/webhook/validation.go
+++ b/pkg/webhook/validation.go
@@ -164,24 +164,6 @@ func (v *validator) validate(obj runtime.Object) (admission.Warnings, error) {
 		))
 	}
 
-	if target := bundle.Spec.Target.ConfigMap; target != nil {
-		path := path.Child("sources")
-		for i, source := range bundle.Spec.Sources {
-			if source.ConfigMap != nil && source.ConfigMap.Name == bundle.Name && source.ConfigMap.Key == target.Key {
-				el = append(el, field.Forbidden(path.Child(fmt.Sprintf("[%d]", i), "configMap", source.ConfigMap.Name, source.ConfigMap.Key), "cannot define the same source as target"))
-			}
-		}
-	}
-
-	if target := bundle.Spec.Target.Secret; target != nil {
-		path := path.Child("sources")
-		for i, source := range bundle.Spec.Sources {
-			if source.Secret != nil && source.Secret.Name == bundle.Name && source.Secret.Key == target.Key {
-				el = append(el, field.Forbidden(path.Child(fmt.Sprintf("[%d]", i), "secret", source.Secret.Name, source.Secret.Key), "cannot define the same source as target"))
-			}
-		}
-	}
-
 	configMap := bundle.Spec.Target.ConfigMap
 	secret := bundle.Spec.Target.Secret
 

--- a/pkg/webhook/validation_test.go
+++ b/pkg/webhook/validation_test.go
@@ -190,36 +190,6 @@ func Test_validate(t *testing.T) {
 				field.Invalid(field.NewPath("spec", "sources", "[2]", "secret"), "key: test, includeAllKeys: true", "source secret key cannot be defined when includeAllKeys is true"),
 			}.ToAggregate().Error()),
 		},
-		"sources defines the same configMap target": {
-			bundle: &trustapi.Bundle{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-bundle"},
-				Spec: trustapi.BundleSpec{
-					Sources: []trustapi.BundleSource{
-						{InLine: ptr.To("test")},
-						{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "test-bundle", Key: "test"}},
-					},
-					Target: trustapi.BundleTarget{ConfigMap: &trustapi.KeySelector{Key: "test"}},
-				},
-			},
-			expErr: ptr.To(field.ErrorList{
-				field.Forbidden(field.NewPath("spec", "sources", "[1]", "configMap", "test-bundle", "test"), "cannot define the same source as target"),
-			}.ToAggregate().Error()),
-		},
-		"sources defines the same secret target": {
-			bundle: &trustapi.Bundle{
-				ObjectMeta: metav1.ObjectMeta{Name: "test-bundle"},
-				Spec: trustapi.BundleSpec{
-					Sources: []trustapi.BundleSource{
-						{InLine: ptr.To("test")},
-						{Secret: &trustapi.SourceObjectKeySelector{Name: "test-bundle", Key: "test"}},
-					},
-					Target: trustapi.BundleTarget{Secret: &trustapi.KeySelector{Key: "test"}},
-				},
-			},
-			expErr: ptr.To(field.ErrorList{
-				field.Forbidden(field.NewPath("spec", "sources", "[1]", "secret", "test-bundle", "test"), "cannot define the same source as target"),
-			}.ToAggregate().Error()),
-		},
 		"target configMap key not defined": {
 			bundle: &trustapi.Bundle{
 				Spec: trustapi.BundleSpec{


### PR DESCRIPTION
While working on https://github.com/cert-manager/trust-manager/pull/475, I noticed this validation that seems wrong to me, at least incomplete. Why shouldn't a user be allowed to use the same key in source and target? This will only become a potential problem if the "trust namespace" is included as a target namespace. And why would you do that? And after https://github.com/cert-manager/trust-manager/pull/460, this check is definitely incomplete - which means we have to find a better way to exclude sources as targets in the controller.