### PR TITLE
feat: Update trust-manager default trust bundle to newest version

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -158,7 +158,7 @@ The repository for the default package image. This image enables the 'useDefault
 #### **defaultPackageImage.tag** ~ `string`
 > Default value:
 > ```yaml
-> "20230311.0"
+> 20230311-deb12u1.0
 > ```
 
 Override the image tag of the default package image. If no value is set, the chart's appVersion is used.

--- a/deploy/charts/trust-manager/values.schema.json
+++ b/deploy/charts/trust-manager/values.schema.json
@@ -599,7 +599,7 @@
       "type": "string"
     },
     "helm-values.defaultPackageImage.tag": {
-      "default": "20230311.0",
+      "default": "20230311-deb12u1.0",
       "description": "Override the image tag of the default package image. If no value is set, the chart's appVersion is used.",
       "type": "string"
     },

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -93,7 +93,7 @@ defaultPackageImage:
   # Override the image tag of the default package image.
   # If no value is set, the chart's appVersion is used.
   # +docs:property
-  tag: "20230311.0"
+  tag: "20230311-deb12u1.0"
 
   # Target image digest. Override any tag, if set.
   # For example:


### PR DESCRIPTION
This is a follow up to #643 which actually updated the helm chart to use the latest trust source version.

Helps with #666 😈 

Steps:
- Update the values file to change the default
- Update the docs with : `make generate-helm-docs`
- Update values schema with: `make generate-helm-schema`
- And verify things: `make verify-helm-values`

Have not deployed, but assume CI will do that