### PR TITLE
Simplify integration test setup

### DIFF
--- a/make/test-integration.mk
+++ b/make/test-integration.mk
@@ -12,17 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-trust_manager_crds := $(bin_dir)/scratch/trust.cert-manager.io_bundles.yaml
-$(trust_manager_crds): $(helm_chart_archive) | $(NEEDS_HELM) $(NEEDS_YQ)
-	$(HELM) template test "$(helm_chart_archive)" | \
-		$(YQ) e '. | select(.kind == "CustomResourceDefinition")' \
-		> $@
-
 .PHONY: test-integration
 ## Integration tests
 ## @category Testing
-test-integration: | $(trust_manager_crds) $(NEEDS_GOTESTSUM) $(NEEDS_ETCD) $(NEEDS_KUBE-APISERVER) $(NEEDS_KUBECTL) $(ARTIFACTS)
-	TRUST_MANAGER_CRDS=$(CURDIR)/$(trust_manager_crds) \
+test-integration: | $(NEEDS_GOTESTSUM) $(NEEDS_ETCD) $(NEEDS_KUBE-APISERVER) $(NEEDS_KUBECTL) $(ARTIFACTS)
 	KUBEBUILDER_ASSETS=$(CURDIR)/$(bin_dir)/tools \
 	$(GOTESTSUM) \
 		--junitfile=$(ARTIFACTS)/junit-go-e2e.xml \

--- a/test/integration/bundle/integration.go
+++ b/test/integration/bundle/integration.go
@@ -17,7 +17,7 @@ limitations under the License.
 package test
 
 import (
-	"os"
+	"path"
 
 	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
@@ -37,15 +37,13 @@ var (
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
-	crdsYamlFile := os.Getenv("TRUST_MANAGER_CRDS")
-	Expect(crdsYamlFile).NotTo(BeEmpty(), "TRUST_MANAGER_CRDS must be set to the path of the CRDs to install")
-
 	env = &envtest.Environment{
 		UseExistingCluster: ptr.To(false),
 		CRDDirectoryPaths: []string{
-			crdsYamlFile,
+			path.Join("..", "..", "..", "deploy", "crds"),
 		},
-		Scheme: trustapi.GlobalScheme,
+		ErrorIfCRDPathMissing: true,
+		Scheme:                trustapi.GlobalScheme,
 	}
 
 	_, err := env.Start()


### PR DESCRIPTION
After https://github.com/cert-manager/makefile-modules/pull/214 is available in this project, we can simplify the integration test setup to use the generated CRD manifests.