### PR TITLE
refactor: dedicated struct for building source data

### DIFF
--- a/cmd/trust-manager/app/options/options.go
+++ b/cmd/trust-manager/app/options/options.go
@@ -31,7 +31,7 @@ import (
 	"k8s.io/client-go/rest"
 	cliflag "k8s.io/component-base/cli/flag"
 
-	"github.com/cert-manager/trust-manager/pkg/bundle"
+	"github.com/cert-manager/trust-manager/pkg/bundle/controller"
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
@@ -75,7 +75,7 @@ type Options struct {
 	Webhook
 
 	// Bundle are options specific to the Bundle controller.
-	Bundle bundle.Options
+	Bundle controller.Options
 
 	// log are options controlling logging
 	log logOptions

--- a/pkg/bundle/controller/options.go
+++ b/pkg/bundle/controller/options.go
@@ -1,0 +1,35 @@
+/*
+Copyright 2025 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package controller
+
+// Options hold options for the Bundle controller.
+type Options struct {
+	// Namespace is the trust Namespace that source data can be referenced.
+	Namespace string
+
+	// DefaultPackageLocation is the location on the filesystem from which the 'default'
+	// certificate package should be loaded. If set, a valid package must be successfully
+	// loaded in order for the controller to start. If unset, referring to the default
+	// certificate package in a `Bundle` resource will cause that Bundle to error.
+	DefaultPackageLocation string
+
+	// SecretTargetsEnabled controls if secret targets are enabled in the Bundle API.
+	SecretTargetsEnabled bool
+
+	// FilterExpiredCerts controls if expired certificates are filtered from the bundle.
+	FilterExpiredCerts bool
+}

--- a/pkg/bundle/internal/target/target_test.go
+++ b/pkg/bundle/internal/target/target_test.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
+	"github.com/cert-manager/trust-manager/pkg/bundle/internal/source"
 	"github.com/cert-manager/trust-manager/pkg/bundle/internal/ssa_client"
 	"github.com/cert-manager/trust-manager/test/dummy"
 )
@@ -654,7 +655,7 @@ func Test_syncConfigMapTarget(t *testing.T) {
 					AdditionalFormats: &trustapi.AdditionalFormats{},
 				},
 			}
-			resolvedBundle := Data{Data: data, BinaryData: make(map[string][]byte)}
+			resolvedBundle := source.BundleData{Data: data, BinaryData: make(map[string][]byte)}
 			if test.withJKS {
 				spec.Target.AdditionalFormats.JKS = &trustapi.JKS{
 					KeySelector: trustapi.KeySelector{
@@ -1285,7 +1286,7 @@ func Test_syncSecretTarget(t *testing.T) {
 					AdditionalFormats: &trustapi.AdditionalFormats{},
 				},
 			}
-			resolvedBundle := Data{Data: data, BinaryData: make(map[string][]byte)}
+			resolvedBundle := source.BundleData{Data: data, BinaryData: make(map[string][]byte)}
 			if test.withJKS {
 				spec.Target.AdditionalFormats.JKS = &trustapi.JKS{
 					KeySelector: trustapi.KeySelector{

--- a/test/env/data.go
+++ b/test/env/data.go
@@ -30,7 +30,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
-	bundlectrl "github.com/cert-manager/trust-manager/pkg/bundle"
+	"github.com/cert-manager/trust-manager/pkg/bundle/controller"
 	"github.com/cert-manager/trust-manager/pkg/util"
 	"github.com/cert-manager/trust-manager/test/dummy"
 
@@ -78,7 +78,7 @@ func DefaultTrustData() TestData {
 
 // newTestBundle creates a new Bundle in the API using the input test data.
 // Returns the create Bundle object.
-func newTestBundle(ctx context.Context, cl client.Client, opts bundlectrl.Options, td TestData, targetType string) *trustapi.Bundle {
+func newTestBundle(ctx context.Context, cl client.Client, opts controller.Options, td TestData, targetType string) *trustapi.Bundle {
 	By("creating trust Bundle")
 
 	configMap := corev1.ConfigMap{
@@ -148,13 +148,13 @@ func newTestBundle(ctx context.Context, cl client.Client, opts bundlectrl.Option
 
 // NewTestBundleSecretTarget creates a new Bundle in the API using the input test data.
 // Returns the create Bundle object.
-func NewTestBundleSecretTarget(ctx context.Context, cl client.Client, opts bundlectrl.Options, td TestData) *trustapi.Bundle {
+func NewTestBundleSecretTarget(ctx context.Context, cl client.Client, opts controller.Options, td TestData) *trustapi.Bundle {
 	return newTestBundle(ctx, cl, opts, td, "Secret")
 }
 
 // newTestBundleConfigMapTarget creates a new Bundle in the API using the input test data with target set to ConfigMap.
 // Returns the create Bundle object.
-func NewTestBundleConfigMapTarget(ctx context.Context, cl client.Client, opts bundlectrl.Options, td TestData) *trustapi.Bundle {
+func NewTestBundleConfigMapTarget(ctx context.Context, cl client.Client, opts controller.Options, td TestData) *trustapi.Bundle {
 	return newTestBundle(ctx, cl, opts, td, "ConfigMap")
 }
 

--- a/test/integration/bundle/suite.go
+++ b/test/integration/bundle/suite.go
@@ -38,6 +38,7 @@ import (
 
 	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
 	"github.com/cert-manager/trust-manager/pkg/bundle"
+	"github.com/cert-manager/trust-manager/pkg/bundle/controller"
 	"github.com/cert-manager/trust-manager/pkg/fspkg"
 	"github.com/cert-manager/trust-manager/test/dummy"
 	testenv "github.com/cert-manager/trust-manager/test/env"
@@ -62,7 +63,7 @@ var _ = Describe("Integration", func() {
 		cl         client.Client
 		mgr        manager.Manager
 		mgrStopped chan struct{}
-		opts       bundle.Options
+		opts       controller.Options
 
 		testBundle *trustapi.Bundle
 		testData   testenv.TestData
@@ -94,7 +95,7 @@ var _ = Describe("Integration", func() {
 		Expect(cl.Create(ctx, namespace)).NotTo(HaveOccurred())
 
 		By("Created trust Namespace: " + namespace.Name)
-		opts = bundle.Options{
+		opts = controller.Options{
 			Namespace:              namespace.Name,
 			DefaultPackageLocation: tmpFileName,
 		}

--- a/test/smoke/suite_test.go
+++ b/test/smoke/suite_test.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
-	"github.com/cert-manager/trust-manager/pkg/bundle"
+	"github.com/cert-manager/trust-manager/pkg/bundle/controller"
 	"github.com/cert-manager/trust-manager/test/dummy"
 	"github.com/cert-manager/trust-manager/test/env"
 
@@ -64,7 +64,7 @@ var _ = Describe("Smoke", func() {
 		By("Creating Bundle for test")
 		testData := env.DefaultTrustData()
 
-		testBundle := env.NewTestBundleConfigMapTarget(ctx, cl, bundle.Options{
+		testBundle := env.NewTestBundleConfigMapTarget(ctx, cl, controller.Options{
 			Namespace: cnf.TrustNamespace,
 		}, testData)
 
@@ -83,7 +83,7 @@ var _ = Describe("Smoke", func() {
 		By("Creating Bundle for test")
 		testData := env.DefaultTrustData()
 
-		testBundle := env.NewTestBundleSecretTarget(ctx, cl, bundle.Options{
+		testBundle := env.NewTestBundleSecretTarget(ctx, cl, controller.Options{
 			Namespace: cnf.TrustNamespace,
 		}, testData)
 


### PR DESCRIPTION
This PR is a rework of https://github.com/cert-manager/trust-manager/pull/442, where I have tried to address the initial review by Ashley.

The main motivation for this PR, is to get closer to a solution to https://github.com/cert-manager/trust-manager/issues/58, as the bundle controller cannot be used directly for this use case. But also preparations for https://github.com/cert-manager/trust-manager/issues/245 , which is something I really would love to do.

I can identify a few more general improvements in this:

- Better modularization, though far from perfect yet.
- Removing the strange `target.Data` struct that was introduced to extract target processing.