### PR TITLE
feat(helm): Allow to configure automountServiceAccountToken

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -179,6 +179,48 @@ digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
 > ```
 
 imagePullPolicy for the default package image.
+#### **automountServiceAccountToken** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+Automounting API credentials for the trust-manager pod.
+
+#### **serviceAccount.create** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+Specifies whether a service account should be created.
+#### **serviceAccount.name** ~ `string`
+
+The name of the service account to use.  
+If not set and create is true, a name is generated using the fullname template.
+
+#### **serviceAccount.automountServiceAccountToken** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+Automount API credentials for a Service Account.
+
+#### **volumes** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+
+Additional volumes to add to the trust-manager pod.
+#### **volumeMounts** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+
+Additional volume mounts to add to the trust-manager container.
 #### **secretTargets.enabled** ~ `bool`
 > Default value:
 > ```yaml

--- a/deploy/charts/trust-manager/templates/_helpers.tpl
+++ b/deploy/charts/trust-manager/templates/_helpers.tpl
@@ -54,3 +54,14 @@ https://github.com/helm/helm/issues/5358
 {{- define "trust-manager.namespace" -}}
     {{ .Values.namespace | default .Release.Namespace }}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "trust-manager.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "trust-manager.name" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/deploy/charts/trust-manager/templates/deployment.yaml
+++ b/deploy/charts/trust-manager/templates/deployment.yaml
@@ -29,7 +29,10 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
     spec:
-      serviceAccountName: {{ include "trust-manager.name" . }}
+      serviceAccountName: {{ include "trust-manager.serviceAccountName" . }}
+      {{- if hasKey .Values "automountServiceAccountToken" }}
+      automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
+      {{- end }}
       {{- if .Values.defaultPackage.enabled }}
       initContainers:
       - name: cert-manager-package-debian
@@ -104,6 +107,9 @@ spec:
         - mountPath: /packages
           name: packages
           readOnly: true
