### PR TITLE
Adding common annotations for all the resources

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -617,6 +617,14 @@ This configures the maximum unavailable pods for disruptions. It can either be s
 > ```
 
 Labels to apply to all resources
+#### **commonAnnotations** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+Annotations to apply to all resources  
+NOTE: These annotations won't be added to the CRDs.
 #### **extraObjects** ~ `array`
 > Default value:
 > ```yaml

--- a/deploy/charts/trust-manager/templates/certificate.yaml
+++ b/deploy/charts/trust-manager/templates/certificate.yaml
@@ -7,6 +7,10 @@ metadata:
   namespace: {{ include "trust-manager.namespace" . }}
   labels:
     {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selfSigned: {}
 
@@ -19,6 +23,10 @@ metadata:
   namespace: {{ include "trust-manager.namespace" . }}
   labels:
     {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   commonName: "{{ include "trust-manager.name" . }}.{{ include "trust-manager.namespace" . }}.svc"
   dnsNames:
@@ -44,6 +52,10 @@ metadata:
   name: trust-manager-policy
   labels:
     {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   allowed:
     commonName:
@@ -66,6 +78,10 @@ metadata:
   name: trust-manager-policy-role
   labels:
     {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 rules:
   - apiGroups: ["policy.cert-manager.io"]
     resources: ["certificaterequestpolicies"]
@@ -80,6 +96,10 @@ metadata:
   name: trust-manager-policy-binding
   labels:
     {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/deploy/charts/trust-manager/templates/clusterrole.yaml
+++ b/deploy/charts/trust-manager/templates/clusterrole.yaml
@@ -3,6 +3,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
     {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   name: {{ include "trust-manager.name" . }}
 rules:
 - apiGroups:

--- a/deploy/charts/trust-manager/templates/clusterrolebinding.yaml
+++ b/deploy/charts/trust-manager/templates/clusterrolebinding.yaml
@@ -3,6 +3,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   labels:
     {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
   name: {{ include "trust-manager.name" . }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/charts/trust-manager/templates/deployment.yaml
+++ b/deploy/charts/trust-manager/templates/deployment.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ include "trust-manager.namespace" . }}
   labels:
     {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:

--- a/deploy/charts/trust-manager/templates/metrics-service.yaml
+++ b/deploy/charts/trust-manager/templates/metrics-service.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     app: {{ include "trust-manager.name" . }}
     {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.app.metrics.service.type }}
   {{- if .Values.app.metrics.service.ipFamilyPolicy }}

--- a/deploy/charts/trust-manager/templates/metrics-servicemonitor.yaml
+++ b/deploy/charts/trust-manager/templates/metrics-servicemonitor.yaml
@@ -8,6 +8,10 @@ metadata:
     app: {{ include "trust-manager.name" . }}
     {{- include "trust-manager.labels" . | nindent 4 }}
     prometheus: {{ .Values.app.metrics.service.servicemonitor.prometheusInstance }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- if .Values.app.metrics.service.servicemonitor.labels }}
 {{ toYaml .Values.app.metrics.service.servicemonitor.labels | indent 4}}
 {{- end }}

--- a/deploy/charts/trust-manager/templates/poddisruptionbudget.yaml
+++ b/deploy/charts/trust-manager/templates/poddisruptionbudget.yaml
@@ -7,6 +7,10 @@ metadata:
   labels:
     app: {{ include "trust-manager.name" . }}
     {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   selector:
     matchLabels:

--- a/deploy/charts/trust-manager/templates/role.yaml
+++ b/deploy/charts/trust-manager/templates/role.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Values.app.trust.namespace }}
   labels:
     {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 rules:
 - apiGroups:
   - ""
@@ -22,6 +26,10 @@ metadata:
   namespace: {{ include "trust-manager.namespace" . }}
   labels:
     {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 rules:
 - apiGroups:
   - "coordination.k8s.io"

--- a/deploy/charts/trust-manager/templates/rolebinding.yaml
+++ b/deploy/charts/trust-manager/templates/rolebinding.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Values.app.trust.namespace }}
   labels:
     {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -21,6 +25,10 @@ metadata:
   namespace: {{ include "trust-manager.namespace" . }}
   labels:
     {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/deploy/charts/trust-manager/templates/serviceaccount.yaml
+++ b/deploy/charts/trust-manager/templates/serviceaccount.yaml
@@ -7,6 +7,10 @@ metadata:
   namespace: {{ include "trust-manager.namespace" . }}
   labels:
     {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 {{- with .Values.imagePullSecrets }}
 imagePullSecrets:
   {{- toYaml . | nindent 2 }}

--- a/deploy/charts/trust-manager/templates/webhook.yaml
+++ b/deploy/charts/trust-manager/templates/webhook.yaml
@@ -36,7 +36,11 @@ metadata:
   name: {{ include "trust-manager.name" . }}-tls
   namespace: {{ .Release.Namespace }}
   labels:
-{{ include "trust-manager.labels" . | indent 4 }}
+    {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 type: kubernetes.io/tls
 data:
   ca.crt: {{ $ca.Cert | b64enc }}
@@ -55,6 +59,10 @@ metadata:
   labels:
     app: {{ include "trust-manager.name" . }}
     {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.app.webhook.service.type }}
   {{- if .Values.app.webhook.service.ipFamilyPolicy }}
@@ -83,11 +91,15 @@ metadata:
   labels:
     app: {{ include "trust-manager.name" . }}
     {{- include "trust-manager.labels" . | nindent 4 }}
-{{ if not .Values.app.webhook.tls.helmCert.enabled }}
+  {{- if or (not .Values.app.webhook.tls.helmCert.enabled) .Values.commonAnnotations }}
   annotations:
+    {{- if not .Values.app.webhook.tls.helmCert.enabled }}
     cert-manager.io/inject-ca-from: "{{ include "trust-manager.namespace" . }}/{{ include "trust-manager.name" . }}"
-{{ end }}
-
+    {{- end }}
+    {{- with .Values.commonAnnotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- end }}
 webhooks:
   - name: trust.cert-manager.io
     rules:

--- a/deploy/charts/trust-manager/values.schema.json
+++ b/deploy/charts/trust-manager/values.schema.json
@@ -12,6 +12,9 @@
         "automountServiceAccountToken": {
           "$ref": "#/$defs/helm-values.automountServiceAccountToken"
         },
+        "commonAnnotations": {
+          "$ref": "#/$defs/helm-values.commonAnnotations"
+        },
         "commonLabels": {
           "$ref": "#/$defs/helm-values.commonLabels"
         },
@@ -501,6 +504,11 @@
       "default": true,
       "description": "Automounting API credentials for the trust-manager pod.",
       "type": "boolean"
+    },
+    "helm-values.commonAnnotations": {
+      "default": {},
+      "description": "Annotations to apply to all resources\nNOTE: These annotations won't be added to the CRDs.",
+      "type": "object"
     },
     "helm-values.commonLabels": {
       "default": {},

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -292,7 +292,7 @@ app:
           #     my-secret-annotation-1: "foo"
           #     my-secret-annotation-2: "bar"
           #   labels:
-          #     my-secret-label: foo
+        #     my-secret-label: foo
 
     # This value specifies if the app should be started in hostNetwork mode. It is required for use in some managed Kubernetes clusters (such as AWS EKS) with custom CNI.
     hostNetwork: false
@@ -352,6 +352,9 @@ podDisruptionBudget:
 # Labels to apply to all resources
 commonLabels: {}
 
+# Annotations to apply to all resources
+# NOTE: These annotations won't be added to the CRDs.
+commonAnnotations: {}
 # Extra manifests to be deployed. This is useful for deploying additional resources that are not part of the chart.
 # For example:
 # extraObjects:


### PR DESCRIPTION
Adding a way for the users to add annotations for all the trust-manager resources. This PR is being raised as part of this https://github.com/cert-manager/trust-manager/issues/597 which indicates a use case for using argocd sync-waves.