### PR TITLE
Add fetch-depth:0 to bookworm upgrade job

### DIFF
--- a/.github/workflows/debian-trust-package-upgrade-bookworm.yaml
+++ b/.github/workflows/debian-trust-package-upgrade-bookworm.yaml
@@ -25,6 +25,10 @@ jobs:
           exit 1
 
       - uses: actions/checkout@v4
+        # Adding `fetch-depth: 0` makes sure tags are also fetched. We need
+        # the tags so `git describe` returns a valid version.
+        # see https://github.com/actions/checkout/issues/701 for extra info about this option
+        with: { fetch-depth: 0 }
 
       - id: go-version
         run: |

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -38,7 +38,7 @@ As well as the trust-manager container images, we also publish a trust package i
 
 This repo will produce the following artifacts each release. For documentation on how those artifacts are produced see the "Process" section.
 
-- *Container Images* - Container images for the are published to `quay.io/jetstack`. 
+- *Container Images* - Container images for the are published to `quay.io/jetstack`.
 - *Helm chart* - An official Helm chart is maintained within this repo and published to `quay.io/jetstack` and `charts.jetstack.io` on each release.
 
 [release workflow]: https://github.com/cert-manager/trust-manager/actions/workflows/release.yaml


### PR DESCRIPTION
Also fixes some trailing whitespace

See #545 for a similar change.