### PR TITLE
Tweak JUnit config for e2e / integration tests

### DIFF
--- a/make/test-integration.mk
+++ b/make/test-integration.mk
@@ -18,7 +18,7 @@
 test-integration: | $(NEEDS_GOTESTSUM) $(NEEDS_ETCD) $(NEEDS_KUBE-APISERVER) $(NEEDS_KUBECTL) $(ARTIFACTS)
 	KUBEBUILDER_ASSETS=$(CURDIR)/$(bin_dir)/tools \
 	$(GOTESTSUM) \
-		--junitfile=$(ARTIFACTS)/junit-go-e2e.xml \
+		--junitfile=$(ARTIFACTS)/junit-go-integration.xml \
 		-- \
 		-coverprofile=$(ARTIFACTS)/filtered.cov \
 		./test/integration/... \

--- a/test/env/ginkgo.go
+++ b/test/env/ginkgo.go
@@ -17,9 +17,7 @@ limitations under the License.
 package env
 
 import (
-	"fmt"
 	"os"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -35,18 +33,6 @@ func init() {
 func RunSuite(t *testing.T, suiteName, artifactDir string) {
 	gomega.RegisterFailHandler(ginkgo.Fail)
 
-	// NB: ARTIFACTS is set in prow jobs to a location which prow uses when consuming reports
-	// see: https://docs.prow.k8s.io/docs/jobs/#job-environment-variables
-	if path := os.Getenv("ARTIFACTS"); len(path) > 0 {
-		artifactDir = path
-	}
-
-	if err := os.MkdirAll(artifactDir, 0o775); err != nil {
-		t.Fatalf("failed to ensure artifactDir %q exists to store reports in: %s", artifactDir, err.Error())
-	}
-
-	junitDestination := filepath.Join(artifactDir, fmt.Sprintf("junit-go-%s.xml", suiteName))
-
 	suiteConfig, reporterConfig := ginkgo.GinkgoConfiguration()
 
 	// NB: CI is set in prow jobs
@@ -55,8 +41,6 @@ func RunSuite(t *testing.T, suiteName, artifactDir string) {
 		reporterConfig.NoColor = true
 		reporterConfig.Verbose = true
 	}
-
-	reporterConfig.JUnitReport = junitDestination
 
 	suiteConfig.RandomizeAllSpecs = true
 


### PR DESCRIPTION
Fixes a few issues:

1. Integration test output had "e2e" in it, which is misleading
2. Integration test output had the same name as the smoke tests, leading to output for one overwriting the other
3. E2E test JUnit output was configured in both Go code and using CLI flags passed to ginkgo, which led to error messages in smoke tests

Example of smoke test errors (from [here](https://storage.googleapis.com/cert-manager-prow-artifacts/pr-logs/pull/cert-manager_trust-manager/550/pull-trust-manager-smoke/1887999307181723648/build-log.txt)):

> Could not open /logs/artifacts/test_smoke_junit-go-e2e.xml:
> open /logs/artifacts/test_smoke_junit-go-e2e.xml: no such file or directory