### PR TITLE
feat(helm-chart): add ability to set pod level security context

### DIFF
--- a/deploy/charts/trust-manager/templates/deployment.yaml
+++ b/deploy/charts/trust-manager/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
       {{- if hasKey .Values "automountServiceAccountToken" }}
       automountServiceAccountToken: {{ .Values.automountServiceAccountToken }}
       {{- end }}
+      {{- if .Values.app.podSecurityContext }}
+      securityContext: {{ toYaml .Values.app.podSecurityContext | nindent 8 }}
+      {{- end }}
       {{- if .Values.defaultPackage.enabled }}
       initContainers:
       - name: cert-manager-package-debian

--- a/deploy/charts/trust-manager/values.schema.json
+++ b/deploy/charts/trust-manager/values.schema.json
@@ -101,6 +101,9 @@
         "podAnnotations": {
           "$ref": "#/$defs/helm-values.app.podAnnotations"
         },
+        "podSecurityContext": {
+          "$ref": "#/$defs/helm-values.app.podSecurityContext"
+        },
         "podLabels": {
           "$ref": "#/$defs/helm-values.app.podLabels"
         },
@@ -267,6 +270,11 @@
     "helm-values.app.podAnnotations": {
       "default": {},
       "description": "Pod annotations to add to trust-manager pods.",
+      "type": "object"
+    },
+    "helm-values.app.podSecurityContext": {
+      "default": null,
+      "description": "Pod level security context to add to trust-manager pods.",
       "type": "object"
     },
     "helm-values.app.podLabels": {

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -237,6 +237,13 @@ app:
 
   # Pod annotations to add to trust-manager pods.
   podAnnotations: {}
+  
+  # Kubernetes pod level securityContext: see https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+  # for example:
+  #   podSecurityContext:
+  #     seccompProfile:
+  #       type: RuntimeDefault
+  # podSecurityContext: {}
 
   # +docs:section=Webhook
 


### PR DESCRIPTION
What
---
Adds a new helm value `app.podSecurityContext` that defaults to nil. When provided it acts as a pass through allowing users to adjust the pod level securityContext.

Evidence
---

#### Template with defaults
##### Command used
`helm template .`

##### Output
``` yaml
spec:
  replicas: 1
  selector:
    matchLabels:
      app: trust-manager
  template:
    metadata:
      labels:
        app: trust-manager
        app.kubernetes.io/name: trust-manager
        helm.sh/chart: trust-manager-v0.0.0
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/version: "v0.0.0"
        app.kubernetes.io/managed-by: Helm
    spec:
      serviceAccountName: trust-manager
      automountServiceAccountToken: true
      initContainers:
```

#### Template with podSecurityContext

##### Command used
`helm template . --set app.podSecurityContext.seccompProfile.type=RuntimeDefault`

##### Output
``` yaml
spec:
  replicas: 1
  selector:
    matchLabels:
      app: trust-manager
  template:
    metadata:
      labels:
        app: trust-manager
        app.kubernetes.io/name: trust-manager
        helm.sh/chart: trust-manager-v0.0.0
        app.kubernetes.io/instance: release-name
        app.kubernetes.io/version: "v0.0.0"
        app.kubernetes.io/managed-by: Helm
    spec:
      serviceAccountName: trust-manager
      automountServiceAccountToken: true
      securityContext: 
        seccompProfile:
          type: RuntimeDefault
```

Relates to: #147

Notes
---
I saw that the chart README.md is auto generated and the command to generate/update it looks to be `make generate-helm-docs` but this resulted in errors locally due to the detected version, is this something that needs to be updated in this PR and if so what's the best process to do so?