### PR TITLE
Fix inconsistent TestCiphersSuite fails on webhook server not starting

### DIFF
--- a/cmd/trust-manager/app/ciphers_test.go
+++ b/cmd/trust-manager/app/ciphers_test.go
@@ -175,6 +175,22 @@ func setupWebHookServer(tmpDir string) error {
 		cmd.PrintErrf("error: %v\n", err)
 		return err
 	}
+
+	// Wait for the webhook server to be ready
+	for attempt := 0; attempt < 10; attempt++ {
+		var conn net.Conn
+		conn, err = net.DialTimeout("tcp", net.JoinHostPort(hostname, "6443"), 100*time.Millisecond)
+		if err != nil {
+			continue
+		}
+		_ = conn.Close()
+		break
+	}
+	if err != nil {
+		cmd.PrintErrf("error: %v\n", err)
+		return err
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
The Webhook server sometimes starts slower than it takes for the `TestCiphersSuite` tests to start running, this PR adds in a short loop to wait for the server to start accepting connections.

Fixes #593