### PR TITLE
Make Bundle webhook configuration precise

### DIFF
--- a/deploy/charts/trust-manager/templates/webhook.yaml
+++ b/deploy/charts/trust-manager/templates/webhook.yaml
@@ -106,12 +106,12 @@ webhooks:
       - apiGroups:
           - "trust.cert-manager.io"
         apiVersions:
-          - "*"
+          - v1alpha1
         operations:
           - CREATE
           - UPDATE
         resources:
-          - "*/*"
+          - bundles
     admissionReviewVersions: ["v1"]
     timeoutSeconds: {{ .Values.app.webhook.timeoutSeconds }}
     failurePolicy: Fail

--- a/test/integration/bundle/integration.go
+++ b/test/integration/bundle/integration.go
@@ -110,8 +110,8 @@ func validatingWebhookConfiguration() *admissionv1.ValidatingWebhookConfiguratio
 		Rules: []admissionv1.RuleWithOperations{{
 			Rule: admissionv1.Rule{
 				APIGroups:   []string{trustapi.SchemeGroupVersion.Group},
-				APIVersions: []string{"*"},
-				Resources:   []string{"*/*"},
+				APIVersions: []string{"v1alpha1"},
+				Resources:   []string{"bundles"},
 			},
 			Operations: []admissionv1.OperationType{admissionv1.Create, admissionv1.Update},
 		}},


### PR DESCRIPTION
While working on https://github.com/cert-manager/trust-manager/pull/668, I noticed that the validating webhook configuration for bundles is imprecise. Since I want to add a sibling webhook for ClusterBundle, I think this should be corrected.