### PR TITLE
Fixup PDB namespace population logic

### DIFF
--- a/deploy/charts/trust-manager/templates/poddisruptionbudget.yaml
+++ b/deploy/charts/trust-manager/templates/poddisruptionbudget.yaml
@@ -3,7 +3,7 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ include "trust-manager.name" . }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ include "trust-manager.namespace" . }}
   labels:
     app: {{ include "trust-manager.name" . }}
     {{- include "trust-manager.labels" . | nindent 4 }}


### PR DESCRIPTION
The current implementation does not account for namespace overrides via Helm Values for the PDB resource.

Instead, it uses `Release.Namespace` or, if undefined, it falls back to the 'default' namespace, which is inconsistent with how the namespace field is populated for all the other resources.

This PR makes the population of the `namespace` field consistent with all the other resources in the Helm Chart.