+        {{- with .Values.volumeMounts }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         resources:
           {{- toYaml .Values.resources | nindent 12 }}
         securityContext:
@@ -144,8 +150,10 @@ spec:
         secret:
           defaultMode: 420
           secretName: {{ include "trust-manager.name" . }}-tls
+      {{- with .Values.volumes }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
       {{- if .Values.app.webhook.hostNetwork }}
       hostNetwork: true
       dnsPolicy: ClusterFirstWithHostNet
       {{- end }}
-

--- a/deploy/charts/trust-manager/templates/serviceaccount.yaml
+++ b/deploy/charts/trust-manager/templates/serviceaccount.yaml
@@ -1,5 +1,7 @@
+{{- if .Values.serviceAccount.create }}
 apiVersion: v1
 kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
   name: {{ include "trust-manager.name" . }}
   namespace: {{ include "trust-manager.namespace" . }}
@@ -8,4 +10,5 @@ metadata:
 {{- with .Values.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}
+{{- end }}
 {{- end }}

--- a/deploy/charts/trust-manager/values.schema.json
+++ b/deploy/charts/trust-manager/values.schema.json
@@ -9,6 +9,9 @@
         "app": {
           "$ref": "#/$defs/helm-values.app"
         },
+        "automountServiceAccountToken": {
+          "$ref": "#/$defs/helm-values.automountServiceAccountToken"
+        },
         "commonLabels": {
           "$ref": "#/$defs/helm-values.commonLabels"
         },
@@ -57,11 +60,20 @@
         "secretTargets": {
           "$ref": "#/$defs/helm-values.secretTargets"
         },
+        "serviceAccount": {
+          "$ref": "#/$defs/helm-values.serviceAccount"
+        },
         "tolerations": {
           "$ref": "#/$defs/helm-values.tolerations"
         },
         "topologySpreadConstraints": {
           "$ref": "#/$defs/helm-values.topologySpreadConstraints"
+        },
+        "volumeMounts": {
+          "$ref": "#/$defs/helm-values.volumeMounts"
+        },
+        "volumes": {
+          "$ref": "#/$defs/helm-values.volumes"
         }
       },
       "type": "object"
@@ -458,6 +470,11 @@
       "description": "Whether to issue a webhook cert using Helm, which removes the need to install cert-manager. Helm-issued certificates can be challenging to rotate and maintain, and the issued cert will have a duration of 10 years and be modified when trust-manager is updated. It's safer and easier to rely on cert-manager for issuing the webhook cert - avoid using Helm-generated certs in production.",
       "type": "boolean"
     },
+    "helm-values.automountServiceAccountToken": {
+      "default": true,
+      "description": "Automounting API credentials for the trust-manager pod.",
+      "type": "boolean"
+    },
     "helm-values.commonLabels": {
       "default": {},
       "description": "Labels to apply to all resources",
@@ -704,6 +721,35 @@
       "description": "If set to true, enable writing trust bundles to Kubernetes Secrets as a target. trust-manager can only write to secrets which are explicitly allowed via either authorizedSecrets or authorizedSecretsAll. Note that enabling secret targets will grant trust-manager read access to all secrets in the cluster.",
       "type": "boolean"
     },
+    "helm-values.serviceAccount": {
+      "additionalProperties": false,
+      "properties": {
+        "automountServiceAccountToken": {
+          "$ref": "#/$defs/helm-values.serviceAccount.automountServiceAccountToken"
+        },
+        "create": {
+          "$ref": "#/$defs/helm-values.serviceAccount.create"
+        },
+        "name": {
+          "$ref": "#/$defs/helm-values.serviceAccount.name"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.serviceAccount.automountServiceAccountToken": {
+      "default": true,
+      "description": "Automount API credentials for a Service Account.",
+      "type": "boolean"
+    },
+    "helm-values.serviceAccount.create": {
+      "default": true,
+      "description": "Specifies whether a service account should be created.",
+      "type": "boolean"
+    },
+    "helm-values.serviceAccount.name": {
+      "description": "The name of the service account to use.\nIf not set and create is true, a name is generated using the fullname template.",
+      "type": "string"
+    },
     "helm-values.tolerations": {
       "default": [],
       "description": "List of Kubernetes Tolerations, if required. For more information, see [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core).\nFor example:\ntolerations:\n- key: foo.bar.com/role\n  operator: Equal\n  value: master\n  effect: NoSchedule",
@@ -713,6 +759,18 @@
     "helm-values.topologySpreadConstraints": {
       "default": [],
       "description": "List of Kubernetes TopologySpreadConstraints. For more information, see [TopologySpreadConstraint v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#topologyspreadconstraint-v1-core).\nFor example:\ntopologySpreadConstraints:\n- maxSkew: 2\n  topologyKey: topology.kubernetes.io/zone\n  whenUnsatisfiable: ScheduleAnyway\n  labelSelector:\n    matchLabels:\n      app.kubernetes.io/name: trust-manager",
+      "items": {},
+      "type": "array"
+    },
+    "helm-values.volumeMounts": {
+      "default": [],
+      "description": "Additional volume mounts to add to the trust-manager container.",
+      "items": {},
+      "type": "array"
+    },
+    "helm-values.volumes": {
+      "default": [],
+      "description": "Additional volumes to add to the trust-manager pod.",
       "items": {},
       "type": "array"
     }

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -104,6 +104,30 @@ defaultPackageImage:
   # imagePullPolicy for the default package image.
   pullPolicy: IfNotPresent
 
+# Automounting API credentials for the trust-manager pod.
+# +docs:property
+automountServiceAccountToken: true
+
+serviceAccount:
+  # Specifies whether a service account should be created.
+  create: true
+
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template.
+  # +docs:property
+  # name: ""
+
+  # Automount API credentials for a Service Account.
+  # +docs:property
+  automountServiceAccountToken: true
+
+
+# Additional volumes to add to the trust-manager pod.
+volumes: []
+
+# Additional volume mounts to add to the trust-manager container.
+volumeMounts: []
+
 secretTargets:
   # If set to true, enable writing trust bundles to Kubernetes Secrets as a target.
   # trust-manager can only write to secrets which are explicitly allowed via either authorizedSecrets or authorizedSecretsAll.


### PR DESCRIPTION
### Motivation
The deployment of trust-manager in an AKS cluster raised a high-severity security finding from Azure Defender, recommending the disabling of automounted service account tokens to prevent potential misuse by compromised pods. 

This PR addresses the issue by allowing users to disable`automountServiceAccountToken` while enabling them to use volumes to access the token. This approach is based on the requirement that `trust-manager` needs the token to interact with the Kubernetes API.

With the proposed changes, you can deploy the chart using the following configuration:
```yml
automountServiceAccountToken: false
serviceAccount:
  automountServiceAccountToken: false
volumes:
- name: serviceaccount-token
  projected:
    defaultMode: 0444
    sources:
    - serviceAccountToken:
        expirationSeconds: 3607
        path: token
    - configMap:
        name: kube-root-ca.crt
        items:
        - key: ca.crt
          path: ca.crt
    - downwardAPI:
        items:
        - path: namespace
          fieldRef:
            apiVersion: v1
            fieldPath: metadata.namespace
volumeMounts:
- mountPath: /var/run/secrets/kubernetes.io/serviceaccount
  name: serviceaccount-token
  readOnly: true
```

Related to: https://github.com/cert-manager/cert-manager/issues/5254

### Changes

* Reuse an existing service account if necessary.
* Configure `automountServiceAccountToken` for both the pod and the service account.
* Enable defining and mounting volumes in the main container.

---
Signed-off-by: German Attanasio <germanattanasio@gmail.com>