### PR TITLE
Update LICENSES file

### DIFF
--- a/LICENSES
+++ b/LICENSES
@@ -1,5 +1,5 @@
 github.com/beorn7/perks/quantile,https://github.com/beorn7/perks/blob/v1.0.1/LICENSE,MIT
-github.com/blang/semver/v4,https://github.com/blang/semver/blob/v4.0.0/v4/LICENSE,MIT
+github.com/blang/semver/v4,https://github.com/blang/semver/blob/v4.0.0/LICENSE,MIT
 github.com/cert-manager/trust-manager,https://github.com/cert-manager/trust-manager/blob/HEAD/LICENSE,Apache-2.0
 github.com/cespare/xxhash/v2,https://github.com/cespare/xxhash/blob/v2.3.0/LICENSE.txt,MIT
 github.com/davecgh/go-spew/spew,https://github.com/davecgh/go-spew/blob/d8f796af33cc/LICENSE,ISC


### PR DESCRIPTION
It seems like the licenses generation is non-idempotent. Example: https://github.com/cert-manager/trust-manager/pull/615/files

To avoid unreleased changes on a functional PR, I suggest updating the file in a separate PR.