### PR TITLE
Use the debian bookworm package for testing + releases

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -151,14 +151,14 @@ repository: jetstack/cert-manager-package-debian
 #### **defaultPackageImage.repository** ~ `string`
 > Default value:
 > ```yaml
-> quay.io/jetstack/cert-manager-package-debian
+> quay.io/jetstack/trust-pkg-debian-bookworm
 > ```
 
 The repository for the default package image. This image enables the 'useDefaultCAs' source on Bundles.
 #### **defaultPackageImage.tag** ~ `string`
 > Default value:
 > ```yaml
-> "20210119.0"
+> "20230311.0"
 > ```
 
 Override the image tag of the default package image. If no value is set, the chart's appVersion is used.

--- a/deploy/charts/trust-manager/values.schema.json
+++ b/deploy/charts/trust-manager/values.schema.json
@@ -559,12 +559,12 @@
       "type": "string"
     },
     "helm-values.defaultPackageImage.repository": {
-      "default": "quay.io/jetstack/cert-manager-package-debian",
+      "default": "quay.io/jetstack/trust-pkg-debian-bookworm",
       "description": "The repository for the default package image. This image enables the 'useDefaultCAs' source on Bundles.",
       "type": "string"
     },
     "helm-values.defaultPackageImage.tag": {
-      "default": "20210119.0",
+      "default": "20230311.0",
       "description": "Override the image tag of the default package image. If no value is set, the chart's appVersion is used.",
       "type": "string"
     },

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -88,12 +88,12 @@ defaultPackageImage:
   # registry: quay.io
 
   # The repository for the default package image. This image enables the 'useDefaultCAs' source on Bundles.
-  repository: quay.io/jetstack/cert-manager-package-debian
+  repository: quay.io/jetstack/trust-pkg-debian-bookworm
 
   # Override the image tag of the default package image.
   # If no value is set, the chart's appVersion is used.
   # +docs:property
-  tag: "20210119.0"
+  tag: "20230311.0"
 
   # Target image digest. Override any tag, if set.
   # For example:

--- a/make/00_mod.mk
+++ b/make/00_mod.mk
@@ -67,7 +67,7 @@ define helm_values_mutation_function
 $(YQ) \
 	'( .image.repository = "$(oci_manager_image_name)" ) | \
 	( .image.tag = "$(oci_manager_image_tag)" ) | \
-	( .defaultPackageImage.repository = "$(oci_package_debian_image_name)" ) | \
-	( .defaultPackageImage.tag = "$(oci_package_debian_image_tag)" )' \
+	( .defaultPackageImage.repository = "$(oci_package_debian_bookworm_image_name)" ) | \
+	( .defaultPackageImage.tag = "$(oci_package_debian_bookworm_image_tag)" )' \
 	$1 --inplace
 endef

--- a/make/test-smoke.mk
+++ b/make/test-smoke.mk
@@ -46,7 +46,7 @@ endif
 
 test-smoke-deps: INSTALL_OPTIONS :=
 test-smoke-deps: INSTALL_OPTIONS += --set image.repository=$(oci_manager_image_name_development)
-test-smoke-deps: INSTALL_OPTIONS += --set defaultPackageImage.repository=$(oci_package_debian_image_name_development)
+test-smoke-deps: INSTALL_OPTIONS += --set defaultPackageImage.repository=$(oci_package_debian_bookworm_image_name_development)
 test-smoke-deps: INSTALL_OPTIONS += --set secretTargets.enabled=true --set secretTargets.authorizedSecretsAll=true
 test-smoke-deps: smoke-setup-cert-manager
 test-smoke-deps: install


### PR DESCRIPTION
This changes trust-manager to use the new Debian Bookworm trust package by default. I've tested this locally by doing the following:

1. Installed trust-manager v0.15.0 using the "old" default package
2. Created a bundle, saved the resulting `ConfigMap`
3. Manually edited the trust-manager deployment to use the new default package
4. Watched the ConfigMap, saw it get updated
5. Saved the new ConfigMap and confirmed it was different

The smoke test also uses the new package in this PR

Closes https://github.com/cert-manager/trust-manager/issues/183