### PR TITLE
Revert "Use PKCS#12 encoder to encode JKS"

### DIFF
--- a/LICENSES
+++ b/LICENSES
@@ -31,6 +31,7 @@ github.com/monochromegane/go-gitignore,https://github.com/monochromegane/go-giti
 github.com/munnerz/goautoneg,https://github.com/munnerz/goautoneg/blob/a7dc8b61c822/LICENSE,BSD-3-Clause
 github.com/onsi/ginkgo/v2,https://github.com/onsi/ginkgo/blob/v2.23.4/LICENSE,MIT
 github.com/onsi/gomega,https://github.com/onsi/gomega/blob/v1.37.0/LICENSE,MIT
+github.com/pavlo-v-chernykh/keystore-go/v4,https://github.com/pavlo-v-chernykh/keystore-go/blob/v4.5.0/LICENSE,MIT
 github.com/peterbourgon/diskv,https://github.com/peterbourgon/diskv/blob/v2.0.1/LICENSE,MIT
 github.com/pkg/errors,https://github.com/pkg/errors/blob/v0.9.1/LICENSE,BSD-2-Clause
 github.com/prometheus/client_golang/internal/github.com/golang/gddo/httputil,https://github.com/prometheus/client_golang/blob/v1.22.0/internal/github.com/golang/gddo/LICENSE,BSD-3-Clause

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/go-cmp v0.7.0
 	github.com/onsi/ginkgo/v2 v2.23.4
 	github.com/onsi/gomega v1.37.0
+	github.com/pavlo-v-chernykh/keystore-go/v4 v4.5.0
 	github.com/spf13/cobra v1.9.1
 	github.com/spf13/pflag v1.0.6
 	github.com/stretchr/testify v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/onsi/ginkgo/v2 v2.23.4 h1:ktYTpKJAVZnDT4VjxSbiBenUjmlL/5QkBEocaWXiQus
 github.com/onsi/ginkgo/v2 v2.23.4/go.mod h1:Bt66ApGPBFzHyR+JO10Zbt0Gsp4uWxu5mIOTusL46e8=
 github.com/onsi/gomega v1.37.0 h1:CdEG8g0S133B4OswTDC/5XPSzE1OeP29QOioj2PID2Y=
 github.com/onsi/gomega v1.37.0/go.mod h1:8D9+Txp43QWKhM24yyOBEdpkzN8FvJyAwecBgsU4KU0=
+github.com/pavlo-v-chernykh/keystore-go/v4 v4.5.0 h1:2nosf3P75OZv2/ZO/9Px5ZgZ5gbKrzA3joN1QMfOGMQ=
+github.com/pavlo-v-chernykh/keystore-go/v4 v4.5.0/go.mod h1:lAVhWwbNaveeJmxrxuSTxMgKpF6DjnuVpn6T8WiBwYQ=
 github.com/peterbourgon/diskv v2.0.1+incompatible h1:UBdAOUP5p4RWqPBg048CAvpKN+vxiaj6gdUUzhl4XmI=
 github.com/peterbourgon/diskv v2.0.1+incompatible/go.mod h1:uqqh8zWWbv1HBMNONnaR/tNboyR3/BZd58JJSHlUSCU=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -55,8 +55,7 @@ func testEncodeJKS(t *testing.T, data string) []byte {
 		t.Fatal(err)
 	}
 
-	// Note: Must use the PKCS12 default password here, as encoding with (non-empty) password is non-deterministic.
-	encoded, err := truststore.NewJKSEncoder(trustapi.DefaultPKCS12Password).Encode(certPool)
+	encoded, err := truststore.NewJKSEncoder(trustapi.DefaultJKSPassword).Encode(certPool)
 	if err != nil {
 		t.Error(err)
 	}
@@ -145,8 +144,7 @@ func Test_Reconcile(t *testing.T) {
 				KeySelector: trustapi.KeySelector{
 					Key: "target.jks",
 				},
-				// Note: Must use the PKCS12 default password here, as encoding with (non-empty) password is non-deterministic.
-				Password: ptr.To(trustapi.DefaultPKCS12Password),
+				Password: ptr.To(trustapi.DefaultJKSPassword),
 			},
 		}
 		jksDefaultAdditionalFormatsOldPassword = trustapi.AdditionalFormats{

--- a/pkg/bundle/source_test.go
+++ b/pkg/bundle/source_test.go
@@ -17,11 +17,13 @@ limitations under the License.
 package bundle
 
 import (
+	"bytes"
 	"encoding/pem"
 	"errors"
 	"strings"
 	"testing"
 
+	jks "github.com/pavlo-v-chernykh/keystore-go/v4"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -488,14 +490,24 @@ func Test_buildSourceBundle(t *testing.T) {
 			assert.Equal(t, test.expJKS, jksExists)
 
 			if test.expJKS {
-				certs, err := pkcs12.DecodeTrustStore(binData, password)
+				reader := bytes.NewReader(binData)
+
+				ks := jks.New()
+
+				err := ks.Load(reader, []byte(password))
 				assert.Nil(t, err)
 
-				assert.Len(t, certs, 1)
+				entryNames := ks.Aliases()
+
+				assert.Len(t, entryNames, 1)
+				assert.True(t, ks.IsTrustedCertificateEntry(entryNames[0]))
+
+				// Safe to ignore errors here, we've tested that it's present and a TrustedCertificateEntry
+				cert, _ := ks.GetTrustedCertificateEntry(entryNames[0])
 
 				// Only one certificate block for this test, so we can safely ignore the `remaining` byte array
 				p, _ := pem.Decode([]byte(data))
-				assert.Equal(t, p.Bytes, certs[0].Raw)
+				assert.Equal(t, p.Bytes, cert.Certificate.Content)
 			}
 
 			binData, pkcs12Exists := resolvedBundle.Data.BinaryData[pkcs12Key]


### PR DESCRIPTION
This is a partial revert of https://github.com/cert-manager/trust-manager/pull/603, in particular changing JKS encoding to use the PKCS#12 encoder. Even if we tested this change on all Java LTS versions, it seems to have caused issues for users. I suggest to switch the encoder when we remove JKS from the Bundler/ClusterBundle spec.

Fixes https://github.com/cert-manager/trust-manager/issues/625