### PR TITLE
Make bundle target optional

### DIFF
--- a/deploy/charts/trust-manager/templates/crd-trust.cert-manager.io_bundles.yaml
+++ b/deploy/charts/trust-manager/templates/crd-trust.cert-manager.io_bundles.yaml
@@ -393,7 +393,6 @@ spec:
                   type: object
               required:
                 - sources
-                - target
               type: object
             status:
               description: Status of the Bundle. This is set and managed automatically.

--- a/deploy/crds/trust.cert-manager.io_bundles.yaml
+++ b/deploy/crds/trust.cert-manager.io_bundles.yaml
@@ -411,7 +411,6 @@ spec:
                 type: object
             required:
             - sources
-            - target
             type: object
           status:
             description: Status of the Bundle. This is set and managed automatically.

--- a/pkg/apis/trust/v1alpha1/types_bundle.go
+++ b/pkg/apis/trust/v1alpha1/types_bundle.go
@@ -65,7 +65,8 @@ type BundleSpec struct {
 	Sources []BundleSource `json:"sources"`
 
 	// Target is the target location in all namespaces to sync source data to.
-	Target BundleTarget `json:"target"`
+	// +optional
+	Target BundleTarget `json:"target,omitzero"`
 }
 
 // BundleSource is the set of sources whose data will be appended and synced to

--- a/pkg/webhook/validation_test.go
+++ b/pkg/webhook/validation_test.go
@@ -47,7 +47,6 @@ func Test_validate(t *testing.T) {
 			},
 			expErr: ptr.To(field.ErrorList{
 				field.Forbidden(field.NewPath("spec", "sources"), "must define at least one source"),
-				field.Invalid(field.NewPath("spec", "target"), trustapi.BundleTarget{}, "must define at least one target"),
 			}.ToAggregate().Error()),
 		},
 		"sources with multiple types defined in items": {
@@ -218,32 +217,6 @@ func Test_validate(t *testing.T) {
 			},
 			expErr: ptr.To(field.ErrorList{
 				field.Forbidden(field.NewPath("spec", "sources", "[1]", "secret", "test-bundle", "test"), "cannot define the same source as target"),
-			}.ToAggregate().Error()),
-		},
-		"target configMap key not defined": {
-			bundle: &trustapi.Bundle{
-				Spec: trustapi.BundleSpec{
-					Sources: []trustapi.BundleSource{
-						{InLine: ptr.To("test")},
-					},
-					Target: trustapi.BundleTarget{ConfigMap: &trustapi.TargetTemplate{Key: ""}},
-				},
-			},
-			expErr: ptr.To(field.ErrorList{
-				field.Invalid(field.NewPath("spec", "target", "configMap", "key"), "", "target configMap key must be defined"),
-			}.ToAggregate().Error()),
-		},
-		"target secret key not defined": {
-			bundle: &trustapi.Bundle{
-				Spec: trustapi.BundleSpec{
-					Sources: []trustapi.BundleSource{
-						{InLine: ptr.To("test")},
-					},
-					Target: trustapi.BundleTarget{Secret: &trustapi.TargetTemplate{Key: ""}},
-				},
-			},
-			expErr: ptr.To(field.ErrorList{
-				field.Invalid(field.NewPath("spec", "target", "secret", "key"), "", "target secret key must be defined"),
 			}.ToAggregate().Error()),
 		},
 		"invalid namespace selector": {
@@ -534,6 +507,9 @@ func Test_validate_update(t *testing.T) {
 			oldBundle: &trustapi.Bundle{
 				ObjectMeta: metav1.ObjectMeta{Name: "testing"},
 				Spec: trustapi.BundleSpec{
+					Sources: []trustapi.BundleSource{
+						{InLine: ptr.To("test")},
+					},
 					Target: trustapi.BundleTarget{
 						ConfigMap: &trustapi.TargetTemplate{
 							Key: "bar",
@@ -541,13 +517,20 @@ func Test_validate_update(t *testing.T) {
 					},
 				},
 			},
-			newBundle: &trustapi.Bundle{},
-			expErr:    ptr.To("spec.target.configmap: Invalid value: \"\": target configMap removal is not allowed"),
+			newBundle: &trustapi.Bundle{
+				Spec: trustapi.BundleSpec{
+					Sources: []trustapi.BundleSource{
+						{InLine: ptr.To("test")},
+					}},
+			},
 		},
 		"if the target secret is removed during update": {
 			oldBundle: &trustapi.Bundle{
 				ObjectMeta: metav1.ObjectMeta{Name: "testing"},
 				Spec: trustapi.BundleSpec{
+					Sources: []trustapi.BundleSource{
+						{InLine: ptr.To("test")},
+					},
 					Target: trustapi.BundleTarget{
 						Secret: &trustapi.TargetTemplate{
 							Key: "bar",
@@ -555,8 +538,12 @@ func Test_validate_update(t *testing.T) {
 					},
 				},
 			},
-			newBundle: &trustapi.Bundle{},
-			expErr:    ptr.To("spec.target.secret: Invalid value: \"\": target secret removal is not allowed"),
+			newBundle: &trustapi.Bundle{
+				Spec: trustapi.BundleSpec{
+					Sources: []trustapi.BundleSource{
+						{InLine: ptr.To("test")},
+					}},
+			},
 		},
 	}
 


### PR DESCRIPTION
This PR makes the bundle target spec optional, and also makes it possible to remove a target configmap/secret configuration. Somehow, we were validating this in our update validating webhook, but I consider it a bug.

Relates to https://github.com/cert-manager/trust-manager/pull/658. This backport of (non-breaking) allowing no targets will simplify the migration to `ClusterBundle`.

Also, removing the validation of the target key from the validating webhook, as the Bundle schema fully validates this.