### PR TITLE
Add build process for Debian Trixie

### DIFF
--- a/.github/workflows/debian-trust-package-release-trixie.yaml
+++ b/.github/workflows/debian-trust-package-release-trixie.yaml
@@ -1,0 +1,43 @@
+name: debian-trust-package-release-trixie
+on:
+  push:
+    branches: ['main']
+    paths:
+      - make/00_debian_trixie_version.mk
+
+jobs:
+  build_images:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read # needed for checkout
+      packages: write # needed for push images
+      id-token: write # needed for keyless signing
+
+    steps:
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        # Adding `fetch-depth: 0` makes sure tags are also fetched. We need
+        # the tags so `git describe` returns a valid version.
+        # see https://github.com/actions/checkout/issues/701 for extra info about this option
+        with: { fetch-depth: 0 }
+
+      - id: go-version
+        run: |
+          make print-go-version >> "$GITHUB_OUTPUT"
+
+      - uses: docker/login-action@v3
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ steps.go-version.outputs.result }}
+
+      - id: release
+        run: make release-debian-trixie-trust-package
+
+    outputs:
+      RELEASE_OCI_MANAGER_IMAGE: ${{ steps.release.outputs.RELEASE_OCI_PACKAGE_DEBIAN_TRIXIE_IMAGE }}
+      RELEASE_OCI_MANAGER_TAG: ${{ steps.release.outputs.RELEASE_OCI_PACKAGE_DEBIAN_TRIXIE_TAG }}

