### PR TITLE
Bump to Go 1.23 (and allow certificates with negative serial numbers)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,10 @@
 module github.com/cert-manager/trust-manager
 
-go 1.22.0
+go 1.23.0
+
+// Added on bump to Go 1.23 as it seems like our current trust bundle contains certs with negative serial numbers.
+// See also https://pkg.go.dev/crypto/x509#ParseCertificate
+godebug x509negativeserial=1
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
Preparations for https://github.com/cert-manager/trust-manager/pull/510 as K8s 1.32 dependencies require Go 1.23.

It seems like Go 1.23 rejects negative serial numbers by default in [x509.ParseCertificate](https://pkg.go.dev/crypto/x509#ParseCertificate), but the old behavior can be restored - as least as a short-term fix.

Long-term fix is probably to ensure our default trust bundles don't contain offending certificates. Maybe https://github.com/cert-manager/trust-manager/issues/183?