### PR TITLE
Check-in testdata such that test can be run in IDE/ using go without using Makefile

### DIFF
--- a/make/test-integration.mk
+++ b/make/test-integration.mk
@@ -12,17 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-trust_manager_crds := $(bin_dir)/scratch/trust.cert-manager.io_bundles.yaml
-$(trust_manager_crds): $(helm_chart_archive) | $(NEEDS_HELM) $(NEEDS_YQ)
+trust_manager_crds := test/testdata/trust.cert-manager.io_bundles.yaml
+
+generate-testdata: $(helm_chart_archive) | $(NEEDS_HELM) $(NEEDS_YQ)
 	$(HELM) template test "$(helm_chart_archive)" | \
-		$(YQ) e '. | select(.kind == "CustomResourceDefinition")' \
-		> $@
+		$(YQ) e '. | select(.kind == "CustomResourceDefinition") | del(.metadata.labels)' \
+		> $(CURDIR)/$(trust_manager_crds)
+
+shared_generate_targets += generate-testdata
 
 .PHONY: test-integration
 ## Integration tests
 ## @category Testing
 test-integration: | $(trust_manager_crds) $(NEEDS_GOTESTSUM) $(NEEDS_ETCD) $(NEEDS_KUBE-APISERVER) $(NEEDS_KUBECTL) $(ARTIFACTS)
-	TRUST_MANAGER_CRDS=$(CURDIR)/$(trust_manager_crds) \
 	KUBEBUILDER_ASSETS=$(CURDIR)/$(bin_dir)/tools \
 	$(GOTESTSUM) \
 		--junitfile=$(ARTIFACTS)/junit-go-e2e.xml \

