### PR TITLE
Add ClusterBundle API validations

### DIFF
--- a/deploy/crds/trust-manager.io_clusterbundles.yaml
+++ b/deploy/crds/trust-manager.io_clusterbundles.yaml
@@ -59,7 +59,7 @@ spec:
           spec:
             description: Desired state of the Bundle resource.
             properties:
-              InLineCAs:
+              inLineCAs:
                 description: InLine is a simple string to append as the source data.
                 type: string
               includeDefaultCAs:
@@ -99,6 +99,7 @@ spec:
                       description: |-
                         Name is the name of the source object in the trust Namespace.
                         This field must be left empty when `selector` is set
+                      maxLength: 253
                       minLength: 1
                       type: string
                     selector:
@@ -154,8 +155,12 @@ spec:
                   - kind
                   type: object
                   x-kubernetes-map-type: atomic
+                  x-kubernetes-validations:
+                  - message: 'exactly one of the following fields must be provided:
+                      [name, selector]'
+                    rule: '[has(self.name), has(self.selector)].exists_one(x,x)'
                 maxItems: 100
-                minItems: 1
+                minItems: 0
                 type: array
                 x-kubernetes-list-type: atomic
               target:
@@ -183,12 +188,11 @@ spec:
                               type: string
                             key:
                               description: Key is the key of the entry in the object's
-                                `data`field to be used.
+                                `data` field to be used.
                               minLength: 1
                               pattern: ^[0-9A-Za-z_.\-]+$
                               type: string
                             password:
-                              default: ""
                               description: |-
                                 Password for PKCS12 trust store.
                                 By default, no password is used (password-less PKCS#12).
@@ -214,6 +218,18 @@ spec:
                           - key
                           type: object
                           x-kubernetes-map-type: atomic
+                          x-kubernetes-validations:
+                          - fieldPath: .password
+                            message: may only be set when format is 'PKCS12'
+                            reason: FieldValueForbidden
+                            rule: '!has(self.password) || (has(self.format) && self.format
+                              == ''PKCS12'')'
+                          - fieldPath: .profile
+                            message: may only be set when format is 'PKCS12'
+                            reason: FieldValueForbidden
+                            rule: '!has(self.profile) || (has(self.format) && self.format
+                              == ''PKCS12'')'
+                        maxItems: 10
                         minItems: 1
                         type: array
                         x-kubernetes-list-map-keys:
@@ -229,12 +245,22 @@ spec:
                             description: Annotations is a key value map to be copied
                               to the target.
                             type: object
+                            x-kubernetes-validations:
+                            - message: must not use forbidden domains as prefixes
+                                (e.g., trust-manager.io)
+                              reason: FieldValueForbidden
+                              rule: self.all(k, !k.startsWith('trust-manager.io/'))
                           labels:
                             additionalProperties:
                               type: string
                             description: Labels is a key value map to be copied to
                               the target.
                             type: object
+                            x-kubernetes-validations:
+                            - message: must not use forbidden domains as prefixes
+                                (e.g., trust-manager.io)
+                              reason: FieldValueForbidden
+                              rule: self.all(k, !k.startsWith('trust-manager.io/'))
                         type: object
                     required:
                     - data
@@ -309,12 +335,11 @@ spec:
                               type: string
                             key:
                               description: Key is the key of the entry in the object's
-                                `data`field to be used.
+                                `data` field to be used.
                               minLength: 1
                               pattern: ^[0-9A-Za-z_.\-]+$
                               type: string
                             password:
-                              default: ""
                               description: |-
                                 Password for PKCS12 trust store.
                                 By default, no password is used (password-less PKCS#12).
@@ -340,6 +365,18 @@ spec:
                           - key
                           type: object
                           x-kubernetes-map-type: atomic
+                          x-kubernetes-validations:
+                          - fieldPath: .password
+                            message: may only be set when format is 'PKCS12'
+                            reason: FieldValueForbidden
+                            rule: '!has(self.password) || (has(self.format) && self.format
+                              == ''PKCS12'')'
+                          - fieldPath: .profile
+                            message: may only be set when format is 'PKCS12'
+                            reason: FieldValueForbidden
+                            rule: '!has(self.profile) || (has(self.format) && self.format
+                              == ''PKCS12'')'
+                        maxItems: 10
                         minItems: 1
                         type: array
                         x-kubernetes-list-map-keys:
