### PR TITLE
Set dummy Helm chart versions

### DIFF
--- a/deploy/charts/trust-manager/Chart.yaml
+++ b/deploy/charts/trust-manager/Chart.yaml
@@ -27,5 +27,5 @@ sources:
 
 kubeVersion: ">= 1.25.0-0"  # The -0 is required for EKS: https://github.com/helm/helm/issues/10375
 
-appVersion: v0.9.0
-version: v0.9.0
+appVersion: v0.0.0
+version: v0.0.0


### PR DESCRIPTION
Having a random version checked into Git is confusing for users.

Fixes https://github.com/cert-manager/trust-manager/issues/489

/cc @inteon @SgtCoDFish 