### PR TITLE
feat: Add a very basic pre-commit configuration

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v6.0.0
+  rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # v6.0.0
   hooks:
     - id: trailing-whitespace
     - id: end-of-file-fixer

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,9 @@
 repos:
 - repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c # v6.0.0
+  rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c
+  # Using the commit hash instead of version directly equivalent to this version:
+  # rev: v6.0.0
+  # ref: https://github.com/pre-commit/pre-commit-hooks/releases/tag/v6.0.0
   hooks:
     - id: trailing-whitespace
     - id: end-of-file-fixer

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+- repo: https://github.com/pre-commit/pre-commit-hooks
+  rev: v6.0.0
+  hooks:
+    - id: trailing-whitespace
+    - id: end-of-file-fixer


### PR DESCRIPTION
In #680 there were a couple of nits that I would personally solve by using pre-commit. I have added the most basic configuration here as a discussion topic. There may be other ways or tools to achieve the same goal of "not having to correct whitespace or newline nits"

Assuming you have this checked out:

```sh
# run once
pre-commit install
# run on any changed files
pre-commit run
# run on specific file(s)
pre-commit run --files deploy/charts/trust-manager/values.yaml
```

## Reasons to have it

- Standard tool available pretty widely
- Sets a very low baseline of checks, to help contributors to catch empty space and newline problems.
- Fixes the issue before committing so it is easier to get right first time
- Only runs on the files you have changed  / staged (unless you specify `--all-files`)
- It is opt in! ie. it should not affect existing users by default. You must set it up per repo once, if want to benefit.

## Concerns / addressed

I've left this section to record concerns about adding this, in the hope they can be addressed.

- <tbd>

Will talk about this on some standup 🤞 