### PR TITLE
feat: add option to disable cluster rbac installation

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -179,6 +179,13 @@ digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
 > ```
 
 imagePullPolicy for the default package image.
+#### **rbac.create** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+Create required ClusterRole and ClusterRoleBinding for trust-manager. If set to false it will also disable the possibility to set secretTargets
 #### **secretTargets.enabled** ~ `bool`
 > Default value:
 > ```yaml

--- a/deploy/charts/trust-manager/templates/clusterrole.yaml
+++ b/deploy/charts/trust-manager/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -64,3 +65,4 @@ rules:
   resourceNames: {{ .Values.secretTargets.authorizedSecrets | toYaml | nindent 2 }}
 {{- end -}}
 {{- end -}}
+{{- end }}

--- a/deploy/charts/trust-manager/templates/clusterrolebinding.yaml
+++ b/deploy/charts/trust-manager/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.rbac.create }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -12,3 +13,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "trust-manager.name" . }}
   namespace: {{ include "trust-manager.namespace" . }}
+{{- end }}

--- a/deploy/charts/trust-manager/values.schema.json
+++ b/deploy/charts/trust-manager/values.schema.json
@@ -54,6 +54,9 @@
         "resources": {
           "$ref": "#/$defs/helm-values.resources"
         },
+        "rbac": {
+          "$ref": "#/$defs/helm-values.rbac"
+        },
         "secretTargets": {
           "$ref": "#/$defs/helm-values.secretTargets"
         },
@@ -672,6 +675,20 @@
       "default": {},
       "description": "Kubernetes pod resource limits for trust.\n\nFor example:\nresources:\n  limits:\n    cpu: 100m\n    memory: 128Mi\n  requests:\n    cpu: 100m\n    memory: 128Mi",
       "type": "object"
+    },
+    "helm-values.rbac": {
+      "additionalProperties": false,
+      "properties": {
+        "create": {
+          "$ref": "#/$defs/helm-values.rbac.create"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.rbac.create": {
+      "default": true,
+      "description": "Create required ClusterRole and ClusterRoleBinding for trust-manager.\nIf set to false it will also disable the possibility to set secretTargets",
+      "type": "boolean"
     },
     "helm-values.secretTargets": {
       "additionalProperties": false,

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -104,6 +104,11 @@ defaultPackageImage:
   # imagePullPolicy for the default package image.
   pullPolicy: IfNotPresent
 
+rbac:
+  # Create required ClusterRole and ClusterRoleBinding for trust-manager.
+  # If set to false it will also disable the possibility to set secretTargets
+  create: true
+
 secretTargets:
   # If set to true, enable writing trust bundles to Kubernetes Secrets as a target.
   # trust-manager can only write to secrets which are explicitly allowed via either authorizedSecrets or authorizedSecretsAll.


### PR DESCRIPTION
## Problem
Currently it is not possible to install trust-manager in managed k8s clusters:

1. where it is not allowed to automatically install clusterroles.
2. where you are not allowed to create roles with resources that are currently not available inside the cluster, for example finalizers in non openshift clusters.

## Solution
We need an option to install trust-manager without trying to create clusterroles during installation. 
With an rbac switch it is possible to disable the installation of the clusterrole and clusterrolebinding.