@@ -355,12 +392,22 @@ spec:
                             description: Annotations is a key value map to be copied
                               to the target.
                             type: object
+                            x-kubernetes-validations:
+                            - message: must not use forbidden domains as prefixes
+                                (e.g., trust-manager.io)
+                              reason: FieldValueForbidden
+                              rule: self.all(k, !k.startsWith('trust-manager.io/'))
                           labels:
                             additionalProperties:
                               type: string
                             description: Labels is a key value map to be copied to
                               the target.
                             type: object
+                            x-kubernetes-validations:
+                            - message: must not use forbidden domains as prefixes
+                                (e.g., trust-manager.io)
+                              reason: FieldValueForbidden
+                              rule: self.all(k, !k.startsWith('trust-manager.io/'))
                         type: object
                     required:
                     - data
@@ -368,8 +415,10 @@ spec:
                 required:
                 - namespaceSelector
                 type: object
-            required:
-            - sources
+                x-kubernetes-validations:
+                - message: 'any of the following fields must be provided: [configMap,
+                    secret]'
+                  rule: '[has(self.configMap), has(self.secret)].exists(x,x)'
             type: object
           status:
             description: Status of the Bundle. This is set and managed automatically.

--- a/test/integration/bundle/cluster_bundle_validation_test.go
+++ b/test/integration/bundle/cluster_bundle_validation_test.go
@@ -1,0 +1,297 @@
+/*
+Copyright 2025 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package test
+
+import (
+	"context"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/klog/v2/ktesting"
+	"k8s.io/utils/ptr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	trustmanagerapi "github.com/cert-manager/trust-manager/pkg/apis/trustmanager/v1alpha2"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("ClusterBundle Validation", func() {
+	var (
+		ctx    context.Context
+		cl     client.Client
+		bundle *trustmanagerapi.ClusterBundle
+	)
+	BeforeEach(func() {
+		_, ctx = ktesting.NewTestContext(GinkgoT())
+
+		var err error
+		cl, err = client.New(env.Config, client.Options{
+			Scheme: trustmanagerapi.GlobalScheme,
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		bundle = &trustmanagerapi.ClusterBundle{}
+		bundle.GenerateName = "validation-"
+	})
+
+	Context("Source item", func() {
+		DescribeTable("should validate key",
+			func(key string, matchErr string) {
+				bundle.Spec.Sources = []trustmanagerapi.BundleSource{{
+					Key: key,
+					SourceReference: trustmanagerapi.SourceReference{
+						Kind: trustmanagerapi.ConfigMapKind,
+						Name: "ca",
+					},
+				}}
+				if matchErr != "" {
+					Expect(cl.Create(ctx, bundle)).Should(MatchError(ContainSubstring(matchErr)))
+				} else {
+					Expect(cl.Create(ctx, bundle)).To(Succeed())
+				}
+			},
+			Entry("when unset", "", "spec.sources[0].key: Invalid value: \"\": spec.sources[0].key in body should be at least 1 chars long"),
+			Entry("when given", "ca.crt", ""),
+			Entry("when using simple wildcard to include some keys", "*.crt", ""),
+			Entry("when using simple wildcard to include all keys", "*", ""),
+			Entry("when using too advanced wildcards", "ca[0-9].crt", "spec.sources[0].key: Invalid value: \"ca[0-9].crt\": spec.sources[0].key in body should match '^[0-9A-Za-z_.\\-*]+$"),
+		)
+
+		DescribeTable("should validate source reference",
+			func(sourceRef trustmanagerapi.SourceReference, matchErr string) {
+				bundle.Spec.Sources = []trustmanagerapi.BundleSource{{
+					Key:             "ca.crt",
+					SourceReference: sourceRef,
+				}}
+				if matchErr != "" {
+					Expect(cl.Create(ctx, bundle)).Should(MatchError(ContainSubstring(matchErr)))
+				} else {
+					Expect(cl.Create(ctx, bundle)).To(Succeed())
+				}
+			},
+			Entry("when kind unset", trustmanagerapi.SourceReference{Name: "ca"}, "spec.sources[0].kind: Unsupported value: \"\": supported values: \"ConfigMap\", \"Secret\""),
+			Entry("when kind ConfigMap", trustmanagerapi.SourceReference{Kind: trustmanagerapi.ConfigMapKind, Name: "ca"}, ""),
+			Entry("when kind Secret", trustmanagerapi.SourceReference{Kind: trustmanagerapi.SecretKind, Name: "ca"}, ""),
+			Entry("when kind unknown", trustmanagerapi.SourceReference{Kind: "OtherKind", Name: "ca"}, "spec.sources[0].kind: Unsupported value: \"OtherKind\": supported values: \"ConfigMap\", \"Secret\""),
+			Entry("when no name nor selector set", trustmanagerapi.SourceReference{Kind: trustmanagerapi.ConfigMapKind}, "spec.sources[0]: Invalid value: \"object\": exactly one of the following fields must be provided: [name, selector]"),
+			Entry("when name set", trustmanagerapi.SourceReference{Name: "ca", Kind: trustmanagerapi.ConfigMapKind}, ""),
+			Entry("when selector set", trustmanagerapi.SourceReference{Kind: trustmanagerapi.ConfigMapKind, Selector: &metav1.LabelSelector{}}, ""),
+			Entry("when name and selector set", trustmanagerapi.SourceReference{Kind: trustmanagerapi.ConfigMapKind, Name: "ca", Selector: &metav1.LabelSelector{}}, "spec.sources[0]: Invalid value: \"object\": exactly one of the following fields must be provided: [name, selector]"),
+		)
+	})
+
+	Context("Target", func() {
+		var (
+			selectorAccessor func(*trustmanagerapi.KeyValueTarget)
+			field            string
+		)
+
+		BeforeEach(func() {
+			bundle.Spec.Target = trustmanagerapi.BundleTarget{
+				NamespaceSelector: &metav1.LabelSelector{},
+			}
+		})
+
+		It("should require namespace selector", func() {
+			bundle.Spec.Target.NamespaceSelector = nil
+			bundle.Spec.Target.ConfigMap = &trustmanagerapi.KeyValueTarget{
+				Data: []trustmanagerapi.TargetKeyValue{{
+					Key: "ca-bundle.crt",
+				}},
+			}
+
+			expectedErr := "spec.target.namespaceSelector: Required value"
+			Expect(cl.Create(ctx, bundle)).Should(MatchError(ContainSubstring(expectedErr)))
+		})
+
+		It("should require a target if namespace selector set", func() {
+			expectedErr := "spec.target: Invalid value: \"object\": any of the following fields must be provided: [configMap, secret]"
+			Expect(cl.Create(ctx, bundle)).Should(MatchError(ContainSubstring(expectedErr)))
+		})
+
+		It("should allow both configmap and secret targets", func() {
+			bundle.Spec.Target.ConfigMap = &trustmanagerapi.KeyValueTarget{
+				Data: []trustmanagerapi.TargetKeyValue{{
+					Key: "ca-bundle.crt",
+				}},
+			}
+			bundle.Spec.Target.Secret = &trustmanagerapi.KeyValueTarget{
+				Data: []trustmanagerapi.TargetKeyValue{{
+					Key: "ca-bundle.crt",
+				}},
+			}
+			Expect(cl.Create(ctx, bundle)).To(Succeed())
+		})
+
+		targetObjectAsserts := func() {
+			DescribeTable("should validate key",
+				func(key string, matchErr string) {
+					selectorAccessor(&trustmanagerapi.KeyValueTarget{
+						Data: []trustmanagerapi.TargetKeyValue{{
+							Key: key,
+						}},
+					})
+					if matchErr != "" {
+						Expect(cl.Create(ctx, bundle)).Should(MatchError(ContainSubstring(matchErr, field, field)))
+					} else {
+						Expect(cl.Create(ctx, bundle)).To(Succeed())
+					}
+				},
+				Entry("when unset", "", "spec.target.%s.data[0].key: Invalid value: \"\": spec.target.%s.data[0].key in body should be at least 1 chars long"),
+				Entry("when given", "ca.crt", ""),
+				Entry("when using wildcard", "*.crt", "spec.target.%s.data[0].key: Invalid value: \"*.crt\": spec.target.%s.data[0].key in body should match '^[0-9A-Za-z_.\\-]+$"),
+			)
+
+			It("should require unique keys", func() {
+				selectorAccessor(&trustmanagerapi.KeyValueTarget{
+					Data: []trustmanagerapi.TargetKeyValue{{
+						Key: "foo",
+					}, {
+						Key: "foo",
+					}},
+				})
+				matchErr := "spec.target.%s.data[1]: Duplicate value: map[string]interface {}{\"key\":\"foo\"}"
+				Expect(cl.Create(ctx, bundle)).Should(MatchError(ContainSubstring(matchErr, field)))
+
+				selectorAccessor(&trustmanagerapi.KeyValueTarget{
+					Data: []trustmanagerapi.TargetKeyValue{{
+						Key: "foo",
+					}, {
+						Key: "bar",
+					}},
+				})
+				Expect(cl.Create(ctx, bundle)).To(Succeed())
+			})
+
+			DescribeTable("should prevent metadata with forbidden prefixes",
+				func(metadata *trustmanagerapi.TargetMetadata, wantErr bool) {
+					selectorAccessor(&trustmanagerapi.KeyValueTarget{
+						Metadata: metadata,
+						Data: []trustmanagerapi.TargetKeyValue{{
+							Key: "ca-bundle.crt",
+						}},
+					})
+					if wantErr {
+						var metadataField = "annotations"
+						if metadata.Labels != nil {
+							metadataField = "labels"
+						}
+						matchErr := "spec.target.%s.metadata.%s: Forbidden: must not use forbidden domains as prefixes (e.g., trust-manager.io)"
+						Expect(cl.Create(ctx, bundle)).Should(MatchError(ContainSubstring(matchErr, field, metadataField)))
+					} else {
+						Expect(cl.Create(ctx, bundle)).To(Succeed())
+					}
+				},
+				Entry("when trust-manager.io annotations are used", &trustmanagerapi.TargetMetadata{Annotations: map[string]string{"trust-manager.io/hash": "test"}}, true),
+				Entry("when trust-manager.io labels are used", &trustmanagerapi.TargetMetadata{Labels: map[string]string{"trust-manager.io/bundle": "bundle"}}, true),
+				Entry("when non-reserved annotations are used", &trustmanagerapi.TargetMetadata{Annotations: map[string]string{"not-trust-manager.io/hash": "test"}}, false),
+				Entry("when non-reserved labels are used", &trustmanagerapi.TargetMetadata{Labels: map[string]string{"not-trust-manager.io/bundle": "bundle"}}, false),
+			)
+
+			DescribeTable("should validate format",
+				func(format trustmanagerapi.BundleFormat, matchErr string) {
+					selectorAccessor(&trustmanagerapi.KeyValueTarget{
+						Data: []trustmanagerapi.TargetKeyValue{{
+							Key:    "ca-bundle",
+							Format: format,
+						}},
+					})
+					if matchErr != "" {
+						Expect(cl.Create(ctx, bundle)).Should(MatchError(ContainSubstring(matchErr, field)))
+					} else {
+						Expect(cl.Create(ctx, bundle)).To(Succeed())
+					}
+				},
+				Entry("when unset", trustmanagerapi.BundleFormat(""), ""),
+				Entry("when PEM", trustmanagerapi.BundleFormatPEM, ""),
+				Entry("when PKCS12", trustmanagerapi.BundleFormatPKCS12, ""),
+				Entry("when invalid case", trustmanagerapi.BundleFormat("PeM"), "spec.target.%s.data[0].format: Unsupported value: \"PeM\": supported values: \"PEM\", \"PKCS12\""),
+				Entry("when invalid case", trustmanagerapi.BundleFormat("pem"), "spec.target.%s.data[0].format: Unsupported value: \"pem\": supported values: \"PEM\", \"PKCS12\""),
+				Entry("when unknown", trustmanagerapi.BundleFormat("JKS"), "spec.target.%s.data[0].format: Unsupported value: \"JKS\": supported values: \"PEM\", \"PKCS12\""),
+			)
+
+			var pkcs12Field string
+			var pkcs12 trustmanagerapi.PKCS12
+
+			pkcs12Asserts := func() {
+				DescribeTable("should validate fields reserved for PCKS12 format",
+					func(format trustmanagerapi.BundleFormat, wantErr bool) {
+						targetKeyValue := trustmanagerapi.TargetKeyValue{
+							Key:    "ca-bundle",
+							Format: format,
+							PKCS12: pkcs12,
+						}
+						selectorAccessor(&trustmanagerapi.KeyValueTarget{
+							Data: []trustmanagerapi.TargetKeyValue{targetKeyValue},
+						})
+
+						if wantErr {
+							matchErr := "spec.target.%s.data[0].%s: Forbidden: may only be set when format is 'PKCS12'"
+							Expect(cl.Create(ctx, bundle)).Should(MatchError(ContainSubstring(matchErr, field, pkcs12Field)))
+						} else {
+							Expect(cl.Create(ctx, bundle)).To(Succeed())
+						}
+					},
+					Entry("reject it when format is empty", trustmanagerapi.BundleFormat(""), true),
+					Entry("reject it when format is PEM", trustmanagerapi.BundleFormatPEM, true),
+					Entry("accept it when format is PKCS12", trustmanagerapi.BundleFormatPKCS12, false),
+				)
+			}
+
+			Context("Password", func() {
+				BeforeEach(func() {
+					pkcs12Field = "password"
+					pkcs12 = trustmanagerapi.PKCS12{Password: ptr.To("my-password")}
+				})
+
+				pkcs12Asserts()
+			})
+
+			Context("Profile", func() {
+				BeforeEach(func() {
+					pkcs12Field = "profile"
+					pkcs12 = trustmanagerapi.PKCS12{Profile: trustmanagerapi.Modern2023PKCS12Profile}
+				})
+
+				pkcs12Asserts()
+			})
+		}
+
+		Context("ConfigMap", func() {
+			BeforeEach(func() {
+				selectorAccessor = func(selector *trustmanagerapi.KeyValueTarget) {
+					bundle.Spec.Target.ConfigMap = selector
+				}
+				field = "configMap"
+			})
+
+			targetObjectAsserts()
+		})
+
+		Context("Secret", func() {
+			BeforeEach(func() {
+				selectorAccessor = func(selector *trustmanagerapi.KeyValueTarget) {
+					bundle.Spec.Target.Secret = selector
+				}
+				field = "secret"
+			})
+
+			targetObjectAsserts()
+		})
+	})
+})

--- a/test/integration/bundle/integration.go
+++ b/test/integration/bundle/integration.go
@@ -82,6 +82,7 @@ var _ = BeforeSuite(func() {
 	Expect(webhook.Register(mgr)).Should(Succeed())
 
 	go func() {
+		defer GinkgoRecover()
 		err = mgr.Start(context.TODO())
 		Expect(err).NotTo(HaveOccurred())
 	}()


### PR DESCRIPTION
This PR adds all API validations for the new `CLusterBundle` API that I was able to implement without adding a validating webhook. I have added a new "integration" test, based on envtest (simplified control plane), to test these validations. I suggested introducing CEL validations in https://github.com/cert-manager/trust-manager/pull/475, but the `Bundle` API wasn't really ready for it, as the expressions became way too complex. But in the new API, I think the CEL expressions are simple enough.....

Label selectors cannot currently be validated using CEL expressions (or OpenAPI schema) and require a webhook for validation. This is probably true for labels/annotations, even if Kubernetes is now providing the [format CEL library](https://kubernetes.io/docs/reference/using-api/cel/#kubernetes-format-library) that might be used for this. I am personally inclined to NOT add a webhook just for this, as it will hopefully be available in CEL later on. And no webhooks implies that trust-manager will not have cert-manager as a prerequisite.

The added tests detected a few minor bugs/improvements in the API:
- PKCS12 password cannot have an API default to be validated correctly. We document the default value and will use a controller default to implement it.
- We have to allow empty `sources`, as the `includeDefaultCAs` has moved out of the `sources` array field. (And also the `inLineCAs` field, which we are planning to deprecate.)
- The `inLineCAs` field had the wrong init-case in the JSON serialization marker, which is now fixed.
- We should set max items for all array fields and max length for string fields to ensure CEL cost estimation doesn't blow up.