### PR TITLE
add metric tracking negative serial numbers on trust bundle certs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/cert-manager/trust-manager
 
-go 1.22.0
+go 1.23
+
+godebug x509negativeserial=1
 
 require (
 	github.com/go-logr/logr v1.4.2

--- a/make/debian-trust-package.mk
+++ b/make/debian-trust-package.mk
@@ -18,7 +18,7 @@ debian_package_json := $(debian_package_layer)/debian-package/cert-manager-packa
 $(debian_package_layer)/debian-package $(bin_dir)/bin:
 	mkdir -p $@
 
-$(bin_dir)/bin/validate-trust-package: cmd/validate-trust-package/*.go pkg/fspkg/*.go | $(NEEDS_GO) $(bin_dir)/bin
+$(bin_dir)/bin/validate-trust-package: cmd/validate-trust-package/*.go pkg/util/*.go pkg/fspkg/*.go go.mod go.sum | $(NEEDS_GO) $(bin_dir)/bin
 	$(GO) build -o $@ ./cmd/validate-trust-package
 
 $(debian_package_json): | $(bin_dir)/bin/validate-trust-package $(debian_package_layer)/debian-package


### PR DESCRIPTION
Related to #511  and #510 

This lets us track where we _would_ have failed if we hadn't set the godebug