### PR TITLE
Final minor adjustments to new ClusterBundle API

### DIFF
--- a/pkg/apis/trust/v1alpha1/conversion.go
+++ b/pkg/apis/trust/v1alpha1/conversion.go
@@ -71,7 +71,9 @@ func Convert_v1alpha1_BundleSource_To_v1alpha2_BundleSource(in *BundleSource, ou
 		out.Name = sourceObjectKeySelector.Name
 		out.Selector = sourceObjectKeySelector.Selector
 		out.Key = sourceObjectKeySelector.Key
-		out.IncludeAllKeys = sourceObjectKeySelector.IncludeAllKeys
+		if sourceObjectKeySelector.IncludeAllKeys {
+			out.Key = "*"
+		}
 	}
 
 	if in.InLine != nil {
@@ -196,11 +198,17 @@ func Convert_v1alpha2_BundleSpec_To_v1alpha1_BundleSpec(in *trustv1alpha2.Bundle
 }
 
 func Convert_v1alpha2_BundleSource_To_v1alpha1_BundleSource(in *trustv1alpha2.BundleSource, out *BundleSource, _ apimachineryconversion.Scope) error {
+	key := in.Key
+	includeAllKeys := false
+	if in.Key == "*" {
+		key = ""
+		includeAllKeys = true
+	}
 	sourceObjectKeySelector := &SourceObjectKeySelector{
 		Name:           in.Name,
 		Selector:       in.Selector,
-		Key:            in.Key,
-		IncludeAllKeys: in.IncludeAllKeys,
+		Key:            key,
+		IncludeAllKeys: includeAllKeys,
 	}
 	switch in.Kind {
 	case trustv1alpha2.ConfigMapKind:

--- a/pkg/apis/trust/v1alpha1/conversion.go
+++ b/pkg/apis/trust/v1alpha1/conversion.go
@@ -130,7 +130,7 @@ func Convert_v1alpha1_BundleTarget_To_v1alpha2_BundleTarget(in *BundleTarget, ou
 		}
 	}
 
-	if out.NamespaceSelector == nil {
+	if in.NamespaceSelector == nil {
 		// NamespaceSelector is required in v1alpha2
 		out.NamespaceSelector = &metav1.LabelSelector{}
 	}

--- a/pkg/apis/trust/v1alpha1/conversion_test.go
+++ b/pkg/apis/trust/v1alpha1/conversion_test.go
@@ -40,6 +40,7 @@ func TestFuzzyConversion(t *testing.T) {
 func fuzzFuncs(_ runtimeserializer.CodecFactory) []interface{} {
 	return []interface{}{
 		spokeBundleSpecFuzzer,
+		spokeSourceObjectKeySelectorFuzzer,
 		spokeBundleTargetFuzzer,
 		hubBundleSourceFuzzer,
 		hubBundleTargetFuzzer,
@@ -66,6 +67,17 @@ func spokeBundleSpecFuzzer(obj *BundleSpec, c randfill.Continue) {
 		}
 		return sourceCount != 1
 	})
+}
+
+func spokeSourceObjectKeySelectorFuzzer(obj *SourceObjectKeySelector, c randfill.Continue) {
+	c.FillNoCustom(obj)
+
+	// Key and IncludeAllKeys cannot be used at the same time
+	if obj.IncludeAllKeys {
+		obj.Key = ""
+	} else if obj.Key == "" {
+		obj.IncludeAllKeys = true
+	}
 }
 
 func spokeBundleTargetFuzzer(obj *BundleTarget, c randfill.Continue) {

--- a/pkg/apis/trust/v1alpha1/types_bundle.go
+++ b/pkg/apis/trust/v1alpha1/types_bundle.go
@@ -45,7 +45,7 @@ type Bundle struct {
 
 	// Status of the Bundle. This is set and managed automatically.
 	// +optional
-	Status BundleStatus `json:"status"`
+	Status BundleStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/apis/trust/v1alpha1/zz_generated.conversion.go
+++ b/pkg/apis/trust/v1alpha1/zz_generated.conversion.go
@@ -120,7 +120,6 @@ func autoConvert_v1alpha1_BundleSource_To_v1alpha2_BundleSource(in *BundleSource
 func autoConvert_v1alpha2_BundleSource_To_v1alpha1_BundleSource(in *v1alpha2.BundleSource, out *BundleSource, s conversion.Scope) error {
 	// WARNING: in.SourceReference requires manual conversion: does not exist in peer-type
 	// WARNING: in.Key requires manual conversion: does not exist in peer-type
-	// WARNING: in.IncludeAllKeys requires manual conversion: does not exist in peer-type
 	return nil
 }
 

--- a/pkg/apis/trustmanager/v1alpha2/types_cluster_bundle.go
+++ b/pkg/apis/trustmanager/v1alpha2/types_cluster_bundle.go
@@ -90,15 +90,12 @@ type BundleSpec struct {
 type BundleSource struct {
 	SourceReference `json:",inline"`
 
-	// Key of the entry in the object's `data` field to be used.
-	//+optional
+	// Key(s) of the entry in the object's `data` field to be used.
+	// Wildcards "*" in Key matches any sequence characters.
+	// A Key containing only "*" will match all data fields.
 	// +kubebuilder:validation:MinLength=1
-	Key string `json:"key,omitempty"`
-
-	// IncludeAllKeys, if true, will include all keys in the source's `data` field when extracting certificates.
-	// Defaults to "false". This field must not be true when `Key` is set.
-	//+optional
-	IncludeAllKeys bool `json:"includeAllKeys,omitempty"`
+	// +kubebuilder:validation:Pattern=`^[0-9A-Za-z_.\-*]+$`
+	Key string `json:"key"`
 }
 
 // BundleTarget is the target resource that the Bundle will sync all source

--- a/pkg/apis/trustmanager/v1alpha2/types_cluster_bundle.go
+++ b/pkg/apis/trustmanager/v1alpha2/types_cluster_bundle.go
@@ -80,7 +80,8 @@ type BundleSpec struct {
 	InLineCAs *string `json:"InLineCAs,omitempty"`
 
 	// Target is the target location in all namespaces to sync source data to.
-	Target BundleTarget `json:"target"`
+	// +optional
+	Target BundleTarget `json:"target,omitzero"`
 }
 
 // BundleSource is the set of sources whose data will be appended and synced to

--- a/pkg/apis/trustmanager/v1alpha2/types_cluster_bundle.go
+++ b/pkg/apis/trustmanager/v1alpha2/types_cluster_bundle.go
@@ -45,7 +45,7 @@ type ClusterBundle struct {
 
 	// Status of the Bundle. This is set and managed automatically.
 	// +optional
-	Status BundleStatus `json:"status"`
+	Status BundleStatus `json:"status,omitzero"`
 }
 
 // +kubebuilder:object:root=true

--- a/pkg/apis/trustmanager/v1alpha2/types_cluster_bundle.go
+++ b/pkg/apis/trustmanager/v1alpha2/types_cluster_bundle.go
@@ -209,6 +209,7 @@ func (t *KeyValueTarget) GetLabels() map[string]string {
 type TargetKeyValue struct {
 	// Key is the key of the entry in the object's `data`field to be used.
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:Pattern=`^[0-9A-Za-z_.\-]+$`
 	Key string `json:"key"`
 
 	// Format defines the format of the target value.


### PR DESCRIPTION
After scrutinizing the new (unpublished) `ClusterBundle` API, I found a few potential improvements. I have created separate commits for each change, so this PR is better reviewed commit by commit. A summary of the proposed API changes:

1. Make `.spec.target` optional. This was done for the current `Bundle` in https://github.com/cert-manager/trust-manager/pull/661.
2. Drop the source `includeAllKeys` field in favor of simple wildcard (`*` only) support in the source `key`. This change allows us to make the source `key` mandatory, thus simplifying overall validation. We can always make it optional later on, when adding support for key-less sources. Since I am planning to use https://pkg.go.dev/path#Match for matching keys, I also added regex pattern validation to the source `key` field.
3. Added target `key` field regex pattern validation, inspired by the changes in source `key` (but no wildcard support here).

In addition, I fixed a minor bug (in<->out) in the conversion logic.

And finally I added the new Go 1.24 `omitzero` marker to bundle status. Since the status field is not a struct-pointer, we can ensure safer marshalling by adding this marker. This change was also backported to the current Bundle API.