### PR TITLE
Add 'fetch-depth: 0' to Debian trust bundle GH checkout action

### DIFF
--- a/.github/workflows/debian-trust-package-release.yaml
+++ b/.github/workflows/debian-trust-package-release.yaml
@@ -16,6 +16,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        # Adding `fetch-depth: 0` makes sure tags are also fetched. We need
+        # the tags so `git describe` returns a valid version.
+        # see https://github.com/actions/checkout/issues/701 for extra info about this option
+        with: { fetch-depth: 0 }
 
       - id: go-version
         run: |

--- a/.github/workflows/debian-trust-package-upgrade.yaml
+++ b/.github/workflows/debian-trust-package-upgrade.yaml
@@ -25,6 +25,10 @@ jobs:
           exit 1
 
       - uses: actions/checkout@v4
+        # Adding `fetch-depth: 0` makes sure tags are also fetched. We need
+        # the tags so `git describe` returns a valid version.
+        # see https://github.com/actions/checkout/issues/701 for extra info about this option
+        with: { fetch-depth: 0 }
 
       - id: go-version
         run: |


### PR DESCRIPTION
Fixes this broken action: https://github.com/cert-manager/trust-manager/actions/runs/12498139714