### PR TITLE
Upgrade oci-build makefile module

### DIFF
--- a/klone.yaml
+++ b/klone.yaml
@@ -10,65 +10,65 @@ targets:
     - folder_name: boilerplate
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 4c928b49036b018acd01eabf3bdcd21be73201a5
+      repo_hash: b1859976bc6d4b0f5c3a231d6665cf3ecb5e6c66
       repo_path: modules/boilerplate
     - folder_name: cert-manager
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 4c928b49036b018acd01eabf3bdcd21be73201a5
+      repo_hash: b1859976bc6d4b0f5c3a231d6665cf3ecb5e6c66
       repo_path: modules/cert-manager
     - folder_name: controller-gen
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 4c928b49036b018acd01eabf3bdcd21be73201a5
+      repo_hash: b1859976bc6d4b0f5c3a231d6665cf3ecb5e6c66
       repo_path: modules/controller-gen
     - folder_name: generate-verify
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 4c928b49036b018acd01eabf3bdcd21be73201a5
+      repo_hash: b1859976bc6d4b0f5c3a231d6665cf3ecb5e6c66
       repo_path: modules/generate-verify
     - folder_name: go
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 4c928b49036b018acd01eabf3bdcd21be73201a5
+      repo_hash: b1859976bc6d4b0f5c3a231d6665cf3ecb5e6c66
       repo_path: modules/go
     - folder_name: helm
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 4c928b49036b018acd01eabf3bdcd21be73201a5
+      repo_hash: b1859976bc6d4b0f5c3a231d6665cf3ecb5e6c66
       repo_path: modules/helm
     - folder_name: help
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 4c928b49036b018acd01eabf3bdcd21be73201a5
+      repo_hash: b1859976bc6d4b0f5c3a231d6665cf3ecb5e6c66
       repo_path: modules/help
     - folder_name: kind
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 4c928b49036b018acd01eabf3bdcd21be73201a5
+      repo_hash: b1859976bc6d4b0f5c3a231d6665cf3ecb5e6c66
       repo_path: modules/kind
     - folder_name: klone
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 4c928b49036b018acd01eabf3bdcd21be73201a5
+      repo_hash: b1859976bc6d4b0f5c3a231d6665cf3ecb5e6c66
       repo_path: modules/klone
     - folder_name: oci-build
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 4c928b49036b018acd01eabf3bdcd21be73201a5
+      repo_hash: b1859976bc6d4b0f5c3a231d6665cf3ecb5e6c66
       repo_path: modules/oci-build
     - folder_name: oci-publish
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 4c928b49036b018acd01eabf3bdcd21be73201a5
+      repo_hash: b1859976bc6d4b0f5c3a231d6665cf3ecb5e6c66
       repo_path: modules/oci-publish
     - folder_name: repository-base
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 4c928b49036b018acd01eabf3bdcd21be73201a5
+      repo_hash: b1859976bc6d4b0f5c3a231d6665cf3ecb5e6c66
       repo_path: modules/repository-base
     - folder_name: tools
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main
-      repo_hash: 4c928b49036b018acd01eabf3bdcd21be73201a5
+      repo_hash: b1859976bc6d4b0f5c3a231d6665cf3ecb5e6c66
       repo_path: modules/tools

--- a/make/00_mod.mk
+++ b/make/00_mod.mk
@@ -38,6 +38,8 @@ oci_package_debian_base_image_flavor := static
 oci_package_debian_image_name := quay.io/jetstack/cert-manager-package-debian
 oci_package_debian_image_tag := $(DEBIAN_BUNDLE_VERSION)
 oci_package_debian_image_name_development := cert-manager.local/cert-manager-package-debian
+debian_package_layer := $(bin_dir)/scratch/debian-trust-package
+oci_package_debian_additional_layers += $(debian_package_layer)
 
 deploy_name := trust-manager
 deploy_namespace := cert-manager

--- a/make/_shared/go/01_mod.mk
+++ b/make/_shared/go/01_mod.mk
@@ -20,7 +20,6 @@ ifndef repo_name
 $(error repo_name is not set)
 endif
 
-go_base_dir := $(dir $(lastword $(MAKEFILE_LIST)))/base/
 golangci_lint_override := $(dir $(lastword $(MAKEFILE_LIST)))/.golangci.override.yaml
 
 .PHONY: go-workspace
@@ -58,11 +57,17 @@ generate-go-mod-tidy: | $(NEEDS_GO)
 
 shared_generate_targets += generate-go-mod-tidy
 
+default_govulncheck_generate_base_dir := $(dir $(lastword $(MAKEFILE_LIST)))/base/
+# The base directory used to copy the govulncheck GH action from. This can be
+# overwritten with an action with extra authentication or with a totally different
+# pipeline (eg. a GitLab pipeline).
+govulncheck_generate_base_dir ?= $(default_govulncheck_generate_base_dir)
+
 .PHONY: generate-govulncheck
 ## Generate base files in the repository
 ## @category [shared] Generate/ Verify
 generate-govulncheck:
-	cp -r $(go_base_dir)/. ./
+	cp -r $(govulncheck_generate_base_dir)/. ./
 
 shared_generate_targets += generate-govulncheck
 

--- a/make/_shared/oci-build/00_mod.mk
+++ b/make/_shared/oci-build/00_mod.mk
@@ -24,6 +24,7 @@ base_image_csi-static := quay.io/jetstack/base-static-csi@sha256:c30595ad2eed496
 
 # Utility functions
 fatal_if_undefined = $(if $(findstring undefined,$(origin $1)),$(error $1 is not set))
