### PR TITLE
Fix Ginkgo commands

### DIFF
--- a/make/test-smoke.mk
+++ b/make/test-smoke.mk
@@ -56,9 +56,9 @@ test-smoke-deps: install
 ## @category Testing
 test-smoke: test-smoke-deps | kind-cluster $(NEEDS_GINKGO) $(ARTIFACTS)
 	$(GINKGO) \
-		--output-dir=$(ARTIFACTS) \
-		--junit-report=junit-go-e2e.xml \
+		--output-dir $(ARTIFACTS) \
+		--junit-report junit-go-e2e.xml \
+		--ldflags "$(go_manager_ldflags)" \
 		./test/smoke/ \
-		-ldflags $(go_manager_ldflags) \
 		-- \
 		--kubeconfig-path $(CURDIR)/$(kind_kubeconfig)


### PR DESCRIPTION
... failing with newer versions of Ginkgo, ref. CI failing in https://github.com/cert-manager/trust-manager/pull/572.

Ginkgo CLI is now validating commands more strictly than it used to, and I think our current commands broke with https://github.com/onsi/ginkgo/releases/tag/v2.23.1.