### PR TITLE
Use Context to pass Logger

### DIFF
--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -1442,13 +1442,12 @@ func Test_Reconcile(t *testing.T) {
 				resourcePatches []interface{}
 			)
 
-			log, ctx := ktesting.NewTestContext(t)
+			_, ctx := ktesting.NewTestContext(t)
 			b := &bundle{
 				client:   fakeClient,
 				recorder: fakeRecorder,
 				clock:    fixedclock,
 				Options: Options{
-					Log:                  log,
 					Namespace:            trustNamespace,
 					SecretTargetsEnabled: !test.disableSecretTargets,
 					FilterExpiredCerts:   true,

--- a/pkg/bundle/controller.go
+++ b/pkg/bundle/controller.go
@@ -31,6 +31,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -71,7 +72,7 @@ func AddBundleController(
 
 		b.defaultPackage = &pkg
 
-		b.Options.Log.Info("successfully loaded default package from filesystem", "id", pkg.StringID(), "path", b.Options.DefaultPackageLocation)
+		logf.FromContext(ctx).Info("successfully loaded default package from filesystem", "id", pkg.StringID(), "path", b.Options.DefaultPackageLocation)
 	}
 
 	// Only reconcile config maps that match the well known name
@@ -191,7 +192,7 @@ func (b *bundle) enqueueRequestsFromBundleFunc(fn func(obj client.Object, bundle
 func (b *bundle) mustBundleList(ctx context.Context) *trustapi.BundleList {
 	var bundleList trustapi.BundleList
 	if err := b.client.List(ctx, &bundleList); err != nil {
-		b.Log.Error(err, "failed to list all Bundles, exiting error")
+		logf.FromContext(ctx).Error(err, "failed to list all Bundles, exiting error")
 		os.Exit(-1)
 	}
 

--- a/pkg/bundle/internal/target/target_test.go
+++ b/pkg/bundle/internal/target/target_test.go
@@ -600,14 +600,14 @@ func Test_syncConfigMapTarget(t *testing.T) {
 				resolvedBundle.BinaryData[pkcs12Key] = pkcs12Data
 			}
 
-			log, ctx := ktesting.NewTestContext(t)
+			_, ctx := ktesting.NewTestContext(t)
 			needsUpdate, err := r.Sync(ctx, Resource{
 				Kind:           KindConfigMap,
 				NamespacedName: types.NamespacedName{Name: bundleName, Namespace: test.namespace.Name},
 			}, &trustapi.Bundle{
 				ObjectMeta: metav1.ObjectMeta{Name: bundleName},
 				Spec:       spec,
-			}, resolvedBundle, log, test.shouldExist)
+			}, resolvedBundle, test.shouldExist)
 			assert.NoError(t, err)
 
 			assert.Equalf(t, test.expNeedsUpdate, needsUpdate, "unexpected needsUpdate, exp=%t got=%t", test.expNeedsUpdate, needsUpdate)
@@ -1212,14 +1212,14 @@ func Test_syncSecretTarget(t *testing.T) {
 				resolvedBundle.BinaryData[pkcs12Key] = pkcs12Data
 			}
 
-			log, ctx := ktesting.NewTestContext(t)
+			_, ctx := ktesting.NewTestContext(t)
 			needsUpdate, err := r.Sync(ctx, Resource{
 				Kind:           KindSecret,
 				NamespacedName: types.NamespacedName{Name: bundleName, Namespace: test.namespace.Name},
 			}, &trustapi.Bundle{
 				ObjectMeta: metav1.ObjectMeta{Name: bundleName},
 				Spec:       spec,
-			}, resolvedBundle, log, test.shouldExist)
+			}, resolvedBundle, test.shouldExist)
 			assert.NoError(t, err)
 
 			assert.Equalf(t, test.expNeedsUpdate, needsUpdate, "unexpected needsUpdate, exp=%t got=%t", test.expNeedsUpdate, needsUpdate)

--- a/pkg/bundle/source.go
+++ b/pkg/bundle/source.go
@@ -26,6 +26,7 @@ import (
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
 	"github.com/cert-manager/trust-manager/pkg/bundle/internal/target"
@@ -54,7 +55,7 @@ func (b *bundle) buildSourceBundle(ctx context.Context, sources []trustapi.Bundl
 	var resolvedBundle bundleData
 	certPool := util.NewCertPool(
 		util.WithFilteredExpiredCerts(b.FilterExpiredCerts),
-		util.WithLogger(b.Log.WithName("cert-pool")),
+		util.WithLogger(logf.FromContext(ctx).WithName("cert-pool")),
 	)
 
 	for _, source := range sources {
@@ -88,7 +89,7 @@ func (b *bundle) buildSourceBundle(ctx context.Context, sources []trustapi.Bundl
 
 		// A source selector may select no configmaps/secrets, and this is not an error.
 		if errors.As(err, &selectsNothingError{}) {
-			b.Log.Info(err.Error())
+			logf.FromContext(ctx).Info(err.Error())
 			continue
 		}
 

--- a/pkg/webhook/validation.go
+++ b/pkg/webhook/validation.go
@@ -21,24 +21,22 @@ import (
 	"fmt"
 	"strconv"
 
-	"github.com/go-logr/logr"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/validation"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/validation/field"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
 )
 
 // validator validates against trust.cert-manager.io resources.
-type validator struct {
-	log logr.Logger
-}
+type validator struct{}
 
 var _ admission.CustomValidator = &validator{}
 
 func (v *validator) ValidateCreate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
-	return v.validate(obj)
+	return v.validate(ctx, obj)
 }
 
 func (v *validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.Object) (admission.Warnings, error) {
@@ -65,7 +63,7 @@ func (v *validator) ValidateUpdate(ctx context.Context, oldObj, newObj runtime.O
 		el = append(el, field.Invalid(path.Child("target", "secret"), "", "target secret removal is not allowed"))
 		return nil, el.ToAggregate()
 	}
-	return v.validate(newObj)
+	return v.validate(ctx, newObj)
 }
 
 func (v *validator) ValidateDelete(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
@@ -73,12 +71,12 @@ func (v *validator) ValidateDelete(ctx context.Context, obj runtime.Object) (adm
 	return nil, nil
 }
 
-func (v *validator) validate(obj runtime.Object) (admission.Warnings, error) {
+func (v *validator) validate(ctx context.Context, obj runtime.Object) (admission.Warnings, error) {
 	bundle, ok := obj.(*trustapi.Bundle)
 	if !ok {
 		return nil, fmt.Errorf("expected a Bundle, but got a %T", obj)
 	}
-	log := v.log.WithValues("name", bundle.Name)
+	log := logf.FromContext(ctx, "name", bundle.Name)
 	log.V(2).Info("received validation request")
 	var (
 		el       field.ErrorList

--- a/pkg/webhook/validation_test.go
+++ b/pkg/webhook/validation_test.go
@@ -428,9 +428,9 @@ func Test_validate(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			log, _ := ktesting.NewTestContext(t)
-			v := &validator{log: log}
-			gotWarnings, gotErr := v.validate(test.bundle)
+			_, ctx := ktesting.NewTestContext(t)
+			v := &validator{}
+			gotWarnings, gotErr := v.validate(ctx, test.bundle)
 			if test.expErr == nil && gotErr != nil {
 				t.Errorf("got an unexpected error: %v", gotErr)
 			} else if test.expErr != nil && (gotErr == nil || *test.expErr != gotErr.Error()) {
@@ -481,8 +481,8 @@ func Test_validate_update(t *testing.T) {
 
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
-			log, ctx := ktesting.NewTestContext(t)
-			v := &validator{log: log}
+			_, ctx := ktesting.NewTestContext(t)
+			v := &validator{}
 			gotWarnings, gotErr := v.ValidateUpdate(ctx, test.oldBundle, test.newBundle)
 			if test.expErr == nil && gotErr != nil {
 				t.Errorf("got an unexpected error: %v", gotErr)

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -19,22 +19,15 @@ package webhook
 import (
 	"fmt"
 
-	"github.com/go-logr/logr"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
 )
 
-// Options are options for running the wehook.
-type Options struct {
-	Log logr.Logger
-}
-
 // Register the webhook endpoints against the Manager.
-func Register(mgr manager.Manager, opts Options) error {
-	opts.Log.Info("registering webhook endpoints")
-	validator := &validator{log: opts.Log.WithName("validation")}
+func Register(mgr manager.Manager) error {
+	validator := &validator{}
 	if err := builder.WebhookManagedBy(mgr).
 		For(&trustapi.Bundle{}).
 		WithValidator(validator).

--- a/test/integration/bundle/suite.go
+++ b/test/integration/bundle/suite.go
@@ -34,7 +34,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/config"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
-	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
 	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
@@ -96,7 +95,6 @@ var _ = Describe("Integration", func() {
 
 		By("Created trust Namespace: " + namespace.Name)
 		opts = bundle.Options{
-			Log:                    logf.Log,
 			Namespace:              namespace.Name,
 			DefaultPackageLocation: tmpFileName,
 		}
@@ -104,12 +102,12 @@ var _ = Describe("Integration", func() {
 		By("Make sure that manager is not running")
 		Expect(mgr).To(BeNil())
 
+		ctrl.SetLogger(log)
 		mgr, err = ctrl.NewManager(env.Config, ctrl.Options{
 			Scheme: trustapi.GlobalScheme,
 			// we don't need leader election for this test,
 			// there should only be one test running at a time
 			LeaderElection: false,
-			Logger:         log,
 			Controller: config.Controller{
 				// need to skip unique controller name validation
 				// since all tests need a dedicated controller

--- a/test/smoke/suite_test.go
+++ b/test/smoke/suite_test.go
@@ -19,7 +19,6 @@ package smoke
 import (
 	"context"
 
-	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -45,12 +44,10 @@ var _ = Describe("Smoke", func() {
 	var (
 		ctx    context.Context
 		cancel func()
-
-		log logr.Logger
 	)
 
 	BeforeEach(func() {
-		log, ctx = ktesting.NewTestContext(GinkgoT())
+		_, ctx = ktesting.NewTestContext(GinkgoT())
 		ctx, cancel = context.WithCancel(ctx)
 	})
 
@@ -68,7 +65,6 @@ var _ = Describe("Smoke", func() {
 		testData := env.DefaultTrustData()
 
 		testBundle := env.NewTestBundleConfigMapTarget(ctx, cl, bundle.Options{
-			Log:       log,
 			Namespace: cnf.TrustNamespace,
 		}, testData)
 
@@ -88,7 +84,6 @@ var _ = Describe("Smoke", func() {
 		testData := env.DefaultTrustData()
 
 		testBundle := env.NewTestBundleSecretTarget(ctx, cl, bundle.Options{
-			Log:       log,
 			Namespace: cnf.TrustNamespace,
 		}, testData)
 


### PR DESCRIPTION
As noted in https://github.com/cert-manager/trust-manager/pull/442#discussion_r1946705109, it seems like we prefer to use the Context to pass around the logger. I've also been annoyed by this when attempting to refactor code. 🦄 

This PR removes all use of Logger as fields in structs - except for the CertPool, which will probably be refactored out of this repository to a more reusable module.

This change will most certainly change the looks of trust-manager logs. Instead of creating a many sub-loggers, we now rely on controller-runtime to initialize the logger supplied with Context. To my experience it does a pretty good job enriching the structured logger with relevant key/value pairs.