--- a/test/integration/bundle/integration.go
+++ b/test/integration/bundle/integration.go
@@ -17,8 +17,6 @@ limitations under the License.
 package test
 
 import (
-	"os"
-
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -30,6 +28,8 @@ import (
 	. "github.com/onsi/gomega"
 )
 
+const crdsYAMLFile = "../../testdata/trust.cert-manager.io_bundles.yaml"
+
 var (
 	env *envtest.Environment
 )
@@ -37,13 +37,10 @@ var (
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
-	crdsYamlFile := os.Getenv("TRUST_MANAGER_CRDS")
-	Expect(crdsYamlFile).NotTo(BeEmpty(), "TRUST_MANAGER_CRDS must be set to the path of the CRDs to install")
-
 	env = &envtest.Environment{
 		UseExistingCluster: ptr.To(false),
 		CRDDirectoryPaths: []string{
-			crdsYamlFile,
+			crdsYAMLFile,
 		},
 		Scheme: trustapi.GlobalScheme,
 	}

--- a/test/testdata/trust.cert-manager.io_bundles.yaml
+++ b/test/testdata/trust.cert-manager.io_bundles.yaml
@@ -1,0 +1,424 @@
+# Source: trust-manager/templates/crd-trust.cert-manager.io_bundles.yaml
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: "bundles.trust.cert-manager.io"
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  group: trust.cert-manager.io
+  names:
+    kind: Bundle
+    listKind: BundleList
+    plural: bundles
+    singular: bundle
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Bundle ConfigMap Target Key
+          jsonPath: .spec.target.configMap.key
+          name: ConfigMap Target
+          type: string
+        - description: Bundle Secret Target Key
+          jsonPath: .spec.target.secret.key
+          name: Secret Target
+          type: string
+        - description: Bundle has been synced
+          jsonPath: .status.conditions[?(@.type == "Synced")].status
+          name: Synced
+          type: string
+        - description: Reason Bundle has Synced status
+          jsonPath: .status.conditions[?(@.type == "Synced")].reason
+          name: Reason
+          type: string
+        - description: Timestamp Bundle was created
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha1
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: Desired state of the Bundle resource.
+              properties:
+                sources:
+                  description: Sources is a set of references to data whose data will sync to the target.
+                  items:
+                    description: |-
+                      BundleSource is the set of sources whose data will be appended and synced to
+                      the BundleTarget in all Namespaces.
+                    properties:
+                      configMap:
+                        description: |-
+                          ConfigMap is a reference (by name) to a ConfigMap's `data` key(s), or to a
+                          list of ConfigMap's `data` key(s) using label selector, in the trust Namespace.
+                        properties:
+                          includeAllKeys:
+                            description: |-
+                              IncludeAllKeys is a flag to include all keys in the object's `data` field to be used. False by default.
+                              This field must not be true when `Key` is set.
+                            type: boolean
+                          key:
+                            description: Key of the entry in the object's `data` field to be used.
+                            minLength: 1
+                            type: string
+                          name:
+                            description: |-
+                              Name is the name of the source object in the trust Namespace.
+                              This field must be left empty when `selector` is set
+                            minLength: 1
+                            type: string
+                          selector:
+                            description: |-
+                              Selector is the label selector to use to fetch a list of objects. Must not be set
+                              when `Name` is set.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      inLine:
+                        description: InLine is a simple string to append as the source data.
+                        type: string
+                      secret:
+                        description: |-
+                          Secret is a reference (by name) to a Secret's `data` key(s), or to a
+                          list of Secret's `data` key(s) using label selector, in the trust Namespace.
+                        properties:
+                          includeAllKeys:
+                            description: |-
+                              IncludeAllKeys is a flag to include all keys in the object's `data` field to be used. False by default.
+                              This field must not be true when `Key` is set.
+                            type: boolean
+                          key:
+                            description: Key of the entry in the object's `data` field to be used.
+                            minLength: 1
+                            type: string
+                          name:
+                            description: |-
+                              Name is the name of the source object in the trust Namespace.
+                              This field must be left empty when `selector` is set
+                            minLength: 1
+                            type: string
+                          selector:
+                            description: |-
+                              Selector is the label selector to use to fetch a list of objects. Must not be set
+                              when `Name` is set.
+                            properties:
+                              matchExpressions:
+                                description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                                items:
+                                  description: |-
+                                    A label selector requirement is a selector that contains values, a key, and an operator that
+                                    relates the key and values.
+                                  properties:
+                                    key:
+                                      description: key is the label key that the selector applies to.
+                                      type: string
+                                    operator:
+                                      description: |-
+                                        operator represents a key's relationship to a set of values.
+                                        Valid operators are In, NotIn, Exists and DoesNotExist.
+                                      type: string
+                                    values:
+                                      description: |-
+                                        values is an array of string values. If the operator is In or NotIn,
+                                        the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                        the values array must be empty. This array is replaced during a strategic
+                                        merge patch.
+                                      items:
+                                        type: string
+                                      type: array
+                                      x-kubernetes-list-type: atomic
+                                  required:
+                                    - key
+                                    - operator
+                                  type: object
+                                type: array
+                                x-kubernetes-list-type: atomic
+                              matchLabels:
+                                additionalProperties:
+                                  type: string
+                                description: |-
+                                  matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                                  map is equivalent to an element of matchExpressions, whose key field is "key", the
+                                  operator is "In", and the values array contains only "value". The requirements are ANDed.
+                                type: object
+                            type: object
+                            x-kubernetes-map-type: atomic
+                        type: object
+                        x-kubernetes-map-type: atomic
+                      useDefaultCAs:
+                        description: |-
+                          UseDefaultCAs, when true, requests the default CA bundle to be used as a source.
+                          Default CAs are available if trust-manager was installed via Helm
+                          or was otherwise set up to include a package-injecting init container by using the
+                          "--default-package-location" flag when starting the trust-manager controller.
+                          If default CAs were not configured at start-up, any request to use the default
+                          CAs will fail.
+                          The version of the default CA package which is used for a Bundle is stored in the
+                          defaultCAPackageVersion field of the Bundle's status field.
+                        type: boolean
+                    type: object
+                    x-kubernetes-map-type: atomic
+                  maxItems: 100
+                  minItems: 1
+                  type: array
+                  x-kubernetes-list-type: atomic
+                target:
+                  description: Target is the target location in all namespaces to sync source data to.
+                  properties:
+                    additionalFormats:
+                      description: AdditionalFormats specifies any additional formats to write to the target
+                      properties:
+                        jks:
+                          description: |-
+                            JKS requests a JKS-formatted binary trust bundle to be written to the target.
+                            The bundle has "changeit" as the default password.
+                            For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
+                          properties:
+                            key:
+                              description: Key is the key of the entry in the object's `data` field to be used.
+                              minLength: 1
+                              type: string
+                            password:
+                              default: changeit
+                              description: Password for JKS trust store
+                              maxLength: 128
+                              minLength: 1
+                              type: string
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                        pkcs12:
+                          description: |-
+                            PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the target.
+                            The bundle is by default created without a password.
+                          properties:
+                            key:
+                              description: Key is the key of the entry in the object's `data` field to be used.
+                              minLength: 1
+                              type: string
+                            password:
+                              default: ""
+                              description: Password for PKCS12 trust store
+                              maxLength: 128
+                              type: string
+                          required:
+                            - key
+                          type: object
+                          x-kubernetes-map-type: atomic
+                      type: object
+                    configMap:
+                      description: |-
+                        ConfigMap is the target ConfigMap in Namespaces that all Bundle source
+                        data will be synced to.
+                      properties:
+                        key:
+                          description: Key is the key of the entry in the object's `data` field to be used.
+                          minLength: 1
+                          type: string
+                      required:
+                        - key
+                      type: object
+                    namespaceSelector:
+                      description: |-
+                        NamespaceSelector will, if set, only sync the target resource in
+                        Namespaces which match the selector.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    secret:
+                      description: |-
+                        Secret is the target Secret that all Bundle source data will be synced to.
+                        Using Secrets as targets is only supported if enabled at trust-manager startup.
+                        By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.
+                      properties:
+                        key:
+                          description: Key is the key of the entry in the object's `data` field to be used.
+                          minLength: 1
+                          type: string
+                      required:
+                        - key
+                      type: object
+                  type: object
+              required:
+                - sources
+                - target
+              type: object
+            status:
+              description: Status of the Bundle. This is set and managed automatically.
+              properties:
+                conditions:
+                  description: |-
+                    List of status conditions to indicate the status of the Bundle.
+                    Known condition types are `Bundle`.
+                  items:
+                    description: BundleCondition contains condition information for a Bundle.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          LastTransitionTime is the timestamp corresponding to the last status
+                          change of this condition.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          Message is a human-readable description of the details of the last
+                          transition, complementing reason.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          If set, this represents the .metadata.generation that the condition was
+                          set based upon.
+                          For instance, if .metadata.generation is currently 12, but the
+                          .status.condition[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the Bundle.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          Reason is a brief machine-readable explanation for the condition's last
+                          transition.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: Status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: Type of the condition, known values are (`Synced`).
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                defaultCAVersion:
+                  description: |-
+                    DefaultCAPackageVersion, if set and non-empty, indicates the version information
+                    which was retrieved when the set of default CAs was requested in the bundle
+                    source. This should only be set if useDefaultCAs was set to "true" on a source,
+                    and will be the same for the same version of a bundle with identical certificates.
+                  type: string
+              type: object
+          required:
+            - spec
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}


### PR DESCRIPTION
Alternative solution for https://github.com/cert-manager/makefile-modules/pull/209.
Makes it possible to run Go tests without Makefile (eg. when running using IDE).

Checks-in the testdata instead of generating on demand as part of the Makefile target.

cc @erikgb