### PR TITLE
Added PKCS12 profile option

### DIFF
--- a/deploy/charts/trust-manager/templates/crd-trust.cert-manager.io_bundles.yaml
+++ b/deploy/charts/trust-manager/templates/crd-trust.cert-manager.io_bundles.yaml
@@ -266,6 +266,22 @@ spec:
                               description: Password for PKCS12 trust store
                               maxLength: 128
                               type: string
+                            profile:
+                              description: |-
+                                Profile specifies the key and certificate encryption algorithms and the HMAC algorithm
+                                used to create the PKCS12 keystore. Default value is `LegacyRC2` for backward compatibility.
+
+                                If provided, allowed values are:
+                                `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
+                                `LegacyDES`: Less secure algorithm. Use this option for maximal compatibility.
+                                `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms
+                                (eg. because of company policy). Please note that the security of the algorithm is not that important
+                                in reality, because the unencrypted certificate and private key are also stored in the Secret.
+                              enum:
+                                - LegacyRC2
+                                - LegacyDES
+                                - Modern2023
+                              type: string
                           required:
                             - key
                           type: object

--- a/deploy/crds/trust.cert-manager.io_bundles.yaml
+++ b/deploy/crds/trust.cert-manager.io_bundles.yaml
@@ -274,6 +274,22 @@ spec:
                             description: Password for PKCS12 trust store
                             maxLength: 128
                             type: string
+                          profile:
+                            description: |-
+                              Profile specifies the key and certificate encryption algorithms and the HMAC algorithm
+                              used to create the PKCS12 keystore. Default value is `LegacyRC2` for backward compatibility.
+
+                              If provided, allowed values are:
+                              `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
+                              `LegacyDES`: Less secure algorithm. Use this option for maximal compatibility.
+                              `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms
+                              (eg. because of company policy). Please note that the security of the algorithm is not that important
+                              in reality, because the unencrypted certificate and private key are also stored in the Secret.
+                            enum:
+                            - LegacyRC2
+                            - LegacyDES
+                            - Modern2023
+                            type: string
                         required:
                         - key
                         type: object

--- a/pkg/apis/trust/v1alpha1/types_bundle.go
+++ b/pkg/apis/trust/v1alpha1/types_bundle.go
@@ -158,7 +158,33 @@ type PKCS12 struct {
 	//+kubebuilder:validation:MaxLength=128
 	//+kubebuilder:default=""
 	Password *string `json:"password,omitempty"`
+
+	// Profile specifies the key and certificate encryption algorithms and the HMAC algorithm
+	// used to create the PKCS12 keystore. Default value is `LegacyRC2` for backward compatibility.
+	//
+	// If provided, allowed values are:
+	// `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
+	// `LegacyDES`: Less secure algorithm. Use this option for maximal compatibility.
+	// `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms
+	// (eg. because of company policy). Please note that the security of the algorithm is not that important
+	// in reality, because the unencrypted certificate and private key are also stored in the Secret.
+	// +optional
+	Profile PKCS12Profile `json:"profile,omitempty"`
 }
+
+// +kubebuilder:validation:Enum=LegacyRC2;LegacyDES;Modern2023
+type PKCS12Profile string
+
+const (
+	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#LegacyRC2
+	LegacyRC2PKCS12Profile PKCS12Profile = "LegacyRC2"
+
+	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#LegacyDES
+	LegacyDESPKCS12Profile PKCS12Profile = "LegacyDES"
+
+	// see: https://pkg.go.dev/software.sslmate.com/src/go-pkcs12#Modern2023
+	Modern2023PKCS12Profile PKCS12Profile = "Modern2023"
+)
 
 // SourceObjectKeySelector is a reference to a source object and its `data` key(s)
 // in the trust Namespace.

--- a/pkg/bundle/internal/target/target.go
+++ b/pkg/bundle/internal/target/target.go
@@ -428,7 +428,7 @@ func (b *Data) Populate(pool *util.CertPool, formats *trustapi.AdditionalFormats
 		}
 
 		if formats.PKCS12 != nil {
-			encoded, err := truststore.NewPKCS12Encoder(*formats.PKCS12.Password).Encode(pool)
+			encoded, err := truststore.NewPKCS12Encoder(*formats.PKCS12.Password, formats.PKCS12.Profile).Encode(pool)
 			if err != nil {
 				return fmt.Errorf("failed to encode PKCS12: %w", err)
 			}

--- a/pkg/bundle/internal/truststore/types_test.go
+++ b/pkg/bundle/internal/truststore/types_test.go
@@ -42,10 +42,16 @@ func Test_Encoder_Deterministic(t *testing.T) {
 			encoder: NewJKSEncoder("my-password"),
 		},
 		"PKCS#12 default password": {
-			encoder: NewPKCS12Encoder(v1alpha1.DefaultPKCS12Password),
+			encoder: NewPKCS12Encoder(v1alpha1.DefaultPKCS12Password, ""),
+		},
+		"PKCS#12 default password, DES encryption": {
+			encoder: NewPKCS12Encoder(v1alpha1.DefaultPKCS12Password, "LegacyDES"),
+		},
+		"PKCS#12 default password, modern encryption": {
+			encoder: NewPKCS12Encoder(v1alpha1.DefaultPKCS12Password, "Modern2023"),
 		},
 		"PKCS#12 custom password": {
-			encoder: NewPKCS12Encoder("my-password"),
+			encoder: NewPKCS12Encoder("my-password", ""),
 			// FIXME: We should try to make all encoders deterministic
 			expNonDeterministic: true,
 		},


### PR DESCRIPTION
This adds a profile option mirroring the values allowed here https://github.com/cert-manager/cert-manager/blob/e1a1ea959aa23ed72d9d7614b34d58ef420ad1d2/pkg/apis/certmanager/v1/types_certificate.go#L521. 

Fixes #457

FYI have not yet managed to get all the tests to run locally but the tests covering the truststore package itself seems to work fine.