### PR TITLE
add leaderElection flag to trust manager

### DIFF
--- a/cmd/trust-manager/app/app.go
+++ b/cmd/trust-manager/app/app.go
@@ -78,11 +78,11 @@ func NewCommand() *cobra.Command {
 			mgr, err := ctrl.NewManager(opts.RestConfig, ctrl.Options{
 				Scheme:                        trustapi.GlobalScheme,
 				EventBroadcaster:              eventBroadcaster,
-				LeaderElection:                opts.LeaderElection,
+				LeaderElection:                opts.LeaderElectionConfig.Enabled,
 				LeaderElectionID:              "trust-manager-leader-election",
 				LeaderElectionReleaseOnCancel: true,
-				LeaseDuration:                 &opts.LeaseDuration,
-				RenewDeadline:                 &opts.RenewDeadline,
+				LeaseDuration:                 &opts.LeaderElectionConfig.LeaseDuration,
+				RenewDeadline:                 &opts.LeaderElectionConfig.RenewDeadline,
 				ReadinessEndpointName:         opts.ReadyzPath,
 				HealthProbeBindAddress:        fmt.Sprintf("0.0.0.0:%d", opts.ReadyzPort),
 				WebhookServer: ctrlwebhook.NewServer(ctrlwebhook.Options{

--- a/cmd/trust-manager/app/app.go
+++ b/cmd/trust-manager/app/app.go
@@ -78,7 +78,7 @@ func NewCommand() *cobra.Command {
 			mgr, err := ctrl.NewManager(opts.RestConfig, ctrl.Options{
 				Scheme:                        trustapi.GlobalScheme,
 				EventBroadcaster:              eventBroadcaster,
-				LeaderElection:                true,
+				LeaderElection:                opts.LeaderElection,
 				LeaderElectionID:              "trust-manager-leader-election",
 				LeaderElectionReleaseOnCancel: true,
 				LeaseDuration:                 &opts.LeaseDuration,

--- a/cmd/trust-manager/app/options/options.go
+++ b/cmd/trust-manager/app/options/options.go
@@ -36,8 +36,8 @@ import (
 )
 
 type LeaderElectionConfig struct {
-	// If true, cert-manager will perform leader election between instances to
-	// ensure no more than one instance of cert-manager operates at a time
+	// If true, trust-manager will perform leader election between instances to
+	// ensure no more than one instance of trust-manager operates at a time
 	Enabled bool
 
 	// The duration that non-leader candidates will wait after observing a leadership

--- a/cmd/trust-manager/app/options/options.go
+++ b/cmd/trust-manager/app/options/options.go
@@ -35,6 +35,24 @@ import (
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
+type LeaderElectionConfig struct {
+	// If true, cert-manager will perform leader election between instances to
+	// ensure no more than one instance of cert-manager operates at a time
+	Enabled bool
+
+	// The duration that non-leader candidates will wait after observing a leadership
+	// renewal until attempting to acquire leadership of a led but unrenewed leader
+	// slot. This is effectively the maximum duration that a leader can be stopped
+	// before it is replaced by another candidate. This is only applicable if leader
+	// election is enabled.
+	LeaseDuration time.Duration
+
+	// The interval between attempts by the acting master to renew a leadership slot
+	// before it stops leading. This must be less than or equal to the lease duration.
+	// This is only applicable if leader election is enabled.
+	RenewDeadline time.Duration
+}
+
 // Options is a struct to hold options for trust-manager
 type Options struct {
 	kubeConfigFlags *genericclioptions.ConfigFlags
@@ -61,14 +79,7 @@ type Options struct {
 	// log are options controlling logging
 	log logOptions
 
-	// Leader election lease duration
-	LeaseDuration time.Duration
-
-	// Leader election if leader election is enabled
-	LeaderElection bool
-
-	// Leader election lease renew duration
-	RenewDeadline time.Duration
+	LeaderElectionConfig LeaderElectionConfig
 }
 
 type logOptions struct {
@@ -192,21 +203,21 @@ func (o *Options) addAppFlags(fs *pflag.FlagSet) {
 		"readiness-probe-path", "/readyz",
 		"HTTP path to expose the readiness probe server.")
 
-	fs.DurationVar(&o.LeaseDuration,
+	fs.BoolVar(&o.LeaderElectionConfig.Enabled, "leader-elect", true, ""+
+		"If true, trust-manager will perform leader election between instances to ensure no more "+
+		"than one instance of trust-manager operates at a time")
+
+	fs.DurationVar(&o.LeaderElectionConfig.LeaseDuration,
 		"leader-election-lease-duration", time.Second*15,
 		"Lease duration for leader election")
 
-	fs.DurationVar(&o.RenewDeadline,
+	fs.DurationVar(&o.LeaderElectionConfig.RenewDeadline,
 		"leader-election-renew-deadline", time.Second*10,
-		"Lease renew deadline for leader election")
+		"Lease renew deadline for leader election.")
 
 	fs.IntVar(&o.MetricsPort,
 		"metrics-port", 9402,
 		"Port to expose Prometheus metrics on 0.0.0.0 on path '/metrics'.")
-
-	fs.BoolVar(&o.LeaderElection,
-		"leader-election", true,
-		"Enable leader election for trust manager.")
 }
 
 func (o *Options) addBundleFlags(fs *pflag.FlagSet) {

--- a/cmd/trust-manager/app/options/options.go
+++ b/cmd/trust-manager/app/options/options.go
@@ -64,6 +64,9 @@ type Options struct {
 	// Leader election lease duration
 	LeaseDuration time.Duration
 
+	// Leader election if leader election is enabled
+	LeaderElection bool
+
 	// Leader election lease renew duration
 	RenewDeadline time.Duration
 }
@@ -200,6 +203,10 @@ func (o *Options) addAppFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&o.MetricsPort,
 		"metrics-port", 9402,
 		"Port to expose Prometheus metrics on 0.0.0.0 on path '/metrics'.")
+
+	fs.BoolVar(&o.LeaderElection,
+		"leader-election", true,
+		"Enable leader election for trust manager.")
 }
 
 func (o *Options) addBundleFlags(fs *pflag.FlagSet) {

--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -352,6 +352,13 @@ The format of trust-manager logging. Accepted values are text or json.
 > ```
 
 The verbosity of trust-manager logging. This takes a value from 1-5, with the higher value being more verbose.
+#### **app.leaderElection.enabled** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+Whether to enable leader election for trust-manager.
 #### **app.leaderElection.leaseDuration** ~ `string`
 > Default value:
 > ```yaml

--- a/deploy/charts/trust-manager/templates/deployment.yaml
+++ b/deploy/charts/trust-manager/templates/deployment.yaml
@@ -83,6 +83,7 @@ spec:
           - "--metrics-port={{.Values.app.metrics.port}}"
           - "--readiness-probe-port={{.Values.app.readinessProbe.port}}"
           - "--readiness-probe-path={{.Values.app.readinessProbe.path}}"
+          - "--leader-elect={{.Values.app.leaderElection.enabled}}"
           - "--leader-election-lease-duration={{.Values.app.leaderElection.leaseDuration}}"
           - "--leader-election-renew-deadline={{.Values.app.leaderElection.renewDeadline}}"
             # trust

--- a/deploy/charts/trust-manager/values.schema.json
+++ b/deploy/charts/trust-manager/values.schema.json
@@ -122,6 +122,9 @@
     "helm-values.app.leaderElection": {
       "additionalProperties": false,
       "properties": {
+        "enabled": {
+          "$ref": "#/$defs/helm-values.app.leaderElection.enabled"
+        },
         "leaseDuration": {
           "$ref": "#/$defs/helm-values.app.leaderElection.leaseDuration"
         },
@@ -130,6 +133,11 @@
         }
       },
       "type": "object"
+    },
+    "helm-values.app.leaderElection.enabled": {
+      "default": true,
+      "description": "Whether to enable leader election for trust-manager.",
+      "type": "boolean"
     },
     "helm-values.app.leaderElection.leaseDuration": {
       "default": "15s",

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -206,6 +206,8 @@ app:
   logLevel: 1
 
   leaderElection:
+    # Whether to enable leader election for trust-manager.
+    enabled: true
     # The duration that non-leader candidates will wait to force acquire leadership.
     # The default should be sufficient in a healthy cluster but can be slightly increased to prevent trust-manager from restart-looping when the API server is overloaded.
     leaseDuration: 15s


### PR DESCRIPTION
Fixes #499, by default the flag is true in order to preserve the original behavior