+fatal_if_deprecated_defined = $(if $(findstring undefined,$(origin $1)),,$(error $1 is deprecated, use $2 instead))
 
 # Validate globals that are required
 $(call fatal_if_undefined,bin_dir)
@@ -37,9 +38,11 @@ GOEXPERIMENT ?=  # empty by default
 #
 # $1 - build_name
 define default_per_build_variables
-cgo_enabled_$1 ?= $(CGO_ENABLED)
-goexperiment_$1 ?= $(GOEXPERIMENT)
-oci_additional_layers_$1 ?= 
+go_$1_cgo_enabled ?= $(CGO_ENABLED)
+go_$1_goexperiment ?= $(GOEXPERIMENT)
+go_$1_flags ?= -tags=
+oci_$1_additional_layers ?= 
+oci_$1_linux_capabilities ?= 
 endef
 
 $(foreach build_name,$(build_names),$(eval $(call default_per_build_variables,$(build_name))))
@@ -48,6 +51,11 @@ $(foreach build_name,$(build_names),$(eval $(call default_per_build_variables,$(
 #
 # $1 - build_name
 define check_per_build_variables
+# Validate deprecated variables
+$(call fatal_if_deprecated_defined,cgo_enabled_$1,go_$1_cgo_enabled)
+$(call fatal_if_deprecated_defined,goexperiment_$1,go_$1_goexperiment)
+$(call fatal_if_deprecated_defined,oci_additional_layers_$1,oci_$1_additional_layers)
+
 # Validate required config exists
 $(call fatal_if_undefined,go_$1_ldflags)
 $(call fatal_if_undefined,go_$1_main_dir)

--- a/make/_shared/oci-build/01_mod.mk
+++ b/make/_shared/oci-build/01_mod.mk
@@ -31,11 +31,13 @@ $(ko_config_path_$1:$(CURDIR)/%=%): | $(NEEDS_YQ) $(bin_dir)/scratch/image
 		$(YQ) '.builds[0].id = "$1"' | \
 		$(YQ) '.builds[0].dir = "$(go_$1_mod_dir)"' | \
 		$(YQ) '.builds[0].main = "$(go_$1_main_dir)"' | \
-		$(YQ) '.builds[0].env[0] = "CGO_ENABLED=$(cgo_enabled_$1)"' | \
-		$(YQ) '.builds[0].env[1] = "GOEXPERIMENT=$(goexperiment_$1)"' | \
+		$(YQ) '.builds[0].env[0] = "CGO_ENABLED=$(go_$1_cgo_enabled)"' | \
+		$(YQ) '.builds[0].env[1] = "GOEXPERIMENT=$(go_$1_goexperiment)"' | \
 		$(YQ) '.builds[0].ldflags[0] = "-s"' | \
 		$(YQ) '.builds[0].ldflags[1] = "-w"' | \
-		$(YQ) '.builds[0].ldflags[2] = "{{.Env.LDFLAGS}}"' \
+		$(YQ) '.builds[0].ldflags[2] = "{{.Env.LDFLAGS}}"' | \
+		$(YQ) '.builds[0].flags[0] = "$(go_$1_flags)"' | \
+		$(YQ) '.builds[0].linux_capabilities = "$(oci_$1_linux_capabilities)"' \
 		> $(CURDIR)/$(oci_layout_path_$1).ko_config.yaml
 
 ko-config-$1: $(ko_config_path_$1:$(CURDIR)/%=%)
@@ -66,7 +68,7 @@ $(oci_build_targets): oci-build-%: ko-config-% | $(NEEDS_KO) $(NEEDS_GO) $(NEEDS
 
 	$(IMAGE_TOOL) append-layers \
 		$(CURDIR)/$(oci_layout_path_$*) \
-		$(oci_additional_layers_$*)
+		$(oci_$*_additional_layers)
 
 	$(IMAGE_TOOL) list-digests \
 		$(CURDIR)/$(oci_layout_path_$*) \

--- a/make/debian-trust-package.mk
+++ b/make/debian-trust-package.mk
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-debian_package_layer := $(bin_dir)/scratch/debian-trust-package
 debian_package_json := $(debian_package_layer)/debian-package/cert-manager-package-debian.json
 
 $(debian_package_layer)/debian-package $(bin_dir)/bin:
@@ -25,8 +24,10 @@ $(debian_package_json): | $(bin_dir)/bin/validate-trust-package $(debian_package
 	BIN_VALIDATE_TRUST_PACKAGE=$(bin_dir)/bin/validate-trust-package \
 		./make/debian-trust-package-fetch.sh exact $(DEBIAN_BUNDLE_SOURCE_IMAGE) $@ $(DEBIAN_BUNDLE_VERSION)
 
+# Make sure the build the package json file when building
+# the OCI image. This will ensure that the $(debian_package_layer)
+# folder has the desired contents.
 oci-build-package_debian: $(debian_package_json)
-oci_additional_layers_package_debian += $(debian_package_layer)
 
 # see https://stackoverflow.com/a/53408233
 sed_inplace := sed -i''


### PR DESCRIPTION
In https://github.com/cert-manager/makefile-modules/pull/241 the `oci_additional_layers_package_debian` variable was renamed to `oci_package_debian_additional_layers`.