### PR TITLE
Fix slightly misleading PKCS#12 profile API docs

### DIFF
--- a/deploy/charts/trust-manager/templates/crd-trust.cert-manager.io_bundles.yaml
+++ b/deploy/charts/trust-manager/templates/crd-trust.cert-manager.io_bundles.yaml
@@ -268,15 +268,15 @@ spec:
                               type: string
                             profile:
                               description: |-
-                                Profile specifies the key and certificate encryption algorithms and the HMAC algorithm
-                                used to create the PKCS12 keystore. Default value is `LegacyRC2` for backward compatibility.
+                                Profile specifies the certificate encryption algorithms and the HMAC algorithm
+                                used to create the PKCS12 trust store.
 
                                 If provided, allowed values are:
                                 `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
                                 `LegacyDES`: Less secure algorithm. Use this option for maximal compatibility.
-                                `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms
-                                (eg. because of company policy). Please note that the security of the algorithm is not that important
-                                in reality, because the unencrypted certificate and private key are also stored in the Secret.
+                                `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms (e.g. because of company policy).
+
+                                Default value is `LegacyRC2` for backward compatibility.
                               enum:
                                 - LegacyRC2
                                 - LegacyDES

--- a/deploy/crds/trust.cert-manager.io_bundles.yaml
+++ b/deploy/crds/trust.cert-manager.io_bundles.yaml
@@ -276,15 +276,15 @@ spec:
                             type: string
                           profile:
                             description: |-
-                              Profile specifies the key and certificate encryption algorithms and the HMAC algorithm
-                              used to create the PKCS12 keystore. Default value is `LegacyRC2` for backward compatibility.
+                              Profile specifies the certificate encryption algorithms and the HMAC algorithm
+                              used to create the PKCS12 trust store.
 
                               If provided, allowed values are:
                               `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
                               `LegacyDES`: Less secure algorithm. Use this option for maximal compatibility.
-                              `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms
-                              (eg. because of company policy). Please note that the security of the algorithm is not that important
-                              in reality, because the unencrypted certificate and private key are also stored in the Secret.
+                              `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms (e.g. because of company policy).
+
+                              Default value is `LegacyRC2` for backward compatibility.
                             enum:
                             - LegacyRC2
                             - LegacyDES

--- a/pkg/apis/trust/v1alpha1/types_bundle.go
+++ b/pkg/apis/trust/v1alpha1/types_bundle.go
@@ -159,15 +159,15 @@ type PKCS12 struct {
 	//+kubebuilder:default=""
 	Password *string `json:"password,omitempty"`
 
-	// Profile specifies the key and certificate encryption algorithms and the HMAC algorithm
-	// used to create the PKCS12 keystore. Default value is `LegacyRC2` for backward compatibility.
+	// Profile specifies the certificate encryption algorithms and the HMAC algorithm
+	// used to create the PKCS12 trust store.
 	//
 	// If provided, allowed values are:
 	// `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
 	// `LegacyDES`: Less secure algorithm. Use this option for maximal compatibility.
-	// `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms
-	// (eg. because of company policy). Please note that the security of the algorithm is not that important
-	// in reality, because the unencrypted certificate and private key are also stored in the Secret.
+	// `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms (e.g. because of company policy).
+	//
+	// Default value is `LegacyRC2` for backward compatibility.
 	// +optional
 	Profile PKCS12Profile `json:"profile,omitempty"`
 }

--- a/pkg/apis/trustmanager/v1alpha2/types_cluster_bundle.go
+++ b/pkg/apis/trustmanager/v1alpha2/types_cluster_bundle.go
@@ -159,15 +159,15 @@ type PKCS12 struct {
 	//+kubebuilder:default=""
 	Password *string `json:"password,omitempty"`
 
-	// Profile specifies the key and certificate encryption algorithms and the HMAC algorithm
-	// used to create the PKCS12 keystore. Default value is `LegacyRC2` for backward compatibility.
+	// Profile specifies the certificate encryption algorithms and the HMAC algorithm
+	// used to create the PKCS12 trust store.
 	//
 	// If provided, allowed values are:
 	// `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
 	// `LegacyDES`: Less secure algorithm. Use this option for maximal compatibility.
-	// `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms
-	// (eg. because of company policy). Please note that the security of the algorithm is not that important
-	// in reality, because the unencrypted certificate and private key are also stored in the Secret.
+	// `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms (e.g. because of company policy).
+	//
+	// Default value is `LegacyRC2` for backward compatibility.
 	// +optional
 	Profile PKCS12Profile `json:"profile,omitempty"`
 }


### PR DESCRIPTION
While working on https://github.com/cert-manager/trust-manager/pull/486, I noticed that the API doc (probably copied from cert-manager) is slightly misleading for trust-manager use. This PR attempts to fix this.

/cc @terricain @SgtCoDFish 