### PR TITLE
Change names of actions workflows to be more explicit

### DIFF
--- a/.github/workflows/debian-trust-package-release-bookworm.yaml
+++ b/.github/workflows/debian-trust-package-release-bookworm.yaml
@@ -1,4 +1,4 @@
-name: debian-trust-package-release
+name: debian-trust-package-release-bookworm
 on:
   push:
     branches: ['main']

--- a/.github/workflows/debian-trust-package-release-bullseye.yaml
+++ b/.github/workflows/debian-trust-package-release-bullseye.yaml
@@ -1,4 +1,4 @@
-name: debian-trust-package-release
+name: debian-trust-package-release-bullseye
 on:
   push:
     branches: ['main']

--- a/.github/workflows/debian-trust-package-upgrade-bullseye.yaml
+++ b/.github/workflows/debian-trust-package-upgrade-bullseye.yaml
@@ -1,5 +1,5 @@
-name: debian-trust-package-upgrade
-concurrency: debian-trust-package-upgrade
+name: debian-trust-package-upgrade-bullseye
+concurrency: debian-trust-package-upgrade-bullseye
 on:
   workflow_dispatch: {}
   schedule:


### PR DESCRIPTION
This was mostly to ensure the name of the bookworm action was different, but I figured it made sense to rename the older ones too (on the assumption that that is safe)