--- a/.github/workflows/debian-trust-package-upgrade-trixie.yaml
+++ b/.github/workflows/debian-trust-package-upgrade-trixie.yaml
@@ -1,0 +1,90 @@
+name: debian-trust-package-upgrade-trixie
+concurrency: debian-trust-package-upgrade-trixie
+on:
+  workflow_dispatch: {}
+  schedule:
+    - cron: '2 2 * * *'
+
+jobs:
+  debian-trust-package-upgrade-trixie:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    env:
+      SOURCE_BRANCH: "${{ github.ref_name }}"
+      SELF_UPGRADE_BRANCH: "debian-trust-package-upgrade-trixie-${{ github.ref_name }}"
+
+    steps:
+      - name: Fail if branch is not head of branch.
+        if: ${{ !startsWith(github.ref, 'refs/heads/') && env.SOURCE_BRANCH != '' && env.SELF_UPGRADE_BRANCH != '' }}
+        run: |
+          echo "This workflow should not be run on a non-branch-head."
+          exit 1
+
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        # Adding `fetch-depth: 0` makes sure tags are also fetched. We need
+        # the tags so `git describe` returns a valid version.
+        # see https://github.com/actions/checkout/issues/701 for extra info about this option
+        with: { fetch-depth: 0 }
+
+      - id: go-version
+        run: |
+          make print-go-version >> "$GITHUB_OUTPUT"
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: ${{ steps.go-version.outputs.result }}
+
+      - run: |
+          git checkout -B "$SELF_UPGRADE_BRANCH"
+
+      - run: |
+          make -j upgrade-debian-trust-package-trixie-version
+
+      - id: is-up-to-date
+        shell: bash
+        run: |
+          git_status=$(git status -s)
+          is_up_to_date="true"
+          if [ -n "$git_status" ]; then
+              is_up_to_date="false"
+              echo "The following changes will be committed:"
+              echo "$git_status"
+          fi
+          echo "result=$is_up_to_date" >> "$GITHUB_OUTPUT"
+
+      - if: ${{ steps.is-up-to-date.outputs.result != 'true' }}
+        run: |
+          git config --global user.name "cert-manager-bot"
+          git config --global user.email "cert-manager-bot@users.noreply.github.com"
+          git add -A && git commit -m "BOT: run 'make upgrade-debian-trust-package-trixie-version'" --signoff
+          git push -f origin "$SELF_UPGRADE_BRANCH"
+
+      - if: ${{ steps.is-up-to-date.outputs.result != 'true' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { repo, owner } = context.repo;
+            const pulls = await github.rest.pulls.list({
+              owner: owner,
+              repo: repo,
+              head: owner + ':' + process.env.SELF_UPGRADE_BRANCH,
+              base: process.env.SOURCE_BRANCH,
+              state: 'open',
+            });
+
+            if (pulls.data.length < 1) {
+              await github.rest.pulls.create({
+                title: '[CI] Merge ' + process.env.SELF_UPGRADE_BRANCH + ' into ' + process.env.SOURCE_BRANCH,
+                owner: owner,
+                repo: repo,
+                head: process.env.SELF_UPGRADE_BRANCH,
+                base: process.env.SOURCE_BRANCH,
+                body: [
+                  'This PR is auto-generated to bump the Debian Bookworm package version',
+                ].join('\n'),
+              });
+            }

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -29,10 +29,12 @@ The release process for this repo is documented below:
 
 ## Trust package
 
-As well as the trust-manager container images, we also publish a trust package image. For more information on what a trust package is, see the [trust-packages readme](trust-packages/README.md). This process is fully automated through GitHub Actions:
+As well as the trust-manager container images, we also publish trust package images. For more information on what a trust package is, see the [trust-packages readme](trust-packages/README.md). This process is fully automated through GitHub Actions:
 
-1. A cron [GitHub Action](https://venafi.slack.com/archives/D06C21X5L13/p1717075543900969) checks for a new ca-certificates package and creates a PR updating `make/00_debian_version.mk` if one is found
-2. Once merged a [GitHub Action](https://github.com/cert-manager/trust-manager/blob/main/.github/workflows/debian-trust-package-release.yaml) will build and release the container image.
+1. A cron [GitHub Action](https://venafi.slack.com/archives/D06C21X5L13/p1717075543900969) checks for a new ca-certificates package for a given Debian version, and creates a PR updating `make/00_debian_*version.mk` if a new version is found
+2. Once merged, a [GitHub Action](https://github.com/cert-manager/trust-manager/blob/main/.github/workflows/debian-trust-package-release.yaml) will build and release the container image.
+
+This automated process is in place for Debian Bullseye (11), Bookworm (12), and Trixie (13).
 
 ## Artifacts
 

--- a/make/00_debian_trixie_version.mk
+++ b/make/00_debian_trixie_version.mk
@@ -1,0 +1,21 @@
+# Copyright 2025 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# WARNING: Changing this file triggers a build and release of the Debian trust package for Trixie (Debian 13)
+#
+# This file is used to store the latest version of the debian trust package and the DEBIAN_BUNDLE_TRIXIE_VERSION
+# variable is automatically updated by the `upgrade-debian-trust-package-trixie-version` target and cron GH action.
+
+DEBIAN_BUNDLE_TRIXIE_VERSION := 20250419.20250419
+DEBIAN_BUNDLE_TRIXIE_SOURCE_IMAGE=docker.io/library/debian:13-slim

--- a/make/00_mod.mk
+++ b/make/00_mod.mk
@@ -16,6 +16,7 @@ oci_platforms := linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
 
 include make/00_debian_version.mk
 include make/00_debian_bookworm_version.mk
+include make/00_debian_trixie_version.mk
 
 repo_name := github.com/cert-manager/trust-manager
 
@@ -52,6 +53,17 @@ oci_package_debian_bookworm_image_tag := $(shell echo $(DEBIAN_BUNDLE_BOOKWORM_V
 oci_package_debian_bookworm_image_name_development := cert-manager.local/trust-pkg-debian-bookworm
 debian_bookworm_package_layer := $(bin_dir)/scratch/debian-trust-package-bookworm
 oci_package_debian_bookworm_additional_layers += $(debian_bookworm_package_layer)
+
+go_package_debian_trixie_main_dir := .
+go_package_debian_trixie_mod_dir := ./trust-packages/debian
+go_package_debian_trixie_ldflags :=
+oci_package_debian_trixie_base_image_flavor := static
+oci_package_debian_trixie_image_name := quay.io/jetstack/trust-pkg-debian-trixie
+# '+' characters are not valid in docker image names. Transform it to a '.' for images
+oci_package_debian_trixie_image_tag := $(shell echo $(DEBIAN_BUNDLE_TRIXIE_VERSION) | tr '+' '-')
+oci_package_debian_trixie_image_name_development := cert-manager.local/trust-pkg-debian-trixie
+debian_trixie_package_layer := $(bin_dir)/scratch/debian-trust-package-trixie
+oci_package_debian_trixie_additional_layers += $(debian_trixie_package_layer)
 
 
 deploy_name := trust-manager

--- a/make/02_mod.mk
+++ b/make/02_mod.mk
@@ -35,6 +35,7 @@ smoke:
 include make/validate-trust-package.mk
 include make/debian-trust-package.mk
 include make/debian-trust-package-bookworm.mk
+include make/debian-trust-package-trixie.mk
 
 .PHONY: release
 ## Publish all release artifacts (image + helm chart)

--- a/make/debian-trust-package-trixie.mk
+++ b/make/debian-trust-package-trixie.mk
@@ -1,0 +1,45 @@
+# Copyright 2025 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+package_name_trixie := cert-manager-debian-trixie
+
+debian_package_trixie_layer := $(bin_dir)/scratch/debian-trust-package-trixie
+debian_package_trixie_json := $(debian_package_trixie_layer)/debian-package/cert-manager-package-debian.json
+
+$(debian_package_trixie_layer)/debian-package:
+	mkdir -p $@
+
+$(debian_package_trixie_json): | $(bin_dir)/bin/validate-trust-package $(debian_package_trixie_layer)/debian-package
+	BIN_VALIDATE_TRUST_PACKAGE=$(bin_dir)/bin/validate-trust-package \
+		./make/debian-trust-package-fetch.sh exact $(DEBIAN_BUNDLE_TRIXIE_SOURCE_IMAGE) $@ $(DEBIAN_BUNDLE_TRIXIE_VERSION) $(package_name_trixie)
+
+oci-build-package_debian_trixie: $(debian_package_trixie_json)
+oci_additional_layers_package_debian_trixie += $(debian_package_trixie_layer)
+
+# see https://stackoverflow.com/a/53408233
+sed_inplace := sed -i''
+ifeq ($(HOST_OS),darwin)
+	sed_inplace := sed -i ''
+endif
+
+.PHONY: upgrade-debian-trust-package-trixie-version
+upgrade-debian-trust-package-trixie-version: | $(bin_dir)/bin/validate-trust-package $(bin_dir)/scratch
+	$(eval temp_out := $(bin_dir)/scratch/debian-trust-package-trixie.temp.json)
+	rm -rf $(temp_out)
+
+	BIN_VALIDATE_TRUST_PACKAGE=$(bin_dir)/bin/validate-trust-package \
+		./make/debian-trust-package-fetch.sh latest $(DEBIAN_BUNDLE_TRIXIE_SOURCE_IMAGE) $(temp_out) $(DEBIAN_BUNDLE_TRIXIE_VERSION) $(package_name_trixie)
+
+	latest_version=$$(jq -r '.version' $(temp_out)); \
+		$(sed_inplace) "s/DEBIAN_BUNDLE_TRIXIE_VERSION := .*/DEBIAN_BUNDLE_TRIXIE_VERSION := $$latest_version/" make/00_debian_trixie_version.mk


### PR DESCRIPTION
I haven't tested this extensively, but it seems like a good start. If there are any issues with this, I might not be able to fix them before I head on paternity leave; but I might as well share the work!

This _intentionally_ doesn't try to migrate to Trixie as our default trust bundle yet. It needs building first, and then we can decide when we want to migrate to Trixie as the default.