### PR TITLE
feat: Bump the ca-certificates package to 20230311+deb12u1

### DIFF
--- a/make/00_debian_bookworm_version.mk
+++ b/make/00_debian_bookworm_version.mk
@@ -17,5 +17,5 @@
 # This file is used to store the latest version of the debian trust package and the DEBIAN_BUNDLE_BOOKWORM_VERSION
 # variable is automatically updated by the `upgrade-debian-trust-package-version` target and cron GH action.
 
-DEBIAN_BUNDLE_BOOKWORM_VERSION=20230311.0
+DEBIAN_BUNDLE_BOOKWORM_VERSION=20230311+deb12u1
 DEBIAN_BUNDLE_BOOKWORM_SOURCE_IMAGE=docker.io/library/debian:12-slim


### PR DESCRIPTION
20230311+deb12u1 matches the current package used in `debian:12.11-slim`. Validated with:

```sh
docker run -ti --rm --name debian-bookworm-12-11 docker.io/library/debian:12.11-slim /bin/bash
apt-get update
apt-get install ca-certificates -y
apt list --installed | grep ca-cer
```

Output being:

```sh
ca-certificates/stable-updates,now 20230311+deb12u1 all [installed]
```

Hence updating the version we specify the match this.