### PR TITLE
Add extraObjects to Helm chart

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -617,5 +617,29 @@ This configures the maximum unavailable pods for disruptions. It can either be s
 > ```
 
 Labels to apply to all resources
+#### **extraObjects** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+
+Extra manifests to be deployed. This is useful for deploying additional resources that are not part of the chart.  
+For example:
+
+```yaml
+extraObjects:
+ - apiVersion: cilium.io/v2
+   kind: CiliumNetworkPolicy
+   metadata:
+     name: trust-manager
+     namespace: trust-manager
+   spec:
+     endpointSelector:
+       matchLabels:
+         io.cilium.k8s.policy.serviceaccount: trust-manager
+     egress:
+       - toEntities:
+           - kube-apiserver
+```
 
 <!-- /AUTO-GENERATED -->

--- a/deploy/charts/trust-manager/templates/extra-manifests.yaml
+++ b/deploy/charts/trust-manager/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/deploy/charts/trust-manager/values.schema.json
+++ b/deploy/charts/trust-manager/values.schema.json
@@ -24,6 +24,9 @@
         "defaultPackageImage": {
           "$ref": "#/$defs/helm-values.defaultPackageImage"
         },
+        "extraObjects": {
+          "$ref": "#/$defs/helm-values.extraObjects"
+        },
         "filterExpiredCertificates": {
           "$ref": "#/$defs/helm-values.filterExpiredCertificates"
         },
@@ -591,6 +594,12 @@
       "default": "20230311.0",
       "description": "Override the image tag of the default package image. If no value is set, the chart's appVersion is used.",
       "type": "string"
+    },
+    "helm-values.extraObjects": {
+      "default": [],
+      "description": "Extra manifests to be deployed. This is useful for deploying additional resources that are not part of the chart.\nFor example:\nextraObjects:\n - apiVersion: cilium.io/v2\n   kind: CiliumNetworkPolicy\n   metadata:\n     name: trust-manager\n     namespace: trust-manager\n   spec:\n     endpointSelector:\n       matchLabels:\n         io.cilium.k8s.policy.serviceaccount: trust-manager\n     egress:\n       - toEntities:\n           - kube-apiserver",
+      "items": {},
+      "type": "array"
     },
     "helm-values.filterExpiredCertificates": {
       "additionalProperties": false,

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -351,3 +351,20 @@ podDisruptionBudget:
 
 # Labels to apply to all resources
 commonLabels: {}
+
+# Extra manifests to be deployed. This is useful for deploying additional resources that are not part of the chart.
+# For example:
+# extraObjects:
+#  - apiVersion: cilium.io/v2
+#    kind: CiliumNetworkPolicy
+#    metadata:
+#      name: trust-manager
+#      namespace: trust-manager
+#    spec:
+#      endpointSelector:
+#        matchLabels:
+#          io.cilium.k8s.policy.serviceaccount: trust-manager
+#      egress:
+#        - toEntities:
+#            - kube-apiserver
+extraObjects: []


### PR DESCRIPTION
This simply allows the addition of further resources through "extraObjects" in the values file, e.g. network policies.

Fixes #584 