### PR TITLE
User-facing migration to ClusterBundle

### DIFF
--- a/deploy/charts/trust-manager/templates/clusterrole-aggregate.yaml
+++ b/deploy/charts/trust-manager/templates/clusterrole-aggregate.yaml
@@ -21,5 +21,10 @@ rules:
   resources:
   - "bundles"
   verbs: ["get", "list", "watch"]
+- apiGroups:
+  - "trust-manager.io"
+  resources:
+  - "clusterbundles"
+  verbs: ["get", "list", "watch"]
 {{- end }}
 {{- end }}

--- a/deploy/charts/trust-manager/templates/clusterrole.yaml
+++ b/deploy/charts/trust-manager/templates/clusterrole.yaml
@@ -36,6 +36,27 @@ rules:
   - "namespaces"
   verbs: ["get", "list", "watch"]
 
+- apiGroups:
+  - "trust-manager.io"
+  resources:
+  - "clusterbundles"
+  # The create and patch verbs are required as long as the migration controller is operating.
+  verbs: ["get", "list", "watch", "create", "patch"]
+
+# Permissions to update finalizers are required for trust-manager to work correctly
+# on OpenShift, even though we don't directly use finalizers at the time of writing
+- apiGroups:
+  - "trust-manager.io"
+  resources:
+  - "clusterbundles/finalizers"
+  verbs: ["update"]
+
+- apiGroups:
+  - "trust-manager.io"
+  resources:
+  - "clusterbundles/status"
+  verbs: ["patch"]
+
 {{- if not .Values.app.targetNamespaces }}
 {{ include "trust-manager.rbac.namespacedResourcesRules" . }}
 {{- end -}}

--- a/deploy/charts/trust-manager/templates/crd-trust-manager.io_clusterbundles.yaml
+++ b/deploy/charts/trust-manager/templates/crd-trust-manager.io_clusterbundles.yaml
@@ -1,0 +1,489 @@
+{{- if .Values.crds.enabled }}
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: "clusterbundles.trust-manager.io"
+  {{- if .Values.crds.keep }}
+  annotations:
+    helm.sh/resource-policy: keep
+  {{- end }}
+  labels:
+    {{- include "trust-manager.labels" . | nindent 4 }}
+spec:
+  group: trust-manager.io
+  names:
+    kind: ClusterBundle
+    listKind: ClusterBundleList
+    plural: clusterbundles
+    singular: clusterbundle
+  scope: Cluster
+  versions:
+    - additionalPrinterColumns:
+        - description: Bundle has been synced
+          jsonPath: .status.conditions[?(@.type == "Synced")].status
+          name: Synced
+          type: string
+        - description: Reason Bundle has Synced status
+          jsonPath: .status.conditions[?(@.type == "Synced")].reason
+          name: Reason
+          type: string
+        - description: Timestamp Bundle was created
+          jsonPath: .metadata.creationTimestamp
+          name: Age
+          type: date
+      name: v1alpha2
+      schema:
+        openAPIV3Schema:
+          properties:
+            apiVersion:
+              description: |-
+                APIVersion defines the versioned schema of this representation of an object.
+                Servers should convert recognized schemas to the latest internal value, and
+                may reject unrecognized values.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources
+              type: string
+            kind:
+              description: |-
+                Kind is a string value representing the REST resource this object represents.
+                Servers may infer this from the endpoint the client submits requests to.
+                Cannot be updated.
+                In CamelCase.
+                More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds
+              type: string
+            metadata:
+              type: object
+            spec:
+              description: spec represents the desired state of the ClusterBundle resource.
+              minProperties: 1
+              properties:
+                defaultCAs:
+                  description: defaultCAs configures the use of a default CA bundle as a trust source.
+                  properties:
+                    provider:
+                      description: "provider identifies the provider of the default CA bundle.\n\nValid values:\n- System: Uses the default CA package made available to trust-manager at startup.\n     The default CA bundle is available only if trust-manager was installed with\n\t\tdefault CA support enabled, either via the Helm chart or by starting the\n\t\ttrust-manager controller with the \"--default-package-location\" flag.\n\n\t\tIf no default CA package was configured at startup, specifying this source\n\t\twill result in reconciliation failure.\n\n\t\tThe version of the default CA package used for this Bundle is reported in\n\t\tstatus.defaultCAVersion.\n- Disabled: No default CAs are used as sources."
+                      enum:
+                        - System
+                        - Disabled
+                      type: string
+                  required:
+                    - provider
+                  type: object
+                inLineCAs:
+                  description: inLineCAs is a simple string to append as the source data.
+                  maxLength: 1048576
+                  minLength: 1
+                  type: string
+                sourceRefs:
+                  description: |-
+                    sourceRefs is a list of references to resources whose data will be appended and synced into
+                    the bundle target resources.
+                  items:
+                    description: |-
+                      BundleSourceRef is a reference to source resource(s) whose data will be appended and synced into
+                      the bundle target resources.
+                    properties:
+                      key:
+                        description: |-
+                          key specifies one or more keys in the object's data field to be used.
+                          The "*" wildcard matches any sequence of characters within a key.
+                          A value of "*" matches all entries in the data field.
+                        maxLength: 253
+                        minLength: 1
+                        pattern: ^[0-9A-Za-z_.\-*]+$
+                        type: string
+                      kind:
+                        description: kind is the kind of the source object.
+                        enum:
+                          - ConfigMap
+                          - Secret
+                        type: string
+                      name:
+                        description: |-
+                          name is the name of the source object in the trust namespace.
+                          This field must be left empty when `selector` is set
+                        maxLength: 253
+                        minLength: 1
+                        type: string
+                      selector:
+                        description: |-
+                          selector is the label selector to use to fetch a list of objects. Must not be set
+                          when `name` is set.
+                        properties:
+                          matchExpressions:
+                            description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                            items:
+                              description: |-
+                                A label selector requirement is a selector that contains values, a key, and an operator that
+                                relates the key and values.
+                              properties:
+                                key:
+                                  description: key is the label key that the selector applies to.
+                                  type: string
+                                operator:
+                                  description: |-
+                                    operator represents a key's relationship to a set of values.
+                                    Valid operators are In, NotIn, Exists and DoesNotExist.
+                                  type: string
+                                values:
+                                  description: |-
+                                    values is an array of string values. If the operator is In or NotIn,
+                                    the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                    the values array must be empty. This array is replaced during a strategic
+                                    merge patch.
+                                  items:
+                                    type: string
+                                  type: array
+                                  x-kubernetes-list-type: atomic
+                              required:
+                                - key
+                                - operator
+                              type: object
+                            type: array
+                            x-kubernetes-list-type: atomic
+                          matchLabels:
+                            additionalProperties:
+                              type: string
+                            description: |-
+                              matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                              map is equivalent to an element of matchExpressions, whose key field is "key", the
+                              operator is "In", and the values array contains only "value". The requirements are ANDed.
+                            type: object
+                        type: object
+                        x-kubernetes-map-type: atomic
+                    required:
+                      - key
+                      - kind
+                    type: object
+                    x-kubernetes-map-type: atomic
+                    x-kubernetes-validations:
+                      - message: exactly one of the fields in [name selector] must be set
+                        rule: '[has(self.name),has(self.selector)].filter(x,x==true).size() == 1'
+                  maxItems: 100
+                  minItems: 0
+                  type: array
+                  x-kubernetes-list-type: atomic
+                target:
+                  description: target is the target location in all namespaces to sync source data to.
+                  properties:
+                    configMap:
+                      description: configMap is the target ConfigMap in Namespaces that all Bundle source data will be synced to.
+                      properties:
+                        data:
+                          description: data is the specification of the object's `data` field.
+                          items:
+                            description: TargetKeyValue is the specification of a key with value in a key-value target resource.
+                            minProperties: 0
+                            properties:
+                              format:
+                                description: |-
+                                  format defines the format of the target value.
+                                  The default format is PEM.
+                                enum:
+                                  - PEM
+                                  - PKCS12
+                                type: string
+                              key:
+                                description: key is the key of the entry in the object's `data` field to be used.
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[0-9A-Za-z_.\-]+$
+                                type: string
+                              password:
+                                description: |-
+                                  password for PKCS12 trust store.
+                                  By default, no password is used (password-less PKCS#12).
+                                maxLength: 128
+                                minLength: 0
+                                type: string
+                              profile:
+                                description: |-
+                                  profile specifies the certificate encryption algorithms and the HMAC algorithm
+                                  used to create the PKCS12 trust store.
+
+                                  If provided, allowed values are:
+                                  `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
+                                  `LegacyDES`: Less secure algorithm. Use this option for maximal compatibility.
+                                  `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms (e.g. because of company policy).
+
+                                  Default value is `LegacyDES`.
+                                enum:
+                                  - LegacyRC2
+                                  - LegacyDES
+                                  - Modern2023
+                                type: string
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                            x-kubernetes-validations:
+                              - fieldPath: .password
+                                message: may only be set when format is 'PKCS12'
+                                reason: FieldValueForbidden
+                                rule: '!has(self.password) || (has(self.format) && self.format == ''PKCS12'')'
+                              - fieldPath: .profile
+                                message: may only be set when format is 'PKCS12'
+                                reason: FieldValueForbidden
+                                rule: '!has(self.profile) || (has(self.format) && self.format == ''PKCS12'')'
+                          maxItems: 10
+                          minItems: 1
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - key
+                          x-kubernetes-list-type: map
+                        metadata:
+                          description: metadata is an optional set of labels and annotations to be copied to the target.
+                          minProperties: 1
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: annotations is a key value map to be copied to the target.
+                              minProperties: 1
+                              type: object
+                              x-kubernetes-validations:
+                                - message: must not use forbidden domains as prefixes (e.g., trust-manager.io)
+                                  reason: FieldValueForbidden
+                                  rule: self.all(k, !k.startsWith('trust-manager.io/'))
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: labels is a key value map to be copied to the target.
+                              minProperties: 1
+                              type: object
+                              x-kubernetes-validations:
+                                - message: must not use forbidden domains as prefixes (e.g., trust-manager.io)
+                                  reason: FieldValueForbidden
+                                  rule: self.all(k, !k.startsWith('trust-manager.io/'))
+                          type: object
+                      required:
+                        - data
+                      type: object
+                    namespaceSelector:
+                      description: namespaceSelector specifies the namespaces where target resources will be synced.
+                      properties:
+                        matchExpressions:
+                          description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
+                          items:
+                            description: |-
+                              A label selector requirement is a selector that contains values, a key, and an operator that
+                              relates the key and values.
+                            properties:
+                              key:
+                                description: key is the label key that the selector applies to.
+                                type: string
+                              operator:
+                                description: |-
+                                  operator represents a key's relationship to a set of values.
+                                  Valid operators are In, NotIn, Exists and DoesNotExist.
+                                type: string
+                              values:
+                                description: |-
+                                  values is an array of string values. If the operator is In or NotIn,
+                                  the values array must be non-empty. If the operator is Exists or DoesNotExist,
+                                  the values array must be empty. This array is replaced during a strategic
+                                  merge patch.
+                                items:
+                                  type: string
+                                type: array
+                                x-kubernetes-list-type: atomic
+                            required:
+                              - key
+                              - operator
+                            type: object
+                          type: array
+                          x-kubernetes-list-type: atomic
+                        matchLabels:
+                          additionalProperties:
+                            type: string
+                          description: |-
+                            matchLabels is a map of {key,value} pairs. A single {key,value} in the matchLabels
+                            map is equivalent to an element of matchExpressions, whose key field is "key", the
+                            operator is "In", and the values array contains only "value". The requirements are ANDed.
+                          type: object
+                      type: object
+                      x-kubernetes-map-type: atomic
+                    secret:
+                      description: |-
+                        secret is the target Secret in Namespaces that all Bundle source data will be synced to.
+                        Using Secrets as targets is only supported if enabled at trust-manager startup.
+                        By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.
+                      properties:
+                        data:
+                          description: data is the specification of the object's `data` field.
+                          items:
+                            description: TargetKeyValue is the specification of a key with value in a key-value target resource.
+                            minProperties: 0
+                            properties:
+                              format:
+                                description: |-
+                                  format defines the format of the target value.
+                                  The default format is PEM.
+                                enum:
+                                  - PEM
+                                  - PKCS12
+                                type: string
+                              key:
+                                description: key is the key of the entry in the object's `data` field to be used.
+                                maxLength: 253
+                                minLength: 1
+                                pattern: ^[0-9A-Za-z_.\-]+$
+                                type: string
+                              password:
+                                description: |-
+                                  password for PKCS12 trust store.
+                                  By default, no password is used (password-less PKCS#12).
+                                maxLength: 128
+                                minLength: 0
+                                type: string
+                              profile:
+                                description: |-
+                                  profile specifies the certificate encryption algorithms and the HMAC algorithm
+                                  used to create the PKCS12 trust store.
+
+                                  If provided, allowed values are:
+                                  `LegacyRC2`: Deprecated. Not supported by default in OpenSSL 3 or Java 20.
+                                  `LegacyDES`: Less secure algorithm. Use this option for maximal compatibility.
+                                  `Modern2023`: Secure algorithm. Use this option in case you have to always use secure algorithms (e.g. because of company policy).
+
+                                  Default value is `LegacyDES`.
+                                enum:
+                                  - LegacyRC2
+                                  - LegacyDES
+                                  - Modern2023
+                                type: string
+                            required:
+                              - key
+                            type: object
+                            x-kubernetes-map-type: atomic
+                            x-kubernetes-validations:
+                              - fieldPath: .password
+                                message: may only be set when format is 'PKCS12'
+                                reason: FieldValueForbidden
+                                rule: '!has(self.password) || (has(self.format) && self.format == ''PKCS12'')'
+                              - fieldPath: .profile
+                                message: may only be set when format is 'PKCS12'
+                                reason: FieldValueForbidden
+                                rule: '!has(self.profile) || (has(self.format) && self.format == ''PKCS12'')'
+                          maxItems: 10
+                          minItems: 1
+                          type: array
+                          x-kubernetes-list-map-keys:
+                            - key
+                          x-kubernetes-list-type: map
+                        metadata:
+                          description: metadata is an optional set of labels and annotations to be copied to the target.
+                          minProperties: 1
+                          properties:
+                            annotations:
+                              additionalProperties:
+                                type: string
+                              description: annotations is a key value map to be copied to the target.
+                              minProperties: 1
+                              type: object
+                              x-kubernetes-validations:
+                                - message: must not use forbidden domains as prefixes (e.g., trust-manager.io)
+                                  reason: FieldValueForbidden
+                                  rule: self.all(k, !k.startsWith('trust-manager.io/'))
+                            labels:
+                              additionalProperties:
+                                type: string
+                              description: labels is a key value map to be copied to the target.
+                              minProperties: 1
+                              type: object
+                              x-kubernetes-validations:
+                                - message: must not use forbidden domains as prefixes (e.g., trust-manager.io)
+                                  reason: FieldValueForbidden
+                                  rule: self.all(k, !k.startsWith('trust-manager.io/'))
+                          type: object
+                      required:
+                        - data
+                      type: object
+                  required:
+                    - namespaceSelector
+                  type: object
+                  x-kubernetes-validations:
+                    - message: at least one of the fields in [configMap secret] must be set
+                      rule: '[has(self.configMap),has(self.secret)].filter(x,x==true).size() >= 1'
+              type: object
+            status:
+              description: status of the ClusterBundle. This is set and managed automatically.
+              minProperties: 1
+              properties:
+                conditions:
+                  description: conditions represent the latest available observations of the ClusterBundle's current state.
+                  items:
+                    description: Condition contains details for one aspect of the current state of this API Resource.
+                    properties:
+                      lastTransitionTime:
+                        description: |-
+                          lastTransitionTime is the last time the condition transitioned from one status to another.
+                          This should be when the underlying condition changed.  If that is not known, then using the time when the API field changed is acceptable.
+                        format: date-time
+                        type: string
+                      message:
+                        description: |-
+                          message is a human readable message indicating details about the transition.
+                          This may be an empty string.
+                        maxLength: 32768
+                        type: string
+                      observedGeneration:
+                        description: |-
+                          observedGeneration represents the .metadata.generation that the condition was set based upon.
+                          For instance, if .metadata.generation is currently 12, but the .status.conditions[x].observedGeneration is 9, the condition is out of date
+                          with respect to the current state of the instance.
+                        format: int64
+                        minimum: 0
+                        type: integer
+                      reason:
+                        description: |-
+                          reason contains a programmatic identifier indicating the reason for the condition's last transition.
+                          Producers of specific condition types may define expected values and meanings for this field,
+                          and whether the values are considered a guaranteed API.
+                          The value should be a CamelCase string.
+                          This field may not be empty.
+                        maxLength: 1024
+                        minLength: 1
+                        pattern: ^[A-Za-z]([A-Za-z0-9_,:]*[A-Za-z0-9_])?$
+                        type: string
+                      status:
+                        description: status of the condition, one of True, False, Unknown.
+                        enum:
+                          - "True"
+                          - "False"
+                          - Unknown
+                        type: string
+                      type:
+                        description: type of condition in CamelCase or in foo.example.com/CamelCase.
+                        maxLength: 316
+                        pattern: ^([a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*/)?(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])$
+                        type: string
+                    required:
+                      - lastTransitionTime
+                      - message
+                      - reason
+                      - status
+                      - type
+                    type: object
+                  maxItems: 10
+                  minItems: 0
+                  type: array
+                  x-kubernetes-list-map-keys:
+                    - type
+                  x-kubernetes-list-type: map
+                defaultCAVersion:
+                  description: |-
+                    defaultCAVersion is the version of the default CA package used for this ClusterBundle
+                    when resolving default CAs, if applicable.
+                    This field is populated only when default CAs are configured via spec.defaultCAs.
+                    ClusterBundles resolved from identical sets of default CA certificates will report
+                    the same defaultCAVersion value.
+                  maxLength: 253
+                  minLength: 1
+                  type: string
+              type: object
+          type: object
+      served: true
+      storage: true
+      subresources:
+        status: {}
+{{- end }}

--- a/deploy/charts/trust-manager/templates/crd-trust.cert-manager.io_bundles.yaml
+++ b/deploy/charts/trust-manager/templates/crd-trust.cert-manager.io_bundles.yaml
@@ -39,9 +39,12 @@ spec:
           jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
+      deprecated: true
+      deprecationWarning: trust.cert-manager.io/v1alpha1 Bundle is deprecated, please migrate to trust-manager.io/v1alpha2 ClusterBundle
       name: v1alpha1
       schema:
         openAPIV3Schema:
+          description: 'Deprecated: v1alpha1.Bundle will be removed in a future release. Migrate to v1alpha2.ClusterBundle instead.'
           properties:
             apiVersion:
               description: |-

--- a/deploy/charts/trust-manager/templates/webhook.yaml
+++ b/deploy/charts/trust-manager/templates/webhook.yaml
@@ -124,3 +124,26 @@ webhooks:
         name: {{ include "trust-manager.name" . }}
         namespace: {{ include "trust-manager.namespace" . }}
         path: /validate-trust-cert-manager-io-v1alpha1-bundle
+  - name: vclusterbundle-v1alpha2.trust-manager.io
+    rules:
+      - apiGroups:
+          - "trust-manager.io"
+        apiVersions:
+          - v1alpha2
+        operations:
+          - CREATE
+          - UPDATE
+        resources:
+          - clusterbundles
+    admissionReviewVersions: ["v1"]
+    timeoutSeconds: {{ .Values.app.webhook.timeoutSeconds }}
+    failurePolicy: Fail
+    sideEffects: None
+    clientConfig:
+{{ if .Values.app.webhook.tls.helmCert.enabled }}
+      caBundle: "{{ $ca.Cert | b64enc }}"
+{{ end }}
+      service:
+        name: {{ include "trust-manager.name" . }}
+        namespace: {{ include "trust-manager.namespace" . }}
+        path: /validate-trust-manager-io-v1alpha2-clusterbundle

--- a/deploy/charts/trust-manager/tests/clusterrole_aggregate_test.yaml
+++ b/deploy/charts/trust-manager/tests/clusterrole_aggregate_test.yaml
@@ -6,33 +6,28 @@ release:
   namespace: trust
 tests:
   - it: default — renders the cluster-view (read) aggregated role
+    documentIndex: 0
     asserts:
       - hasDocuments:
           count: 1
+
       - equal:
           path: metadata.name
           value: trust-manager-cluster-view
-        documentIndex: 0
+
       - equal:
           path: metadata.labels["rbac.authorization.k8s.io/aggregate-to-cluster-reader"]
           value: "true"
-        documentIndex: 0
+
       - equal:
-          path: rules[0].verbs
-          value: ["get", "list", "watch"]
-        documentIndex: 0
-      - equal:
-          path: rules[0].apiGroups
-          value: ["trust.cert-manager.io"]
-        documentIndex: 0
-      - equal:
-          path: rules[0].resources
-          value: ["bundles"]
-        documentIndex: 0
-      - lengthEqual:
           path: rules
-          count: 1
-        documentIndex: 0
+          value:
+            - verbs: ["get", "list", "watch"]
+              apiGroups: ["trust.cert-manager.io"]
+              resources: ["bundles"]
+            - verbs: ["get", "list", "watch"]
+              apiGroups: ["trust-manager.io"]
+              resources: ["clusterbundles"]
 
   - it: global.rbac.aggregateClusterRoles=false suppresses the role
     set:

--- a/deploy/crds/trust.cert-manager.io_bundles.yaml
+++ b/deploy/crds/trust.cert-manager.io_bundles.yaml
@@ -35,9 +35,14 @@ spec:
       jsonPath: .metadata.creationTimestamp
       name: Age
       type: date
+    deprecated: true
+    deprecationWarning: trust.cert-manager.io/v1alpha1 Bundle is deprecated, please
+      migrate to trust-manager.io/v1alpha2 ClusterBundle
     name: v1alpha1
     schema:
       openAPIV3Schema:
+        description: 'Deprecated: v1alpha1.Bundle will be removed in a future release.
+          Migrate to v1alpha2.ClusterBundle instead.'
         properties:
           apiVersion:
             description: |-

--- a/make/00_mod.mk
+++ b/make/00_mod.mk
@@ -70,8 +70,6 @@ oci_package_debian_trixie_additional_layers += $(debian_trixie_package_layer)
 deploy_name := trust-manager
 deploy_namespace := cert-manager
 
-# Exclude new ClusterBundle API from Helm chart for now.
-crds_template_exclude_pattern := trust-manager.io_clusterbundles.yaml
 helm_chart_source_dir := deploy/charts/trust-manager
 helm_chart_image_name := quay.io/jetstack/charts/trust-manager
 helm_chart_version := $(VERSION)

--- a/pkg/apis/trust/v1alpha1/types_bundle.go
+++ b/pkg/apis/trust/v1alpha1/types_bundle.go
@@ -26,6 +26,7 @@ var BundleLabelKey = "trust.cert-manager.io/bundle"
 var BundleHashAnnotationKey = "trust.cert-manager.io/hash"
 
 // +kubebuilder:object:root=true
+// +kubebuilder:deprecatedversion:warning="trust.cert-manager.io/v1alpha1 Bundle is deprecated, please migrate to trust-manager.io/v1alpha2 ClusterBundle"
 // +kubebuilder:printcolumn:name="ConfigMap Target",type="string",JSONPath=".spec.target.configMap.key",description="Bundle ConfigMap Target Key"
 // +kubebuilder:printcolumn:name="Secret Target",type="string",JSONPath=".spec.target.secret.key",description="Bundle Secret Target Key"
 // +kubebuilder:printcolumn:name="Synced",type="string",JSONPath=`.status.conditions[?(@.type == "Synced")].status`,description="Bundle has been synced"
@@ -36,6 +37,7 @@ var BundleHashAnnotationKey = "trust.cert-manager.io/hash"
 // +genclient
 // +genclient:nonNamespaced
 
+// Deprecated: v1alpha1.Bundle will be removed in a future release. Migrate to v1alpha2.ClusterBundle instead.
 type Bundle struct {
 	metav1.TypeMeta `json:",inline"`
 
@@ -54,6 +56,8 @@ type Bundle struct {
 }
 
 // +kubebuilder:object:root=true
+
+// Deprecated: v1alpha1.BundleList will be removed in one of the next releases. Migrate to v1alpha2.ClusterBundleList instead.
 type BundleList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata"`

--- a/pkg/applyconfigurations/trust/v1alpha1/bundle.go
+++ b/pkg/applyconfigurations/trust/v1alpha1/bundle.go
@@ -28,6 +28,8 @@ import (
 
 // BundleApplyConfiguration represents a declarative configuration of the Bundle type for use
 // with apply.
+//
+// Deprecated: v1alpha1.Bundle will be removed in a future release. Migrate to v1alpha2.ClusterBundle instead.
 type BundleApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration `json:",inline"`
 	// metadata is the standard object's metadata.

--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -35,7 +35,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
+	trustmanagerapi "github.com/cert-manager/trust-manager/pkg/apis/trustmanager/v1alpha2"
 	"github.com/cert-manager/trust-manager/pkg/bundle/controller"
 	"github.com/cert-manager/trust-manager/pkg/bundle/internal/source"
 	"github.com/cert-manager/trust-manager/pkg/bundle/internal/ssa_client"
@@ -83,12 +83,12 @@ func (b *bundle) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, 
 	return ctrl.Result{}, resultErr
 }
 
-func (b *bundle) reconcileBundle(ctx context.Context, req ctrl.Request) (statusPatch *trustapi.BundleStatus, returnedErr error) {
+func (b *bundle) reconcileBundle(ctx context.Context, req ctrl.Request) (statusPatch *trustmanagerapi.BundleStatus, returnedErr error) {
 	log := logf.FromContext(ctx).WithValues("bundle", req.NamespacedName.Name)
 	ctx = logf.IntoContext(ctx, log)
 	log.V(2).Info("syncing bundle")
 
-	var bundle trustapi.Bundle
+	var bundle trustmanagerapi.ClusterBundle
 	err := b.client.Get(ctx, req.NamespacedName, &bundle)
 	if apierrors.IsNotFound(err) {
 		log.V(2).Info("bundle no longer exists, ignoring")
@@ -102,10 +102,10 @@ func (b *bundle) reconcileBundle(ctx context.Context, req ctrl.Request) (statusP
 
 	// Initialize patch with current status field values, except conditions.
 	// This is done to ensure information is not lost in patch if exiting early.
-	statusPatch = &trustapi.BundleStatus{
+	statusPatch = &trustmanagerapi.BundleStatus{
 		DefaultCAPackageVersion: bundle.Status.DefaultCAPackageVersion,
 	}
-	resolvedBundle, err := b.bundleBuilder.BuildBundle(ctx, bundle.Spec.Sources)
+	resolvedBundle, err := b.bundleBuilder.BuildBundle(ctx, bundle.Spec)
 
 	if err != nil {
 		var reason, message string
@@ -127,7 +127,7 @@ func (b *bundle) reconcileBundle(ctx context.Context, req ctrl.Request) (statusP
 			bundle.Status.Conditions,
 			&statusPatch.Conditions,
 			metav1.Condition{
-				Type:               trustapi.BundleConditionSynced,
+				Type:               trustmanagerapi.BundleConditionSynced,
 				Status:             metav1.ConditionFalse,
 				Reason:             reason,
 				Message:            errMsg,
@@ -149,7 +149,7 @@ func (b *bundle) reconcileBundle(ctx context.Context, req ctrl.Request) (statusP
 			bundle.Status.Conditions,
 			&statusPatch.Conditions,
 			metav1.Condition{
-				Type:               trustapi.BundleConditionSynced,
+				Type:               trustmanagerapi.BundleConditionSynced,
 				Status:             metav1.ConditionFalse,
 				Reason:             "SecretTargetsDisabled",
 				Message:            "Bundle has Secret targets but the feature is disabled",
@@ -222,7 +222,7 @@ func (b *bundle) reconcileBundle(ctx context.Context, req ctrl.Request) (statusP
 		}
 		err := b.targetReconciler.Cache.List(ctx, targetList, &client.ListOptions{
 			LabelSelector: labels.SelectorFromSet(map[string]string{
-				trustapi.BundleLabelKey: bundle.Name,
+				trustmanagerapi.BundleLabelKey: bundle.Name,
 			}),
 		})
 		if err != nil {
@@ -279,7 +279,7 @@ func (b *bundle) reconcileBundle(ctx context.Context, req ctrl.Request) (statusP
 				bundle.Status.Conditions,
 				&statusPatch.Conditions,
 				metav1.Condition{
-					Type:               trustapi.BundleConditionSynced,
+					Type:               trustmanagerapi.BundleConditionSynced,
 					Status:             metav1.ConditionFalse,
 					Reason:             fmt.Sprintf("Sync%sTargetFailed", t.Kind),
 					Message:            fmt.Sprintf("Failed to sync bundle %s to namespace %q: %s", t.Kind, t.Namespace, err),
@@ -314,7 +314,7 @@ func (b *bundle) reconcileBundle(ctx context.Context, req ctrl.Request) (statusP
 	}
 
 	syncedCondition := metav1.Condition{
-		Type:               trustapi.BundleConditionSynced,
+		Type:               trustmanagerapi.BundleConditionSynced,
 		Status:             metav1.ConditionTrue,
 		Reason:             "Synced",
 		Message:            message,
@@ -338,7 +338,7 @@ func (b *bundle) reconcileBundle(ctx context.Context, req ctrl.Request) (statusP
 	return statusPatch, nil
 }
 
-func (b *bundle) bundleTargetNamespaceSelector(bundleTarget trustapi.BundleTarget) (labels.Selector, error) {
+func (b *bundle) bundleTargetNamespaceSelector(bundleTarget trustmanagerapi.BundleTarget) (labels.Selector, error) {
 	nsSelector := bundleTarget.NamespaceSelector
 
 	// LabelSelectorAsSelector returns a Selector selecting nothing if LabelSelector is nil,

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -17,15 +17,19 @@ limitations under the License.
 package bundle
 
 import (
+	"bytes"
 	"context"
 	"sync"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/json"
 	coreapplyconfig "k8s.io/client-go/applyconfigurations/core/v1"
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
 	"k8s.io/client-go/tools/events"
@@ -36,7 +40,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
+	trustmanagerapi "github.com/cert-manager/trust-manager/pkg/apis/trustmanager/v1alpha2"
 	"github.com/cert-manager/trust-manager/pkg/bundle/controller"
 	"github.com/cert-manager/trust-manager/pkg/bundle/internal/source"
 	"github.com/cert-manager/trust-manager/pkg/bundle/internal/ssa_client"
@@ -57,7 +61,7 @@ func testEncodePKCS12(t *testing.T, data string) []byte {
 		t.Fatal(err)
 	}
 
-	encoded, err := truststore.NewPKCS12Encoder(trustapi.DefaultPKCS12Password, trustapi.Modern2023PKCS12Profile).Encode(certPool)
+	encoded, err := truststore.NewPKCS12Encoder(trustmanagerapi.DefaultPKCS12Password, trustmanagerapi.Modern2023PKCS12Profile).Encode(certPool)
 	if err != nil {
 		t.Error(err)
 	}
@@ -103,27 +107,27 @@ func Test_Reconcile(t *testing.T) {
 			},
 		}
 
-		baseBundle = &trustapi.Bundle{
-			TypeMeta: metav1.TypeMeta{Kind: "Bundle", APIVersion: "trust.cert-manager.io/v1alpha1"},
+		baseBundle = &trustmanagerapi.ClusterBundle{
+			TypeMeta: metav1.TypeMeta{Kind: "ClusterBundle", APIVersion: "trust-manager.io/v1alpha2"},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:            bundleName,
 				Generation:      bundleGeneration,
 				UID:             "123",
 				ResourceVersion: "1000",
 			},
-			Spec: trustapi.BundleSpec{
-				Sources: []trustapi.BundleSource{
-					{ConfigMap: &trustapi.SourceObjectKeySelector{Name: sourceConfigMapName, Key: sourceConfigMapKey}},
-					{Secret: &trustapi.SourceObjectKeySelector{Name: sourceSecretName, Key: sourceSecretKey}},
-					{InLine: dummy.TestCertificate3},
+			Spec: trustmanagerapi.BundleSpec{
+				SourceRefs: []trustmanagerapi.BundleSourceRef{
+					{SourceReference: trustmanagerapi.SourceReference{Kind: trustmanagerapi.ConfigMapKind, Name: sourceConfigMapName}, Key: sourceConfigMapKey},
+					{SourceReference: trustmanagerapi.SourceReference{Kind: trustmanagerapi.SecretKind, Name: sourceSecretName}, Key: sourceSecretKey},
 				},
-				Target: trustapi.BundleTarget{ConfigMap: &trustapi.TargetTemplate{Key: targetKey}},
+				InLineCAs: dummy.TestCertificate3,
+				Target:    trustmanagerapi.BundleTarget{ConfigMap: &trustmanagerapi.KeyValueTarget{Data: []trustmanagerapi.TargetKeyValue{{Key: targetKey}}}},
 			},
 		}
 
-		baseBundleLabels = map[string]string{trustapi.BundleLabelKey: bundleName}
+		baseBundleLabels = map[string]string{trustmanagerapi.BundleLabelKey: bundleName}
 
-		baseBundleOwnerRef = []metav1.OwnerReference{*metav1.NewControllerRef(baseBundle, trustapi.SchemeGroupVersion.WithKind(trustapi.BundleKind))}
+		baseBundleOwnerRef = []metav1.OwnerReference{*metav1.NewControllerRef(baseBundle, trustmanagerapi.SchemeGroupVersion.WithKind(trustmanagerapi.ClusterBundleKind))}
 
 		namespaces = []client.Object{
 			&corev1.Namespace{TypeMeta: metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"}, ObjectMeta: metav1.ObjectMeta{Name: trustNamespace}},
@@ -141,39 +145,43 @@ func Test_Reconcile(t *testing.T) {
 			Bundle:  dummy.TestCertificate5,
 		}
 
-		pkcs12DefaultAdditionalFormats = trustapi.AdditionalFormats{
-			PKCS12: &trustapi.PKCS12{
-				KeySelector: trustapi.KeySelector{
-					Key: "target.p12",
+		pkcs12DefaultKeyValue = trustmanagerapi.KeyValueTarget{
+			Data: []trustmanagerapi.TargetKeyValue{
+				{Key: targetKey},
+				{
+					Key:    "target.p12",
+					Format: trustmanagerapi.BundleFormatPKCS12,
+					PKCS12: trustmanagerapi.PKCS12{Password: ptr.To(trustmanagerapi.DefaultPKCS12Password)},
 				},
-				Password: ptr.To(trustapi.DefaultPKCS12Password),
 			},
 		}
-		pkcs12DefaultAdditionalFormatsOldPassword = trustapi.AdditionalFormats{
-			PKCS12: &trustapi.PKCS12{
-				KeySelector: trustapi.KeySelector{
-					Key: "target.p12",
+		pkcs12DefaultKeyValueOldPassword = trustmanagerapi.KeyValueTarget{
+			Data: []trustmanagerapi.TargetKeyValue{
+				{Key: targetKey},
+				{
+					Key:    "target.p12",
+					Format: trustmanagerapi.BundleFormatPKCS12,
+					PKCS12: trustmanagerapi.PKCS12{Password: new("OLD PASSWORD")},
 				},
-				Password: new("OLD PASSWORD"),
 			},
 		}
 
-		configMapPatch = func(name, namespace string, data map[string]string, binData map[string][]byte, key *string, additionalFormats *trustapi.AdditionalFormats) *coreapplyconfig.ConfigMapApplyConfiguration {
+		configMapPatch = func(name, namespace string, data map[string]string, binData map[string][]byte, key *string, keyValue *trustmanagerapi.KeyValueTarget) *coreapplyconfig.ConfigMapApplyConfiguration {
 			annotations := map[string]string{}
 			if key != nil {
-				annotations[trustapi.BundleHashAnnotationKey] = target.TrustBundleHash([]byte(data[*key]), additionalFormats, nil)
+				annotations[trustmanagerapi.BundleHashAnnotationKey] = target.TrustBundleHash([]byte(data[*key]), keyValue)
 			}
 
 			return coreapplyconfig.
 				ConfigMap(name, namespace).
 				WithLabels(map[string]string{
-					trustapi.BundleLabelKey: baseBundle.GetName(),
+					trustmanagerapi.BundleLabelKey: baseBundle.GetName(),
 				}).
 				WithAnnotations(annotations).
 				WithOwnerReferences(
 					v1.OwnerReference().
-						WithAPIVersion(trustapi.SchemeGroupVersion.String()).
-						WithKind(trustapi.BundleKind).
+						WithAPIVersion(trustmanagerapi.SchemeGroupVersion.String()).
+						WithKind(trustmanagerapi.ClusterBundleKind).
 						WithName(baseBundle.GetName()).
 						WithUID(baseBundle.GetUID()).
 						WithBlockOwnerDeletion(true).
@@ -183,10 +191,10 @@ func Test_Reconcile(t *testing.T) {
 				WithBinaryData(binData)
 		}
 
-		secretPatch = func(name, namespace string, data map[string]string, key *string, additionaFormats *trustapi.AdditionalFormats) *coreapplyconfig.SecretApplyConfiguration {
+		secretPatch = func(name, namespace string, data map[string]string, key *string, keyValue *trustmanagerapi.KeyValueTarget) *coreapplyconfig.SecretApplyConfiguration {
 			annotations := map[string]string{}
 			if key != nil {
-				annotations[trustapi.BundleHashAnnotationKey] = target.TrustBundleHash([]byte(data[*key]), additionaFormats, nil)
+				annotations[trustmanagerapi.BundleHashAnnotationKey] = target.TrustBundleHash([]byte(data[*key]), keyValue)
 			}
 
 			binaryData := map[string][]byte{}
@@ -197,13 +205,13 @@ func Test_Reconcile(t *testing.T) {
 			return coreapplyconfig.
 				Secret(name, namespace).
 				WithLabels(map[string]string{
-					trustapi.BundleLabelKey: baseBundle.GetName(),
+					trustmanagerapi.BundleLabelKey: baseBundle.GetName(),
 				}).
 				WithAnnotations(annotations).
 				WithOwnerReferences(
 					v1.OwnerReference().
-						WithAPIVersion(trustapi.SchemeGroupVersion.String()).
-						WithKind(trustapi.BundleKind).
+						WithAPIVersion(trustmanagerapi.SchemeGroupVersion.String()).
+						WithKind(trustmanagerapi.ClusterBundleKind).
 						WithName(baseBundle.GetName()).
 						WithUID(baseBundle.GetUID()).
 						WithBlockOwnerDeletion(true).
@@ -212,10 +220,10 @@ func Test_Reconcile(t *testing.T) {
 				WithData(binaryData)
 		}
 
-		targetConfigMap = func(namespace string, data map[string]string, binData map[string][]byte, key *string, withOwnerRef bool, additionaFormats *trustapi.AdditionalFormats) *corev1.ConfigMap {
+		targetConfigMap = func(namespace string, data map[string]string, binData map[string][]byte, key *string, withOwnerRef bool, keyValue *trustmanagerapi.KeyValueTarget) *corev1.ConfigMap {
 			annotations := map[string]string{}
 			if key != nil {
-				annotations[trustapi.BundleHashAnnotationKey] = target.TrustBundleHash([]byte(data[*key]), additionaFormats, nil)
+				annotations[trustmanagerapi.BundleHashAnnotationKey] = target.TrustBundleHash([]byte(data[*key]), keyValue)
 			}
 
 			dataEntries := make([]string, 0, len(data))
@@ -249,10 +257,10 @@ func Test_Reconcile(t *testing.T) {
 			return configmap
 		}
 
-		targetSecret = func(namespace string, data map[string]string, key *string, withOwnerRef bool, additionaFormats *trustapi.AdditionalFormats) *corev1.Secret {
+		targetSecret = func(namespace string, data map[string]string, key *string, withOwnerRef bool, keyValue *trustmanagerapi.KeyValueTarget) *corev1.Secret {
 			annotations := map[string]string{}
 			if key != nil {
-				annotations[trustapi.BundleHashAnnotationKey] = target.TrustBundleHash([]byte(data[*key]), additionaFormats, nil)
+				annotations[trustmanagerapi.BundleHashAnnotationKey] = target.TrustBundleHash([]byte(data[*key]), keyValue)
 			}
 
 			dataEntries := make([]string, 0, len(data))
@@ -296,7 +304,7 @@ func Test_Reconcile(t *testing.T) {
 		expResult               ctrl.Result
 		expError                bool
 		expPatches              []any
-		expBundlePatch          *trustapi.BundleStatus
+		expBundlePatch          *trustmanagerapi.BundleStatus
 		expEvent                string
 		targetNamespaces        []string
 	}{
@@ -311,9 +319,9 @@ func Test_Reconcile(t *testing.T) {
 			existingNamespaces: namespaces,
 			existingBundles:    []client.Object{gen.BundleFrom(baseBundle)},
 			expError:           false,
-			expBundlePatch: &trustapi.BundleStatus{Conditions: []metav1.Condition{
+			expBundlePatch: &trustmanagerapi.BundleStatus{Conditions: []metav1.Condition{
 				{
-					Type:               trustapi.BundleConditionSynced,
+					Type:               trustmanagerapi.BundleConditionSynced,
 					Status:             metav1.ConditionFalse,
 					Reason:             "SourceNotFound",
 					Message:            `Bundle source was not found: failed to get ConfigMap trust-namespace/source-configmap: configmaps "source-configmap" not found`,
@@ -329,9 +337,9 @@ func Test_Reconcile(t *testing.T) {
 			existingConfigMaps: []client.Object{&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: trustNamespace, Name: sourceConfigMapName}}},
 			existingBundles:    []client.Object{gen.BundleFrom(baseBundle)},
 			expError:           false,
-			expBundlePatch: &trustapi.BundleStatus{Conditions: []metav1.Condition{
+			expBundlePatch: &trustmanagerapi.BundleStatus{Conditions: []metav1.Condition{
 				{
-					Type:               trustapi.BundleConditionSynced,
+					Type:               trustmanagerapi.BundleConditionSynced,
 					Status:             metav1.ConditionFalse,
 					Reason:             "SourceNotFound",
 					Message:            `Bundle source was not found: no data found in ConfigMap trust-namespace/source-configmap at key "configmap-key"`,
@@ -346,9 +354,9 @@ func Test_Reconcile(t *testing.T) {
 			existingConfigMaps: []client.Object{sourceConfigMap},
 			existingBundles:    []client.Object{gen.BundleFrom(baseBundle)},
 			expError:           false,
-			expBundlePatch: &trustapi.BundleStatus{Conditions: []metav1.Condition{
+			expBundlePatch: &trustmanagerapi.BundleStatus{Conditions: []metav1.Condition{
 				{
-					Type:               trustapi.BundleConditionSynced,
+					Type:               trustmanagerapi.BundleConditionSynced,
 					Status:             metav1.ConditionFalse,
 					Reason:             "SourceNotFound",
 					Message:            `Bundle source was not found: failed to get Secret trust-namespace/source-secret: secrets "source-secret" not found`,
@@ -364,9 +372,9 @@ func Test_Reconcile(t *testing.T) {
 			existingSecrets:    []client.Object{&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: trustNamespace, Name: sourceSecretName}}},
 			existingBundles:    []client.Object{gen.BundleFrom(baseBundle)},
 			expError:           false,
-			expBundlePatch: &trustapi.BundleStatus{Conditions: []metav1.Condition{
+			expBundlePatch: &trustmanagerapi.BundleStatus{Conditions: []metav1.Condition{
 				{
-					Type:               trustapi.BundleConditionSynced,
+					Type:               trustmanagerapi.BundleConditionSynced,
 					Status:             metav1.ConditionFalse,
 					Reason:             "SourceNotFound",
 					Message:            `Bundle source was not found: no data found in Secret trust-namespace/source-secret at key "secret-key"`,
@@ -410,10 +418,10 @@ func Test_Reconcile(t *testing.T) {
 				configMapPatch(baseBundle.Name, "ns-1", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 				configMapPatch(baseBundle.Name, "ns-2", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 			},
-			expBundlePatch: &trustapi.BundleStatus{
+			expBundlePatch: &trustmanagerapi.BundleStatus{
 				Conditions: []metav1.Condition{
 					{
-						Type:               trustapi.BundleConditionSynced,
+						Type:               trustmanagerapi.BundleConditionSynced,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "Synced",
@@ -449,7 +457,7 @@ func Test_Reconcile(t *testing.T) {
 			},
 			existingBundles: []client.Object{
 				gen.BundleFrom(baseBundle,
-					func(b *trustapi.Bundle) {
+					func(b *trustmanagerapi.ClusterBundle) {
 						// swap target configmap for secret
 						keySelector := b.Spec.Target.ConfigMap
 						b.Spec.Target.ConfigMap = nil
@@ -463,10 +471,10 @@ func Test_Reconcile(t *testing.T) {
 				secretPatch(baseBundle.Name, "ns-1", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, ptr.To(targetKey), nil),
 				secretPatch(baseBundle.Name, "ns-2", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, ptr.To(targetKey), nil),
 			},
-			expBundlePatch: &trustapi.BundleStatus{
+			expBundlePatch: &trustmanagerapi.BundleStatus{
 				Conditions: []metav1.Condition{
 					{
-						Type:               trustapi.BundleConditionSynced,
+						Type:               trustmanagerapi.BundleConditionSynced,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "Synced",
@@ -490,7 +498,7 @@ func Test_Reconcile(t *testing.T) {
 						"target.p12": []byte("foo"),
 					},
 					new("old-target"),
-					true, &pkcs12DefaultAdditionalFormats,
+					true, &pkcs12DefaultKeyValue,
 				),
 				targetConfigMap(
 					"ns-2",
@@ -502,13 +510,13 @@ func Test_Reconcile(t *testing.T) {
 						"target.p12": []byte("foo"),
 					},
 					new("old-target"),
-					true, &pkcs12DefaultAdditionalFormats,
+					true, &pkcs12DefaultKeyValue,
 				),
 			},
 			existingSecrets: []client.Object{sourceSecret},
 			existingBundles: []client.Object{
 				gen.BundleFrom(baseBundle,
-					gen.SetBundleTargetAdditionalFormats(pkcs12DefaultAdditionalFormats),
+					gen.SetBundleKeyValueTarget(pkcs12DefaultKeyValue),
 				)},
 			expError: false,
 			expPatches: []any{
@@ -516,22 +524,22 @@ func Test_Reconcile(t *testing.T) {
 					targetKey: dummy.DefaultJoinedCerts(),
 				}, map[string][]byte{
 					"target.p12": testEncodePKCS12(t, dummy.DefaultJoinedCerts()),
-				}, ptr.To(targetKey), &pkcs12DefaultAdditionalFormats),
+				}, ptr.To(targetKey), &pkcs12DefaultKeyValue),
 				configMapPatch(baseBundle.Name, "ns-1", map[string]string{
 					targetKey: dummy.DefaultJoinedCerts(),
 				}, map[string][]byte{
 					"target.p12": testEncodePKCS12(t, dummy.DefaultJoinedCerts()),
-				}, ptr.To(targetKey), &pkcs12DefaultAdditionalFormats),
+				}, ptr.To(targetKey), &pkcs12DefaultKeyValue),
 				configMapPatch(baseBundle.Name, "ns-2", map[string]string{
 					targetKey: dummy.DefaultJoinedCerts(),
 				}, map[string][]byte{
 					"target.p12": testEncodePKCS12(t, dummy.DefaultJoinedCerts()),
-				}, ptr.To(targetKey), &pkcs12DefaultAdditionalFormats),
+				}, ptr.To(targetKey), &pkcs12DefaultKeyValue),
 			},
-			expBundlePatch: &trustapi.BundleStatus{
+			expBundlePatch: &trustmanagerapi.BundleStatus{
 				Conditions: []metav1.Condition{
 					{
-						Type:               trustapi.BundleConditionSynced,
+						Type:               trustmanagerapi.BundleConditionSynced,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "Synced",
@@ -555,7 +563,7 @@ func Test_Reconcile(t *testing.T) {
 						"old-target.p12": []byte("foo"),
 					},
 					ptr.To(targetKey),
-					true, &pkcs12DefaultAdditionalFormats,
+					true, &pkcs12DefaultKeyValue,
 				),
 				targetConfigMap(
 					"ns-2",
@@ -567,13 +575,13 @@ func Test_Reconcile(t *testing.T) {
 						"old-target.p12": []byte("foo"),
 					},
 					ptr.To(targetKey),
-					true, &pkcs12DefaultAdditionalFormats,
+					true, &pkcs12DefaultKeyValue,
 				),
 			},
 			existingSecrets: []client.Object{sourceSecret},
 			existingBundles: []client.Object{
 				gen.BundleFrom(baseBundle,
-					gen.SetBundleTargetAdditionalFormats(pkcs12DefaultAdditionalFormats),
+					gen.SetBundleKeyValueTarget(pkcs12DefaultKeyValue),
 				),
 			},
 			expError: false,
@@ -582,22 +590,22 @@ func Test_Reconcile(t *testing.T) {
 					targetKey: dummy.DefaultJoinedCerts(),
 				}, map[string][]byte{
 					"target.p12": testEncodePKCS12(t, dummy.DefaultJoinedCerts()),
-				}, ptr.To(targetKey), &pkcs12DefaultAdditionalFormats),
+				}, ptr.To(targetKey), &pkcs12DefaultKeyValue),
 				configMapPatch(baseBundle.Name, "ns-1", map[string]string{
 					targetKey: dummy.DefaultJoinedCerts(),
 				}, map[string][]byte{
 					"target.p12": testEncodePKCS12(t, dummy.DefaultJoinedCerts()),
-				}, ptr.To(targetKey), &pkcs12DefaultAdditionalFormats),
+				}, ptr.To(targetKey), &pkcs12DefaultKeyValue),
 				configMapPatch(baseBundle.Name, "ns-2", map[string]string{
 					targetKey: dummy.DefaultJoinedCerts(),
 				}, map[string][]byte{
 					"target.p12": testEncodePKCS12(t, dummy.DefaultJoinedCerts()),
-				}, ptr.To(targetKey), &pkcs12DefaultAdditionalFormats),
+				}, ptr.To(targetKey), &pkcs12DefaultKeyValue),
 			},
-			expBundlePatch: &trustapi.BundleStatus{
+			expBundlePatch: &trustmanagerapi.BundleStatus{
 				Conditions: []metav1.Condition{
 					{
-						Type:               trustapi.BundleConditionSynced,
+						Type:               trustmanagerapi.BundleConditionSynced,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "Synced",
@@ -620,7 +628,7 @@ func Test_Reconcile(t *testing.T) {
 						"target.p12": testEncodePKCS12(t, dummy.DefaultJoinedCerts()),
 					},
 					ptr.To(targetKey),
-					true, &pkcs12DefaultAdditionalFormats,
+					true, &pkcs12DefaultKeyValue,
 				),
 				targetConfigMap(
 					"ns-1",
@@ -631,7 +639,7 @@ func Test_Reconcile(t *testing.T) {
 						"target.p12": testEncodePKCS12(t, dummy.DefaultJoinedCerts()),
 					},
 					ptr.To(targetKey),
-					true, &pkcs12DefaultAdditionalFormats,
+					true, &pkcs12DefaultKeyValue,
 				),
 				targetConfigMap(
 					"ns-2",
@@ -642,21 +650,21 @@ func Test_Reconcile(t *testing.T) {
 						"target.p12": testEncodePKCS12(t, dummy.DefaultJoinedCerts()),
 					},
 					ptr.To(targetKey),
-					true, &pkcs12DefaultAdditionalFormats,
+					true, &pkcs12DefaultKeyValue,
 				),
 			},
 			existingSecrets: []client.Object{sourceSecret},
 			existingBundles: []client.Object{
 				gen.BundleFrom(baseBundle,
-					gen.SetBundleTargetAdditionalFormats(pkcs12DefaultAdditionalFormats),
+					gen.SetBundleKeyValueTarget(pkcs12DefaultKeyValue),
 				),
 			},
 			expError:   false,
-			expPatches: []any{},
-			expBundlePatch: &trustapi.BundleStatus{
+			expPatches: nil,
+			expBundlePatch: &trustmanagerapi.BundleStatus{
 				Conditions: []metav1.Condition{
 					{
-						Type:               trustapi.BundleConditionSynced,
+						Type:               trustmanagerapi.BundleConditionSynced,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "Synced",
@@ -679,7 +687,7 @@ func Test_Reconcile(t *testing.T) {
 						"target.p12": testEncodePKCS12(t, dummy.DefaultJoinedCerts()),
 					},
 					ptr.To(targetKey),
-					true, &pkcs12DefaultAdditionalFormatsOldPassword,
+					true, &pkcs12DefaultKeyValueOldPassword,
 				),
 				targetConfigMap(
 					"ns-1",
@@ -690,7 +698,7 @@ func Test_Reconcile(t *testing.T) {
 						"target.p12": testEncodePKCS12(t, dummy.DefaultJoinedCerts()),
 					},
 					ptr.To(targetKey),
-					true, &pkcs12DefaultAdditionalFormatsOldPassword,
+					true, &pkcs12DefaultKeyValueOldPassword,
 				),
 				targetConfigMap(
 					"ns-2",
@@ -701,13 +709,13 @@ func Test_Reconcile(t *testing.T) {
 						"target.p12": testEncodePKCS12(t, dummy.DefaultJoinedCerts()),
 					},
 					ptr.To(targetKey),
-					true, &pkcs12DefaultAdditionalFormats,
+					true, &pkcs12DefaultKeyValue,
 				),
 			},
 			existingSecrets: []client.Object{sourceSecret},
 			existingBundles: []client.Object{
 				gen.BundleFrom(baseBundle,
-					gen.SetBundleTargetAdditionalFormats(pkcs12DefaultAdditionalFormats),
+					gen.SetBundleKeyValueTarget(pkcs12DefaultKeyValue),
 				),
 			},
 			expError: false,
@@ -716,17 +724,17 @@ func Test_Reconcile(t *testing.T) {
 					targetKey: dummy.DefaultJoinedCerts(),
 				}, map[string][]byte{
 					"target.p12": testEncodePKCS12(t, dummy.DefaultJoinedCerts()),
-				}, ptr.To(targetKey), &pkcs12DefaultAdditionalFormats),
+				}, ptr.To(targetKey), &pkcs12DefaultKeyValue),
 				configMapPatch(baseBundle.Name, "ns-1", map[string]string{
 					targetKey: dummy.DefaultJoinedCerts(),
 				}, map[string][]byte{
 					"target.p12": testEncodePKCS12(t, dummy.DefaultJoinedCerts()),
-				}, ptr.To(targetKey), &pkcs12DefaultAdditionalFormats),
+				}, ptr.To(targetKey), &pkcs12DefaultKeyValue),
 			},
-			expBundlePatch: &trustapi.BundleStatus{
+			expBundlePatch: &trustmanagerapi.BundleStatus{
 				Conditions: []metav1.Condition{
 					{
-						Type:               trustapi.BundleConditionSynced,
+						Type:               trustmanagerapi.BundleConditionSynced,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "Synced",
@@ -742,7 +750,7 @@ func Test_Reconcile(t *testing.T) {
 			existingConfigMaps: []client.Object{sourceConfigMap},
 			existingSecrets:    []client.Object{sourceSecret},
 			existingBundles: []client.Object{gen.BundleFrom(baseBundle,
-				func(b *trustapi.Bundle) {
+				func(b *trustmanagerapi.ClusterBundle) {
 					// copy configmap target to secret target
 					b.Spec.Target.Secret = b.Spec.Target.ConfigMap
 				},
@@ -756,10 +764,10 @@ func Test_Reconcile(t *testing.T) {
 				secretPatch(baseBundle.Name, "ns-1", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, ptr.To(targetKey), nil),
 				secretPatch(baseBundle.Name, "ns-2", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, ptr.To(targetKey), nil),
 			},
-			expBundlePatch: &trustapi.BundleStatus{
+			expBundlePatch: &trustmanagerapi.BundleStatus{
 				Conditions: []metav1.Condition{
 					{
-						Type:               trustapi.BundleConditionSynced,
+						Type:               trustmanagerapi.BundleConditionSynced,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "Synced",
@@ -787,9 +795,9 @@ func Test_Reconcile(t *testing.T) {
 				configMapPatch(baseBundle.Name, "ns-1", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 				configMapPatch(baseBundle.Name, "ns-2", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 			},
-			expBundlePatch: &trustapi.BundleStatus{
+			expBundlePatch: &trustmanagerapi.BundleStatus{
 				Conditions: []metav1.Condition{{
-					Type:               trustapi.BundleConditionSynced,
+					Type:               trustmanagerapi.BundleConditionSynced,
 					Status:             metav1.ConditionTrue,
 					LastTransitionTime: fixedmetatime,
 					Reason:             "Synced",
@@ -825,9 +833,9 @@ func Test_Reconcile(t *testing.T) {
 				configMapPatch(baseBundle.Name, "random-namespace", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 				configMapPatch(baseBundle.Name, "another-random-namespace", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 			},
-			expBundlePatch: &trustapi.BundleStatus{
+			expBundlePatch: &trustmanagerapi.BundleStatus{
 				Conditions: []metav1.Condition{{
-					Type:               trustapi.BundleConditionSynced,
+					Type:               trustmanagerapi.BundleConditionSynced,
 					Status:             metav1.ConditionTrue,
 					LastTransitionTime: fixedmetatime,
 					Reason:             "Synced",
@@ -878,9 +886,9 @@ func Test_Reconcile(t *testing.T) {
 				configMapPatch(baseBundle.Name, "ns-1", map[string]string{}, nil, nil, nil),
 				configMapPatch(baseBundle.Name, "ns-2", map[string]string{}, nil, nil, nil),
 			},
-			expBundlePatch: &trustapi.BundleStatus{
+			expBundlePatch: &trustmanagerapi.BundleStatus{
 				Conditions: []metav1.Condition{{
-					Type:               trustapi.BundleConditionSynced,
+					Type:               trustmanagerapi.BundleConditionSynced,
 					Status:             metav1.ConditionTrue,
 					LastTransitionTime: fixedmetatime,
 					Reason:             "Synced",
@@ -924,10 +932,10 @@ func Test_Reconcile(t *testing.T) {
 			existingSecrets: []client.Object{sourceSecret},
 			existingBundles: []client.Object{
 				gen.BundleFrom(baseBundle,
-					gen.SetBundleStatus(trustapi.BundleStatus{
+					gen.SetBundleStatus(trustmanagerapi.BundleStatus{
 						Conditions: []metav1.Condition{
 							{
-								Type:               trustapi.BundleConditionSynced,
+								Type:               trustmanagerapi.BundleConditionSynced,
 								Status:             metav1.ConditionTrue,
 								LastTransitionTime: fixedmetatime,
 								Reason:             "Synced",
@@ -943,10 +951,10 @@ func Test_Reconcile(t *testing.T) {
 				configMapPatch(baseBundle.Name, "ns-1", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 				configMapPatch(baseBundle.Name, "ns-2", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 			},
-			expBundlePatch: &trustapi.BundleStatus{
+			expBundlePatch: &trustmanagerapi.BundleStatus{
 				Conditions: []metav1.Condition{
 					{
-						Type:               trustapi.BundleConditionSynced,
+						Type:               trustmanagerapi.BundleConditionSynced,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "Synced",
@@ -992,10 +1000,10 @@ func Test_Reconcile(t *testing.T) {
 			existingBundles: []client.Object{gen.BundleFrom(baseBundle)},
 			expError:        false,
 			expPatches:      nil,
-			expBundlePatch: &trustapi.BundleStatus{
+			expBundlePatch: &trustmanagerapi.BundleStatus{
 				Conditions: []metav1.Condition{
 					{
-						Type:               trustapi.BundleConditionSynced,
+						Type:               trustmanagerapi.BundleConditionSynced,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "Synced",
@@ -1040,10 +1048,10 @@ func Test_Reconcile(t *testing.T) {
 			existingSecrets: []client.Object{sourceSecret},
 			existingBundles: []client.Object{
 				gen.BundleFrom(baseBundle,
-					gen.SetBundleStatus(trustapi.BundleStatus{
+					gen.SetBundleStatus(trustmanagerapi.BundleStatus{
 						Conditions: []metav1.Condition{
 							{
-								Type:               trustapi.BundleConditionSynced,
+								Type:               trustmanagerapi.BundleConditionSynced,
 								Status:             metav1.ConditionTrue,
 								LastTransitionTime: fixedmetatime,
 								Reason:             "Synced",
@@ -1064,12 +1072,12 @@ func Test_Reconcile(t *testing.T) {
 			existingNamespaces: namespaces,
 			existingConfigMaps: []client.Object{sourceConfigMap},
 			existingSecrets:    []client.Object{sourceSecret},
-			existingBundles:    []client.Object{gen.BundleFrom(baseBundle, gen.AppendBundleUsesDefaultPackage())},
+			existingBundles:    []client.Object{gen.BundleFrom(baseBundle, gen.IncludeDefaultCAs())},
 			expError:           false,
 			expPatches:         nil,
-			expBundlePatch: &trustapi.BundleStatus{Conditions: []metav1.Condition{
+			expBundlePatch: &trustmanagerapi.BundleStatus{Conditions: []metav1.Condition{
 				{
-					Type:               trustapi.BundleConditionSynced,
+					Type:               trustmanagerapi.BundleConditionSynced,
 					Status:             metav1.ConditionFalse,
 					Reason:             "SourceNotFound",
 					Message:            `Bundle source was not found: no default package was specified when trust-manager was started; default CAs not available`,
@@ -1113,11 +1121,11 @@ func Test_Reconcile(t *testing.T) {
 			existingSecrets: []client.Object{sourceSecret},
 			existingBundles: []client.Object{
 				gen.BundleFrom(baseBundle,
-					gen.AppendBundleUsesDefaultPackage(),
-					gen.SetBundleStatus(trustapi.BundleStatus{
+					gen.IncludeDefaultCAs(),
+					gen.SetBundleStatus(trustmanagerapi.BundleStatus{
 						Conditions: []metav1.Condition{
 							{
-								Type:               trustapi.BundleConditionSynced,
+								Type:               trustmanagerapi.BundleConditionSynced,
 								Status:             metav1.ConditionTrue,
 								LastTransitionTime: fixedmetatime,
 								Reason:             "Synced",
@@ -1135,10 +1143,10 @@ func Test_Reconcile(t *testing.T) {
 				configMapPatch(baseBundle.Name, "ns-1", map[string]string{targetKey: dummy.JoinCerts(dummy.TestCertificate2, dummy.TestCertificate1, dummy.TestCertificate3, dummy.TestCertificate5)}, nil, ptr.To(targetKey), nil),
 				configMapPatch(baseBundle.Name, "ns-2", map[string]string{targetKey: dummy.JoinCerts(dummy.TestCertificate2, dummy.TestCertificate1, dummy.TestCertificate3, dummy.TestCertificate5)}, nil, ptr.To(targetKey), nil),
 			},
-			expBundlePatch: &trustapi.BundleStatus{
+			expBundlePatch: &trustmanagerapi.BundleStatus{
 				Conditions: []metav1.Condition{
 					{
-						Type:               trustapi.BundleConditionSynced,
+						Type:               trustmanagerapi.BundleConditionSynced,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "Synced",
@@ -1183,10 +1191,10 @@ func Test_Reconcile(t *testing.T) {
 			},
 			existingSecrets: []client.Object{sourceSecret},
 			existingBundles: []client.Object{gen.BundleFrom(baseBundle,
-				gen.SetBundleStatus(trustapi.BundleStatus{
+				gen.SetBundleStatus(trustmanagerapi.BundleStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:               trustapi.BundleConditionSynced,
+							Type:               trustmanagerapi.BundleConditionSynced,
 							Status:             metav1.ConditionTrue,
 							LastTransitionTime: fixedmetatime,
 							Reason:             "Synced",
@@ -1204,10 +1212,10 @@ func Test_Reconcile(t *testing.T) {
 				configMapPatch(baseBundle.Name, "ns-1", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 				configMapPatch(baseBundle.Name, "ns-2", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 			},
-			expBundlePatch: &trustapi.BundleStatus{
+			expBundlePatch: &trustmanagerapi.BundleStatus{
 				Conditions: []metav1.Condition{
 					{
-						Type:               trustapi.BundleConditionSynced,
+						Type:               trustmanagerapi.BundleConditionSynced,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "Synced",
@@ -1252,13 +1260,13 @@ func Test_Reconcile(t *testing.T) {
 			},
 			existingSecrets: []client.Object{sourceSecret},
 			existingBundles: []client.Object{gen.BundleFrom(baseBundle,
-				func(b *trustapi.Bundle) {
-					b.Spec.Target = trustapi.BundleTarget{}
+				func(b *trustmanagerapi.ClusterBundle) {
+					b.Spec.Target = trustmanagerapi.BundleTarget{}
 				},
-				gen.SetBundleStatus(trustapi.BundleStatus{
+				gen.SetBundleStatus(trustmanagerapi.BundleStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:               trustapi.BundleConditionSynced,
+							Type:               trustmanagerapi.BundleConditionSynced,
 							Status:             metav1.ConditionTrue,
 							LastTransitionTime: fixedmetatime,
 							Reason:             "Synced",
@@ -1276,10 +1284,10 @@ func Test_Reconcile(t *testing.T) {
 				configMapPatch(baseBundle.Name, "ns-1", nil, nil, nil, nil),
 				configMapPatch(baseBundle.Name, "ns-2", nil, nil, nil, nil),
 			},
-			expBundlePatch: &trustapi.BundleStatus{
+			expBundlePatch: &trustmanagerapi.BundleStatus{
 				Conditions: []metav1.Condition{
 					{
-						Type:               trustapi.BundleConditionSynced,
+						Type:               trustmanagerapi.BundleConditionSynced,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "Synced",
@@ -1324,16 +1332,16 @@ func Test_Reconcile(t *testing.T) {
 			},
 			existingSecrets: []client.Object{sourceSecret},
 			existingBundles: []client.Object{gen.BundleFrom(baseBundle,
-				func(b *trustapi.Bundle) {
+				func(b *trustmanagerapi.ClusterBundle) {
 					// swap target configmap for secret
 					keySelector := b.Spec.Target.ConfigMap
 					b.Spec.Target.ConfigMap = nil
 					b.Spec.Target.Secret = keySelector
 				},
-				gen.SetBundleStatus(trustapi.BundleStatus{
+				gen.SetBundleStatus(trustmanagerapi.BundleStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:               trustapi.BundleConditionSynced,
+							Type:               trustmanagerapi.BundleConditionSynced,
 							Status:             metav1.ConditionTrue,
 							LastTransitionTime: fixedmetatime,
 							Reason:             "Synced",
@@ -1354,10 +1362,10 @@ func Test_Reconcile(t *testing.T) {
 				configMapPatch(baseBundle.Name, "ns-1", nil, nil, nil, nil),
 				configMapPatch(baseBundle.Name, "ns-2", nil, nil, nil, nil),
 			},
-			expBundlePatch: &trustapi.BundleStatus{
+			expBundlePatch: &trustmanagerapi.BundleStatus{
 				Conditions: []metav1.Condition{
 					{
-						Type:               trustapi.BundleConditionSynced,
+						Type:               trustmanagerapi.BundleConditionSynced,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "Synced",
@@ -1375,14 +1383,14 @@ func Test_Reconcile(t *testing.T) {
 			existingConfigMaps:   []client.Object{sourceConfigMap},
 			existingSecrets:      []client.Object{sourceSecret},
 			existingBundles: []client.Object{gen.BundleFrom(baseBundle,
-				func(b *trustapi.Bundle) {
+				func(b *trustmanagerapi.ClusterBundle) {
 					// copy configmap target to secret target
 					b.Spec.Target.Secret = b.Spec.Target.ConfigMap
 				},
-				gen.SetBundleStatus(trustapi.BundleStatus{
+				gen.SetBundleStatus(trustmanagerapi.BundleStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:               trustapi.BundleConditionSynced,
+							Type:               trustmanagerapi.BundleConditionSynced,
 							Status:             metav1.ConditionTrue,
 							LastTransitionTime: fixedmetatime,
 							Reason:             "Synced",
@@ -1394,11 +1402,11 @@ func Test_Reconcile(t *testing.T) {
 			)},
 			configureDefaultPackage: true,
 			expError:                false,
-			expPatches:              []any{},
-			expBundlePatch: &trustapi.BundleStatus{
+			expPatches:              nil,
+			expBundlePatch: &trustmanagerapi.BundleStatus{
 				Conditions: []metav1.Condition{
 					{
-						Type:               trustapi.BundleConditionSynced,
+						Type:               trustmanagerapi.BundleConditionSynced,
 						Status:             metav1.ConditionFalse,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "SecretTargetsDisabled",
@@ -1426,10 +1434,10 @@ func Test_Reconcile(t *testing.T) {
 				},
 			},
 			existingSecrets: []client.Object{sourceSecret},
-			expBundlePatch: &trustapi.BundleStatus{
+			expBundlePatch: &trustmanagerapi.BundleStatus{
 				Conditions: []metav1.Condition{
 					{
-						Type:               trustapi.BundleConditionSynced,
+						Type:               trustmanagerapi.BundleConditionSynced,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "Synced",
@@ -1440,12 +1448,12 @@ func Test_Reconcile(t *testing.T) {
 			},
 			expEvent: `Normal Synced Successfully synced Bundle to all namespaces`,
 			existingBundles: []client.Object{gen.BundleFrom(baseBundle,
-				func(b *trustapi.Bundle) {
+				func(b *trustmanagerapi.ClusterBundle) {
 				},
-				gen.SetBundleStatus(trustapi.BundleStatus{
+				gen.SetBundleStatus(trustmanagerapi.BundleStatus{
 					Conditions: []metav1.Condition{
 						{
-							Type:               trustapi.BundleConditionSynced,
+							Type:               trustmanagerapi.BundleConditionSynced,
 							Status:             metav1.ConditionTrue,
 							LastTransitionTime: fixedmetatime,
 							Reason:             "Synced",
@@ -1481,7 +1489,7 @@ func Test_Reconcile(t *testing.T) {
 			existingConfigMaps: []client.Object{sourceConfigMap},
 			existingSecrets:    []client.Object{sourceSecret},
 			existingBundles: []client.Object{
-				gen.BundleFrom(baseBundle, func(b *trustapi.Bundle) {
+				gen.BundleFrom(baseBundle, func(b *trustmanagerapi.ClusterBundle) {
 					b.Spec.Target.Secret = nil
 					b.Spec.Target.NamespaceSelector = nil
 				}),
@@ -1492,10 +1500,10 @@ func Test_Reconcile(t *testing.T) {
 				configMapPatch(baseBundle.Name, "ns-1", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 				configMapPatch(baseBundle.Name, "ns-2", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 			},
-			expBundlePatch: &trustapi.BundleStatus{
+			expBundlePatch: &trustmanagerapi.BundleStatus{
 				Conditions: []metav1.Condition{
 					{
-						Type:               trustapi.BundleConditionSynced,
+						Type:               trustmanagerapi.BundleConditionSynced,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "Synced",
@@ -1533,7 +1541,7 @@ func Test_Reconcile(t *testing.T) {
 			existingConfigMaps: []client.Object{sourceConfigMap},
 			existingSecrets:    []client.Object{sourceSecret},
 			existingBundles: []client.Object{
-				gen.BundleFrom(baseBundle, func(b *trustapi.Bundle) {
+				gen.BundleFrom(baseBundle, func(b *trustmanagerapi.ClusterBundle) {
 					b.Spec.Target.Secret = nil
 					b.Spec.Target.NamespaceSelector = &metav1.LabelSelector{
 						MatchExpressions: []metav1.LabelSelectorRequirement{
@@ -1552,10 +1560,10 @@ func Test_Reconcile(t *testing.T) {
 				configMapPatch(baseBundle.Name, "ns-1", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 				configMapPatch(baseBundle.Name, "ns-2", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 			},
-			expBundlePatch: &trustapi.BundleStatus{
+			expBundlePatch: &trustmanagerapi.BundleStatus{
 				Conditions: []metav1.Condition{
 					{
-						Type:               trustapi.BundleConditionSynced,
+						Type:               trustmanagerapi.BundleConditionSynced,
 						Status:             metav1.ConditionTrue,
 						LastTransitionTime: fixedmetatime,
 						Reason:             "Synced",
@@ -1644,7 +1652,20 @@ func Test_Reconcile(t *testing.T) {
 			}
 			assert.Equal(t, tt.expEvent, event)
 
-			assert.ElementsMatch(t, tt.expPatches, resourcePatches, "unexpected objects patched")
+			diff := cmp.Diff(tt.expPatches, resourcePatches, cmpopts.SortSlices(func(x, y any) bool {
+				xj, err := json.Marshal(x)
+				if err != nil {
+					panic(err)
+				}
+				yj, err := json.Marshal(y)
+				if err != nil {
+					panic(err)
+				}
+				return bytes.Compare(xj, yj) < 0
+			}))
+			if diff != "" {
+				t.Fatalf("unexpected objects patched (-want +got):\n%s", diff)
+			}
 		})
 	}
 }

--- a/pkg/bundle/controller.go
+++ b/pkg/bundle/controller.go
@@ -38,7 +38,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	ctrlsource "sigs.k8s.io/controller-runtime/pkg/source"
 
-	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
+	trustmanagerapi "github.com/cert-manager/trust-manager/pkg/apis/trustmanager/v1alpha2"
 	"github.com/cert-manager/trust-manager/pkg/bundle/controller"
 	"github.com/cert-manager/trust-manager/pkg/bundle/internal/source"
 	"github.com/cert-manager/trust-manager/pkg/bundle/internal/target"
@@ -54,8 +54,8 @@ func CacheOpts(opts controller.Options) cache.Options {
 		ReaderFailOnMissingInformer: true,
 		DefaultNamespaces:           ctrCacheNamespaces,
 		ByObject: map[client.Object]cache.ByObject{
-			&trustapi.Bundle{}:  {},
-			&corev1.Namespace{}: {},
+			&trustmanagerapi.ClusterBundle{}: {},
+			&corev1.Namespace{}:              {},
 			&corev1.ConfigMap{}: {
 				// Only cache full ConfigMaps in the "watched" namespace.
 				// Target ConfigMaps have a dedicated cache
@@ -80,7 +80,7 @@ func SetupWithManager(
 	mgr ctrl.Manager,
 	opts controller.Options,
 ) error {
-	targetRequirement, err := labels.NewRequirement(trustapi.BundleLabelKey, selection.Exists, nil)
+	targetRequirement, err := labels.NewRequirement(trustmanagerapi.BundleLabelKey, selection.Exists, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create target label requirement: %w", err)
 	}
@@ -112,6 +112,10 @@ func SetupWithManager(
 	// Add Bundle controller to manager.
 	if err := addBundleController(ctx, mgr, opts, targetCache); err != nil {
 		return fmt.Errorf("failed to register Bundle controller: %w", err)
+	}
+
+	if err := (&controller.BundleReconciler{Client: mgr.GetClient()}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("failed to register Bundle migration controller: %w", err)
 	}
 
 	return nil
@@ -174,7 +178,7 @@ func addBundleController(
 				handler.TypedEnqueueRequestForOwner[*metav1.PartialObjectMetadata](
 					mgr.GetScheme(),
 					mgr.GetRESTMapper(),
-					&trustapi.Bundle{},
+					&trustmanagerapi.ClusterBundle{},
 					handler.OnlyControllerOwner(),
 				),
 			),
@@ -190,7 +194,7 @@ func addBundleController(
 				handler.TypedEnqueueRequestForOwner[*metav1.PartialObjectMetadata](
 					mgr.GetScheme(),
 					mgr.GetRESTMapper(),
-					&trustapi.Bundle{},
+					&trustmanagerapi.ClusterBundle{},
 					handler.OnlyControllerOwner(),
 				),
 			),
@@ -200,12 +204,12 @@ func addBundleController(
 	////// Sources //////
 
 	// Reconcile trust.cert-manager.io Bundles
-	controller.Watches(&trustapi.Bundle{}, &handler.EnqueueRequestForObject{}).
+	controller.Watches(&trustmanagerapi.ClusterBundle{}, &handler.EnqueueRequestForObject{}).
 
 		// Watch all Namespaces. Cache whole Namespaces to include Phase Status.
 		// Reconcile all Bundles on a Namespace change.
 		Watches(&corev1.Namespace{}, b.enqueueRequestsFromBundleFunc(
-			func(obj client.Object, bundle trustapi.Bundle) bool {
+			func(obj client.Object, bundle trustmanagerapi.ClusterBundle) bool {
 				namespaceSelector, err := b.bundleTargetNamespaceSelector(bundle.Spec.Target)
 				if err != nil {
 					// We have an invalid selector, so we can skip this Bundle.
@@ -218,9 +222,9 @@ func addBundleController(
 		// Watch ConfigMaps in trust Namespace.
 		// Reconcile Bundles who reference a modified source ConfigMap.
 		Watches(&corev1.ConfigMap{}, b.enqueueRequestsFromBundleFunc(
-			func(obj client.Object, bundle trustapi.Bundle) bool {
-				for _, s := range bundle.Spec.Sources {
-					if sourceSelectsObject(s.ConfigMap, obj) {
+			func(obj client.Object, bundle trustmanagerapi.ClusterBundle) bool {
+				for _, s := range bundle.Spec.SourceRefs {
+					if sourceSelectsObject(s, trustmanagerapi.ConfigMapKind, obj) {
 						return true
 					}
 				}
@@ -230,9 +234,9 @@ func addBundleController(
 		// Watch Secrets in trust Namespace.
 		// Reconcile Bundles who reference a modified source Secret.
 		Watches(&corev1.Secret{}, b.enqueueRequestsFromBundleFunc(
-			func(obj client.Object, bundle trustapi.Bundle) bool {
-				for _, s := range bundle.Spec.Sources {
-					if sourceSelectsObject(s.Secret, obj) {
+			func(obj client.Object, bundle trustmanagerapi.ClusterBundle) bool {
+				for _, s := range bundle.Spec.SourceRefs {
+					if sourceSelectsObject(s, trustmanagerapi.SecretKind, obj) {
 						return true
 					}
 				}
@@ -250,7 +254,7 @@ func addBundleController(
 // enqueueRequestsFromBundleFunc returns an event handler for watching Bundle dependants.
 // It will invoke the provided function for all Bundles and trigger a Bundle reconcile if the
 // functions returns true.
-func (b *bundle) enqueueRequestsFromBundleFunc(fn func(obj client.Object, bundle trustapi.Bundle) bool) handler.EventHandler {
+func (b *bundle) enqueueRequestsFromBundleFunc(fn func(obj client.Object, bundle trustmanagerapi.ClusterBundle) bool) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(
 		func(ctx context.Context, obj client.Object) []reconcile.Request {
 			// If an error happens here, and we do nothing, we run the risk of
@@ -273,8 +277,8 @@ func (b *bundle) enqueueRequestsFromBundleFunc(fn func(obj client.Object, bundle
 
 // mustBundleList will return a BundleList of all Bundles in the cluster. If an
 // error occurs, will exit error the program.
-func (b *bundle) mustBundleList(ctx context.Context) *trustapi.BundleList {
-	var bundleList trustapi.BundleList
+func (b *bundle) mustBundleList(ctx context.Context) *trustmanagerapi.ClusterBundleList {
+	var bundleList trustmanagerapi.ClusterBundleList
 	if err := b.client.List(ctx, &bundleList); err != nil {
 		logf.FromContext(ctx).Error(err, "failed to list all Bundles, exiting error")
 		os.Exit(-1)
@@ -291,16 +295,16 @@ func inNamespacePredicate(namespace string) predicate.Predicate {
 }
 
 // sourceSelectsObject returns true if source selector selects obj and false otherwise
-func sourceSelectsObject(selector *trustapi.SourceObjectKeySelector, obj client.Object) bool {
-	if selector == nil {
+func sourceSelectsObject(source trustmanagerapi.BundleSourceRef, kind string, obj client.Object) bool {
+	if source.Kind != kind {
 		return false
 	}
 
-	if labelsMatchSelector(obj.GetLabels(), selector.Selector) {
+	if labelsMatchSelector(obj.GetLabels(), source.Selector) {
 		return true
 	}
 
-	if selector.Name == obj.GetName() {
+	if source.Name == obj.GetName() {
 		return true
 	}
 

--- a/pkg/bundle/controller.go
+++ b/pkg/bundle/controller.go
@@ -37,7 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	ctrlsource "sigs.k8s.io/controller-runtime/pkg/source"
 
-	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
+	trustmanagerapi "github.com/cert-manager/trust-manager/pkg/apis/trustmanager/v1alpha2"
 	"github.com/cert-manager/trust-manager/pkg/bundle/controller"
 	"github.com/cert-manager/trust-manager/pkg/bundle/internal/source"
 	"github.com/cert-manager/trust-manager/pkg/bundle/internal/target"
@@ -53,8 +53,8 @@ func CacheOpts(opts controller.Options) cache.Options {
 		ReaderFailOnMissingInformer: true,
 		DefaultNamespaces:           ctrCacheNamespaces,
 		ByObject: map[client.Object]cache.ByObject{
-			&trustapi.Bundle{}:  {},
-			&corev1.Namespace{}: {},
+			&trustmanagerapi.ClusterBundle{}: {},
+			&corev1.Namespace{}:              {},
 			&corev1.ConfigMap{}: {
 				// Only cache full ConfigMaps in the "watched" namespace.
 				// Target ConfigMaps have a dedicated cache
@@ -79,7 +79,7 @@ func SetupWithManager(
 	mgr ctrl.Manager,
 	opts controller.Options,
 ) error {
-	targetRequirement, err := labels.NewRequirement(trustapi.BundleLabelKey, selection.Exists, nil)
+	targetRequirement, err := labels.NewRequirement(trustmanagerapi.BundleLabelKey, selection.Exists, nil)
 	if err != nil {
 		return fmt.Errorf("failed to create target label requirement: %w", err)
 	}
@@ -111,6 +111,10 @@ func SetupWithManager(
 	// Add Bundle controller to manager.
 	if err := addBundleController(ctx, mgr, opts, targetCache); err != nil {
 		return fmt.Errorf("failed to register Bundle controller: %w", err)
+	}
+
+	if err := (&controller.BundleReconciler{Client: mgr.GetClient()}).SetupWithManager(mgr); err != nil {
+		return fmt.Errorf("failed to register Bundle migration controller: %w", err)
 	}
 
 	return nil
@@ -173,7 +177,7 @@ func addBundleController(
 				handler.TypedEnqueueRequestForOwner[*metav1.PartialObjectMetadata](
 					mgr.GetScheme(),
 					mgr.GetRESTMapper(),
-					&trustapi.Bundle{},
+					&trustmanagerapi.ClusterBundle{},
 					handler.OnlyControllerOwner(),
 				),
 			),
@@ -189,7 +193,7 @@ func addBundleController(
 				handler.TypedEnqueueRequestForOwner[*metav1.PartialObjectMetadata](
 					mgr.GetScheme(),
 					mgr.GetRESTMapper(),
-					&trustapi.Bundle{},
+					&trustmanagerapi.ClusterBundle{},
 					handler.OnlyControllerOwner(),
 				),
 			),
@@ -199,12 +203,12 @@ func addBundleController(
 	////// Sources //////
 
 	// Reconcile trust.cert-manager.io Bundles
-	controller.Watches(&trustapi.Bundle{}, &handler.EnqueueRequestForObject{}).
+	controller.Watches(&trustmanagerapi.ClusterBundle{}, &handler.EnqueueRequestForObject{}).
 
 		// Watch all Namespaces. Cache whole Namespaces to include Phase Status.
 		// Reconcile all Bundles on a Namespace change.
 		Watches(&corev1.Namespace{}, b.enqueueRequestsFromBundleFunc(
-			func(obj client.Object, bundle trustapi.Bundle) bool {
+			func(obj client.Object, bundle trustmanagerapi.ClusterBundle) bool {
 				namespaceSelector, err := b.bundleTargetNamespaceSelector(bundle.Spec.Target)
 				if err != nil {
 					// We have an invalid selector, so we can skip this Bundle.
@@ -217,9 +221,9 @@ func addBundleController(
 		// Watch ConfigMaps in trust Namespace.
 		// Reconcile Bundles who reference a modified source ConfigMap.
 		Watches(&corev1.ConfigMap{}, b.enqueueRequestsFromBundleFunc(
-			func(obj client.Object, bundle trustapi.Bundle) bool {
-				for _, s := range bundle.Spec.Sources {
-					if sourceSelectsObject(s.ConfigMap, obj) {
+			func(obj client.Object, bundle trustmanagerapi.ClusterBundle) bool {
+				for _, s := range bundle.Spec.SourceRefs {
+					if sourceSelectsObject(s, trustmanagerapi.ConfigMapKind, obj) {
 						return true
 					}
 				}
@@ -229,9 +233,9 @@ func addBundleController(
 		// Watch Secrets in trust Namespace.
 		// Reconcile Bundles who reference a modified source Secret.
 		Watches(&corev1.Secret{}, b.enqueueRequestsFromBundleFunc(
-			func(obj client.Object, bundle trustapi.Bundle) bool {
-				for _, s := range bundle.Spec.Sources {
-					if sourceSelectsObject(s.Secret, obj) {
+			func(obj client.Object, bundle trustmanagerapi.ClusterBundle) bool {
+				for _, s := range bundle.Spec.SourceRefs {
+					if sourceSelectsObject(s, trustmanagerapi.SecretKind, obj) {
 						return true
 					}
 				}
@@ -249,7 +253,7 @@ func addBundleController(
 // enqueueRequestsFromBundleFunc returns an event handler for watching Bundle dependants.
 // It will invoke the provided function for all Bundles and trigger a Bundle reconcile if the
 // function returns true.
-func (b *bundle) enqueueRequestsFromBundleFunc(fn func(obj client.Object, bundle trustapi.Bundle) bool) handler.EventHandler {
+func (b *bundle) enqueueRequestsFromBundleFunc(fn func(obj client.Object, bundle trustmanagerapi.ClusterBundle) bool) handler.EventHandler {
 	return handler.EnqueueRequestsFromMapFunc(
 		func(ctx context.Context, obj client.Object) []reconcile.Request {
 			// EnqueueRequestsFromMapFunc cannot return an error. If listing Bundles fails,
@@ -273,8 +277,8 @@ func (b *bundle) enqueueRequestsFromBundleFunc(fn func(obj client.Object, bundle
 // mustBundleList returns a BundleList of all Bundles in the cluster.
 // If an error occurs, the program will panic to avoid silently dropping
 // an event that could leave Bundles out of sync with their target resources.
-func (b *bundle) mustBundleList(ctx context.Context) *trustapi.BundleList {
-	var bundleList trustapi.BundleList
+func (b *bundle) mustBundleList(ctx context.Context) *trustmanagerapi.ClusterBundleList {
+	var bundleList trustmanagerapi.ClusterBundleList
 	if err := b.client.List(ctx, &bundleList); err != nil {
 		logf.FromContext(ctx).Error(err, "failed to list all Bundles, panicking")
 		panic(err)
@@ -291,16 +295,16 @@ func inNamespacePredicate(namespace string) predicate.Predicate {
 }
 
 // sourceSelectsObject returns true if source selector selects obj and false otherwise
-func sourceSelectsObject(selector *trustapi.SourceObjectKeySelector, obj client.Object) bool {
-	if selector == nil {
+func sourceSelectsObject(source trustmanagerapi.BundleSourceRef, kind string, obj client.Object) bool {
+	if source.Kind != kind {
 		return false
 	}
 
-	if labelsMatchSelector(obj.GetLabels(), selector.Selector) {
+	if labelsMatchSelector(obj.GetLabels(), source.Selector) {
 		return true
 	}
 
-	if selector.Name == obj.GetName() {
+	if source.Name == obj.GetName() {
 		return true
 	}
 

--- a/pkg/bundle/controller/bundle_controller.go
+++ b/pkg/bundle/controller/bundle_controller.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:staticcheck // SA1019 staticcheck will warn about our use of the deprecated Bundle resource, but we still need to reconcile it so people can migrate
 package controller
 
 import (

--- a/pkg/bundle/internal/source/source.go
+++ b/pkg/bundle/internal/source/source.go
@@ -19,15 +19,16 @@ package source
 import (
 	"context"
 	"fmt"
+	"maps"
+	"path"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
-	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
+	trustmanagerapi "github.com/cert-manager/trust-manager/pkg/apis/trustmanager/v1alpha2"
 	"github.com/cert-manager/trust-manager/pkg/bundle/controller"
 	"github.com/cert-manager/trust-manager/pkg/fspkg"
 	"github.com/cert-manager/trust-manager/pkg/util"
@@ -60,7 +61,7 @@ type BundleBuilder struct {
 
 // BuildBundle retrieves and concatenates all source bundle data for this Bundle object.
 // Each source data is validated and pruned to ensure that all certificates within are valid.
-func (b *BundleBuilder) BuildBundle(ctx context.Context, sources []trustapi.BundleSource) (BundleData, error) {
+func (b *BundleBuilder) BuildBundle(ctx context.Context, spec trustmanagerapi.BundleSpec) (BundleData, error) {
 	var resolvedBundle BundleData
 	resolvedBundle.CertPool = util.NewCertPool(
 		util.WithFilteredExpiredCerts(b.FilterExpiredCerts),
@@ -68,32 +69,38 @@ func (b *BundleBuilder) BuildBundle(ctx context.Context, sources []trustapi.Bund
 		util.WithLogger(logf.FromContext(ctx).WithName("cert-pool")),
 	)
 
-	for _, source := range sources {
+	for _, source := range spec.SourceRefs {
 		var certSource bundleSource
 
-		switch {
-		case source.ConfigMap != nil:
-			certSource = &configMapBundleSource{b.Reader, b.Namespace, source.ConfigMap}
+		switch source.Kind {
+		case trustmanagerapi.ConfigMapKind:
+			certSource = &configMapBundleSource{b.Reader, b.Namespace, source}
 
-		case source.Secret != nil:
-			certSource = &secretBundleSource{b.Reader, b.Namespace, source.Secret}
+		case trustmanagerapi.SecretKind:
+			certSource = &secretBundleSource{b.Reader, b.Namespace, source}
 
-		case source.InLine != "":
-			certSource = &inlineBundleSource{source.InLine}
-
-		case source.UseDefaultCAs != nil:
-			if !*source.UseDefaultCAs {
-				continue
-			}
-			if b.DefaultPackage == nil {
-				return BundleData{}, NotFoundError{fmt.Errorf("no default package was specified when trust-manager was started; default CAs not available")}
-			}
-			certSource = &defaultCAsBundleSource{b.DefaultPackage.Bundle}
-			resolvedBundle.DefaultCAPackageStringID = b.DefaultPackage.StringID()
 		default:
-			panic(fmt.Sprintf("don't know how to process source: %+v", source))
+			panic(fmt.Sprintf("don't know how to process source of kind: %q", source.Kind))
 		}
 
+		if err := certSource.addToCertPool(ctx, resolvedBundle.CertPool); err != nil {
+			return BundleData{}, err
+		}
+	}
+
+	if spec.InLineCAs != "" {
+		certSource := &inlineBundleSource{spec.InLineCAs}
+		if err := certSource.addToCertPool(ctx, resolvedBundle.CertPool); err != nil {
+			return BundleData{}, err
+		}
+	}
+
+	if spec.DefaultCAs.Provider == trustmanagerapi.DefaultCAsProviderSystem {
+		if b.DefaultPackage == nil {
+			return BundleData{}, NotFoundError{fmt.Errorf("no default package was specified when trust-manager was started; default CAs not available")}
+		}
+		certSource := &defaultCAsBundleSource{b.DefaultPackage.Bundle}
+		resolvedBundle.DefaultCAPackageStringID = b.DefaultPackage.StringID()
 		if err := certSource.addToCertPool(ctx, resolvedBundle.CertPool); err != nil {
 			return BundleData{}, err
 		}
@@ -136,7 +143,7 @@ func (s defaultCAsBundleSource) addToCertPool(_ context.Context, pool *util.Cert
 type configMapBundleSource struct {
 	client.Reader
 	Namespace string
-	ref       *trustapi.SourceObjectKeySelector
+	ref       trustmanagerapi.BundleSourceRef
 }
 
 func (b configMapBundleSource) addToCertPool(ctx context.Context, pool *util.CertPool) error {
@@ -175,37 +182,29 @@ func (b configMapBundleSource) addToCertPool(ctx context.Context, pool *util.Cer
 
 		configMaps = cml.Items
 	}
-
 	for _, cm := range configMaps {
-		if len(b.ref.Key) > 0 {
-			// ConfigMaps may store values under either the string Data field or
-			// the byte BinaryData field. Prefer Data, but fall back to
-			// BinaryData so base64-encoded CAs are also resolvable.
-			data, ok := cm.Data[b.ref.Key]
-			binaryData, binaryOk := cm.BinaryData[b.ref.Key]
-			switch {
-			case ok:
-				if err := pool.AddCertsFromPEM([]byte(data)); err != nil {
-					return InvalidPEMError{fmt.Errorf("invalid PEM data in ConfigMap %s/%s at key %q: %w", cm.Namespace, cm.Name, b.ref.Key, err)}
-				}
-			case binaryOk:
-				if err := pool.AddCertsFromPEM(binaryData); err != nil {
-					return InvalidPEMError{fmt.Errorf("invalid PEM data in ConfigMap %s/%s at key %q: %w", cm.Namespace, cm.Name, b.ref.Key, err)}
-				}
-			default:
-				return NotFoundError{fmt.Errorf("no data found in ConfigMap %s/%s at key %q", cm.Namespace, cm.Name, b.ref.Key)}
+		data := make(map[string][]byte, len(cm.Data)+len(cm.BinaryData))
+		maps.Copy(data, cm.BinaryData)
+		for k, v := range cm.Data {
+			data[k] = []byte(v)
+		}
+
+		found := false
+		for k, v := range data {
+			ok, err := path.Match(b.ref.Key, k)
+			if err != nil {
+				return fmt.Errorf("failed to match key %q in ConfigMap %s/%s: %w", b.ref.Key, cm.Namespace, cm.Name, err)
 			}
-		} else if ptr.Deref(b.ref.IncludeAllKeys, false) {
-			for key, data := range cm.Data {
-				if err := pool.AddCertsFromPEM([]byte(data)); err != nil {
-					return InvalidPEMError{fmt.Errorf("invalid PEM data in ConfigMap %s/%s at key %q: %w", cm.Namespace, cm.Name, key, err)}
+			if ok {
+				if err := pool.AddCertsFromPEM(v); err != nil {
+					return InvalidPEMError{fmt.Errorf("invalid PEM data in ConfigMap %s/%s at key %q: %w", cm.Namespace, cm.Name, k, err)}
 				}
+				found = true
 			}
-			for key, data := range cm.BinaryData {
-				if err := pool.AddCertsFromPEM(data); err != nil {
-					return InvalidPEMError{fmt.Errorf("invalid PEM data in ConfigMap %s/%s at key %q: %w", cm.Namespace, cm.Name, key, err)}
-				}
-			}
+		}
+
+		if !found {
+			return NotFoundError{fmt.Errorf("no data found in ConfigMap %s/%s at key %q", cm.Namespace, cm.Name, b.ref.Key)}
 		}
 	}
 	return nil
@@ -214,7 +213,7 @@ func (b configMapBundleSource) addToCertPool(ctx context.Context, pool *util.Cer
 type secretBundleSource struct {
 	client.Reader
 	Namespace string
-	ref       *trustapi.SourceObjectKeySelector
+	ref       trustmanagerapi.BundleSourceRef
 }
 
 func (b secretBundleSource) addToCertPool(ctx context.Context, pool *util.CertPool) error {
@@ -255,25 +254,33 @@ func (b secretBundleSource) addToCertPool(ctx context.Context, pool *util.CertPo
 	}
 
 	for _, secret := range secrets {
-		if len(b.ref.Key) > 0 {
-			data, ok := secret.Data[b.ref.Key]
-			if !ok {
-				return NotFoundError{fmt.Errorf("no data found in Secret %s/%s at key %q", secret.Namespace, secret.Name, b.ref.Key)}
+		// This is done to prevent mistakes. TLS Secrets should never include keys
+		// matching the private-key entry, including via wildcard patterns.
+		if secret.Type == corev1.SecretTypeTLS {
+			matchesPrivateKey, err := path.Match(b.ref.Key, corev1.TLSPrivateKeyKey)
+			if err != nil {
+				return fmt.Errorf("failed to match key %q against TLS private key for Secret %s/%s: %w", b.ref.Key, secret.Namespace, secret.Name, err)
 			}
-			if err := pool.AddCertsFromPEM(data); err != nil {
-				return InvalidPEMError{fmt.Errorf("invalid PEM data in Secret %s/%s at key %q: %w", secret.Namespace, secret.Name, b.ref.Key, err)}
+			if matchesPrivateKey {
+				return InvalidSecretError{fmt.Errorf("including keys matching %q is not supported for TLS Secrets such as %s/%s", corev1.TLSPrivateKeyKey, secret.Namespace, secret.Name)}
 			}
-		} else if ptr.Deref(b.ref.IncludeAllKeys, false) {
-			// This is done to prevent mistakes. All keys should never be included for a TLS secret, since that would include the private key.
-			if secret.Type == corev1.SecretTypeTLS {
-				return InvalidSecretError{fmt.Errorf("includeAllKeys is not supported for TLS Secrets such as %s/%s", secret.Namespace, secret.Name)}
+		}
+		found := false
+		for k, v := range secret.Data {
+			ok, err := path.Match(b.ref.Key, k)
+			if err != nil {
+				return fmt.Errorf("failed to match key %q in Secret %s/%s: %w", b.ref.Key, secret.Namespace, secret.Name, err)
 			}
-
-			for key, data := range secret.Data {
-				if err := pool.AddCertsFromPEM(data); err != nil {
-					return InvalidPEMError{fmt.Errorf("invalid PEM data in Secret %s/%s at key %q: %w", secret.Namespace, secret.Name, key, err)}
+			if ok {
+				if err := pool.AddCertsFromPEM(v); err != nil {
+					return InvalidPEMError{fmt.Errorf("invalid PEM data in Secret %s/%s at key %q: %w", secret.Namespace, secret.Name, k, err)}
 				}
+				found = true
 			}
+		}
+
+		if !found {
+			return NotFoundError{fmt.Errorf("no data found in Secret %s/%s at key %q", secret.Namespace, secret.Name, b.ref.Key)}
 		}
 	}
 	return nil

--- a/pkg/bundle/internal/source/source_test.go
+++ b/pkg/bundle/internal/source/source_test.go
@@ -27,7 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
-	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
+	trustmanagerapi "github.com/cert-manager/trust-manager/pkg/apis/trustmanager/v1alpha2"
 	"github.com/cert-manager/trust-manager/pkg/bundle/controller"
 	"github.com/cert-manager/trust-manager/pkg/fspkg"
 	"github.com/cert-manager/trust-manager/pkg/util"
@@ -37,7 +37,9 @@ import (
 
 func Test_BuildBundle(t *testing.T) {
 	tests := map[string]struct {
-		sources                     []trustapi.BundleSource
+		sources                     []trustmanagerapi.BundleSourceRef
+		defaultCAs                  trustmanagerapi.DefaultCAsSource
+		inLineCAs                   string
 		filterExpired               bool
 		objects                     []runtime.Object
 		expData                     string
@@ -50,33 +52,31 @@ func Test_BuildBundle(t *testing.T) {
 			expNotFoundError: true,
 		},
 		"if single InLine source defined with newlines, should trim and return": {
-			sources: []trustapi.BundleSource{
-				{InLine: dummy.TestCertificate1 + "\n" + dummy.TestCertificate2 + "\n"},
-			},
-			expData: dummy.JoinCerts(dummy.TestCertificate2, dummy.TestCertificate1),
+			inLineCAs: dummy.TestCertificate1 + "\n" + dummy.TestCertificate2 + "\n",
+			expData:   dummy.JoinCerts(dummy.TestCertificate2, dummy.TestCertificate1),
 		},
 		"if single DefaultPackage source defined, should return": {
-			sources: []trustapi.BundleSource{{UseDefaultCAs: new(true)}},
-			expData: dummy.JoinCerts(dummy.TestCertificate5),
+			defaultCAs: trustmanagerapi.DefaultCAsSource{Provider: trustmanagerapi.DefaultCAsProviderSystem},
+			expData:    dummy.JoinCerts(dummy.TestCertificate5),
 		},
 		"if single ConfigMap source which doesn't exist, return NotFoundError": {
-			sources: []trustapi.BundleSource{
-				{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "configmap", Key: "key"}},
+			sources: []trustmanagerapi.BundleSourceRef{
+				{SourceReference: trustmanagerapi.SourceReference{Name: "configmap", Kind: trustmanagerapi.ConfigMapKind}, Key: "key"},
 			},
 			expError:         true,
 			expNotFoundError: true,
 		},
 		"if single ConfigMap source whose key doesn't exist, return NotFoundError": {
-			sources: []trustapi.BundleSource{
-				{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "configmap", Key: "key"}},
+			sources: []trustmanagerapi.BundleSourceRef{
+				{SourceReference: trustmanagerapi.SourceReference{Name: "configmap", Kind: trustmanagerapi.ConfigMapKind}, Key: "key"},
 			},
 			objects:          []runtime.Object{&corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Name: "configmap"}}},
 			expError:         true,
 			expNotFoundError: true,
 		},
 		"if single ConfigMap source referencing single key, return data": {
-			sources: []trustapi.BundleSource{
-				{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "configmap", Key: "key"}},
+			sources: []trustmanagerapi.BundleSourceRef{
+				{SourceReference: trustmanagerapi.SourceReference{Name: "configmap", Kind: trustmanagerapi.ConfigMapKind}, Key: "key"},
 			},
 			objects: []runtime.Object{&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Name: "configmap"},
@@ -85,8 +85,8 @@ func Test_BuildBundle(t *testing.T) {
 			expData: dummy.JoinCerts(dummy.TestCertificate2, dummy.TestCertificate1),
 		},
 		"if single ConfigMap source referencing single key stored in binaryData, return data": {
-			sources: []trustapi.BundleSource{
-				{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "configmap", Key: "key"}},
+			sources: []trustmanagerapi.BundleSourceRef{
+				{SourceReference: trustmanagerapi.SourceReference{Name: "configmap", Kind: trustmanagerapi.ConfigMapKind}, Key: "key"},
 			},
 			objects: []runtime.Object{&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Name: "configmap"},
@@ -95,8 +95,8 @@ func Test_BuildBundle(t *testing.T) {
 			expData: dummy.JoinCerts(dummy.TestCertificate2, dummy.TestCertificate1),
 		},
 		"if single ConfigMap source with key in both data and binaryData, data takes precedence": {
-			sources: []trustapi.BundleSource{
-				{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "configmap", Key: "key"}},
+			sources: []trustmanagerapi.BundleSourceRef{
+				{SourceReference: trustmanagerapi.SourceReference{Name: "configmap", Kind: trustmanagerapi.ConfigMapKind}, Key: "key"},
 			},
 			objects: []runtime.Object{&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Name: "configmap"},
@@ -106,8 +106,8 @@ func Test_BuildBundle(t *testing.T) {
 			expData: dummy.JoinCerts(dummy.TestCertificate1),
 		},
 		"if single ConfigMap source whose key is absent from both data and binaryData, return NotFoundError": {
-			sources: []trustapi.BundleSource{
-				{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "configmap", Key: "key"}},
+			sources: []trustmanagerapi.BundleSourceRef{
+				{SourceReference: trustmanagerapi.SourceReference{Name: "configmap", Kind: trustmanagerapi.ConfigMapKind}, Key: "key"},
 			},
 			objects: []runtime.Object{&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Name: "configmap"},
@@ -118,8 +118,8 @@ func Test_BuildBundle(t *testing.T) {
 			expNotFoundError: true,
 		},
 		"if single ConfigMap source with invalid PEM in binaryData, return error": {
-			sources: []trustapi.BundleSource{
-				{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "configmap", Key: "key"}},
+			sources: []trustmanagerapi.BundleSourceRef{
+				{SourceReference: trustmanagerapi.SourceReference{Name: "configmap", Kind: trustmanagerapi.ConfigMapKind}, Key: "key"},
 			},
 			objects: []runtime.Object{&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Name: "configmap"},
@@ -130,8 +130,8 @@ func Test_BuildBundle(t *testing.T) {
 			expError: true,
 		},
 		"if single ConfigMap source including all keys, return data": {
-			sources: []trustapi.BundleSource{
-				{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "configmap", IncludeAllKeys: new(true)}},
+			sources: []trustmanagerapi.BundleSourceRef{
+				{SourceReference: trustmanagerapi.SourceReference{Name: "configmap", Kind: trustmanagerapi.ConfigMapKind}, Key: "*"},
 			},
 			objects: []runtime.Object{&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Name: "configmap"},
@@ -140,8 +140,8 @@ func Test_BuildBundle(t *testing.T) {
 			expData: dummy.JoinCerts(dummy.TestCertificate2, dummy.TestCertificate1, dummy.TestCertificate3),
 		},
 		"if single ConfigMap source including all keys across data and binaryData, return data": {
-			sources: []trustapi.BundleSource{
-				{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "configmap", IncludeAllKeys: new(true)}},
+			sources: []trustmanagerapi.BundleSourceRef{
+				{SourceReference: trustmanagerapi.SourceReference{Name: "configmap", Kind: trustmanagerapi.ConfigMapKind}, Key: "*"},
 			},
 			objects: []runtime.Object{&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Name: "configmap"},
@@ -152,8 +152,8 @@ func Test_BuildBundle(t *testing.T) {
 		},
 		"if single ConfigMap source, return data even when order changes": {
 			// Test uses the same data as the previous one but with different order
-			sources: []trustapi.BundleSource{
-				{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "configmap", Key: "key"}},
+			sources: []trustmanagerapi.BundleSourceRef{
+				{SourceReference: trustmanagerapi.SourceReference{Name: "configmap", Kind: trustmanagerapi.ConfigMapKind}, Key: "key"},
 			},
 			objects: []runtime.Object{&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Name: "configmap"},
@@ -162,16 +162,16 @@ func Test_BuildBundle(t *testing.T) {
 			expData: dummy.JoinCerts(dummy.TestCertificate2, dummy.TestCertificate1),
 		},
 		"if selects no ConfigMap sources, should return NotFoundError": {
-			sources: []trustapi.BundleSource{
-				{ConfigMap: &trustapi.SourceObjectKeySelector{Key: "key", Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"selects-nothing": "true"}}}},
+			sources: []trustmanagerapi.BundleSourceRef{
+				{Key: "key", SourceReference: trustmanagerapi.SourceReference{Name: "configmap", Kind: trustmanagerapi.ConfigMapKind, Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"selects-nothing": "true"}}}},
 			},
 			expError:         true,
 			expNotFoundError: true,
 		},
 		"if selects at least one ConfigMap source, return data": {
-			sources: []trustapi.BundleSource{
-				{ConfigMap: &trustapi.SourceObjectKeySelector{Key: "key", Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"trust-bundle.certs": "includes"}}}},
-				{ConfigMap: &trustapi.SourceObjectKeySelector{Key: "key", Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"selects-nothing": "true"}}}},
+			sources: []trustmanagerapi.BundleSourceRef{
+				{Key: "key", SourceReference: trustmanagerapi.SourceReference{Name: "configmap", Kind: trustmanagerapi.ConfigMapKind, Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"trust-bundle.certs": "includes"}}}},
+				{Key: "key", SourceReference: trustmanagerapi.SourceReference{Name: "configmap", Kind: trustmanagerapi.ConfigMapKind, Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"selects-nothing": "true"}}}},
 			},
 			objects: []runtime.Object{&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Name: "configmap", Labels: map[string]string{"trust-bundle.certs": "includes"}},
@@ -180,8 +180,8 @@ func Test_BuildBundle(t *testing.T) {
 			expData: dummy.JoinCerts(dummy.TestCertificate2, dummy.TestCertificate1),
 		},
 		"if selects at least one ConfigMap source including all keys, return data": {
-			sources: []trustapi.BundleSource{
-				{ConfigMap: &trustapi.SourceObjectKeySelector{IncludeAllKeys: new(true), Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"trust-bundle.certs": "includes"}}}},
+			sources: []trustmanagerapi.BundleSourceRef{
+				{Key: "*", SourceReference: trustmanagerapi.SourceReference{Kind: trustmanagerapi.ConfigMapKind, Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"trust-bundle.certs": "includes"}}}},
 			},
 			objects: []runtime.Object{
 				&corev1.ConfigMap{
@@ -200,10 +200,10 @@ func Test_BuildBundle(t *testing.T) {
 			expData: dummy.JoinCerts(dummy.TestCertificate2, dummy.TestCertificate1, dummy.TestCertificate4, dummy.TestCertificate3),
 		},
 		"if ConfigMap and InLine source, return concatenated data": {
-			sources: []trustapi.BundleSource{
-				{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "configmap", Key: "key"}},
-				{InLine: dummy.TestCertificate2},
+			sources: []trustmanagerapi.BundleSourceRef{
+				{SourceReference: trustmanagerapi.SourceReference{Name: "configmap", Kind: trustmanagerapi.ConfigMapKind}, Key: "key"},
 			},
+			inLineCAs: dummy.TestCertificate2,
 			objects: []runtime.Object{&corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{Name: "configmap"},
 				Data:       map[string]string{"key": dummy.TestCertificate1},
@@ -211,23 +211,23 @@ func Test_BuildBundle(t *testing.T) {
 			expData: dummy.JoinCerts(dummy.TestCertificate2, dummy.TestCertificate1),
 		},
 		"if single Secret source exists which doesn't exist, should return not found error": {
-			sources: []trustapi.BundleSource{
-				{Secret: &trustapi.SourceObjectKeySelector{Name: "secret", Key: "key"}},
+			sources: []trustmanagerapi.BundleSourceRef{
+				{SourceReference: trustmanagerapi.SourceReference{Name: "secret", Kind: trustmanagerapi.SecretKind}, Key: "key"},
 			},
 			expError:         true,
 			expNotFoundError: true,
 		},
 		"if single Secret source whose key doesn't exist, return NotFoundError": {
-			sources: []trustapi.BundleSource{
-				{Secret: &trustapi.SourceObjectKeySelector{Name: "secret", Key: "key"}},
+			sources: []trustmanagerapi.BundleSourceRef{
+				{SourceReference: trustmanagerapi.SourceReference{Name: "secret", Kind: trustmanagerapi.SecretKind}, Key: "key"},
 			},
 			objects:          []runtime.Object{&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "secret"}}},
 			expError:         true,
 			expNotFoundError: true,
 		},
 		"if single Secret source of type TLS including all keys, return InvalidSecretError": {
-			sources: []trustapi.BundleSource{
-				{Secret: &trustapi.SourceObjectKeySelector{Name: "secret", IncludeAllKeys: new(true)}},
+			sources: []trustmanagerapi.BundleSourceRef{
+				{SourceReference: trustmanagerapi.SourceReference{Name: "secret", Kind: trustmanagerapi.SecretKind}, Key: "*"},
 			},
 			objects: []runtime.Object{&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "secret"},
@@ -238,8 +238,8 @@ func Test_BuildBundle(t *testing.T) {
 			expInvalidSecretSourceError: true,
 		},
 		"if single Secret source referencing single key, return data": {
-			sources: []trustapi.BundleSource{
-				{Secret: &trustapi.SourceObjectKeySelector{Name: "secret", Key: "key"}},
+			sources: []trustmanagerapi.BundleSourceRef{
+				{SourceReference: trustmanagerapi.SourceReference{Name: "secret", Kind: trustmanagerapi.SecretKind}, Key: "key"},
 			},
 			objects: []runtime.Object{&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "secret"},
@@ -248,8 +248,8 @@ func Test_BuildBundle(t *testing.T) {
 			expData: dummy.JoinCerts(dummy.TestCertificate2, dummy.TestCertificate1),
 		},
 		"if single Secret source including all keys, return data": {
-			sources: []trustapi.BundleSource{
-				{Secret: &trustapi.SourceObjectKeySelector{Name: "secret", IncludeAllKeys: new(true)}},
+			sources: []trustmanagerapi.BundleSourceRef{
+				{SourceReference: trustmanagerapi.SourceReference{Name: "secret", Kind: trustmanagerapi.SecretKind}, Key: "*"},
 			},
 			objects: []runtime.Object{&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "secret"},
@@ -258,10 +258,10 @@ func Test_BuildBundle(t *testing.T) {
 			expData: dummy.JoinCerts(dummy.TestCertificate2, dummy.TestCertificate1, dummy.TestCertificate4),
 		},
 		"if Secret and InLine source, return concatenated data": {
-			sources: []trustapi.BundleSource{
-				{Secret: &trustapi.SourceObjectKeySelector{Name: "secret", Key: "key"}},
-				{InLine: dummy.TestCertificate1},
+			sources: []trustmanagerapi.BundleSourceRef{
+				{SourceReference: trustmanagerapi.SourceReference{Name: "secret", Kind: trustmanagerapi.SecretKind}, Key: "key"},
 			},
+			inLineCAs: dummy.TestCertificate1,
 			objects: []runtime.Object{&corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{Name: "secret"},
 				Data:       map[string][]byte{"key": []byte(dummy.TestCertificate2)},
@@ -269,11 +269,11 @@ func Test_BuildBundle(t *testing.T) {
 			expData: dummy.JoinCerts(dummy.TestCertificate2, dummy.TestCertificate1),
 		},
 		"if Secret, ConfigMap and InLine source, return concatenated data": {
-			sources: []trustapi.BundleSource{
-				{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "configmap", Key: "key"}},
-				{InLine: dummy.TestCertificate3},
-				{Secret: &trustapi.SourceObjectKeySelector{Name: "secret", Key: "key"}},
+			sources: []trustmanagerapi.BundleSourceRef{
+				{SourceReference: trustmanagerapi.SourceReference{Name: "configmap", Kind: trustmanagerapi.ConfigMapKind}, Key: "key"},
+				{SourceReference: trustmanagerapi.SourceReference{Name: "secret", Kind: trustmanagerapi.SecretKind}, Key: "key"},
 			},
+			inLineCAs: dummy.TestCertificate3,
 			objects: []runtime.Object{
 				&corev1.ConfigMap{
 					ObjectMeta: metav1.ObjectMeta{Name: "configmap"},
@@ -287,9 +287,9 @@ func Test_BuildBundle(t *testing.T) {
 			expData: dummy.JoinCerts(dummy.TestCertificate2, dummy.TestCertificate1, dummy.TestCertificate3),
 		},
 		"if source Secret exists, but not ConfigMap, return not found error": {
-			sources: []trustapi.BundleSource{
-				{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "configmap", Key: "key"}},
-				{Secret: &trustapi.SourceObjectKeySelector{Name: "secret", Key: "key"}},
+			sources: []trustmanagerapi.BundleSourceRef{
+				{SourceReference: trustmanagerapi.SourceReference{Name: "configmap", Kind: trustmanagerapi.ConfigMapKind}, Key: "key"},
+				{SourceReference: trustmanagerapi.SourceReference{Name: "secret", Kind: trustmanagerapi.SecretKind}, Key: "key"},
 			},
 			objects: []runtime.Object{
 				&corev1.ConfigMap{
@@ -301,9 +301,9 @@ func Test_BuildBundle(t *testing.T) {
 			expNotFoundError: true,
 		},
 		"if source ConfigMap exists, but not Secret, return not found error": {
-			sources: []trustapi.BundleSource{
-				{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "configmap", Key: "key"}},
-				{Secret: &trustapi.SourceObjectKeySelector{Name: "secret", Key: "key"}},
+			sources: []trustmanagerapi.BundleSourceRef{
+				{SourceReference: trustmanagerapi.SourceReference{Name: "configmap", Kind: trustmanagerapi.ConfigMapKind}, Key: "key"},
+				{SourceReference: trustmanagerapi.SourceReference{Name: "secret", Kind: trustmanagerapi.SecretKind}, Key: "key"},
 			},
 			objects: []runtime.Object{
 				&corev1.Secret{
@@ -315,8 +315,8 @@ func Test_BuildBundle(t *testing.T) {
 			expNotFoundError: true,
 		},
 		"if selects at least one Secret source including all keys, return data": {
-			sources: []trustapi.BundleSource{
-				{Secret: &trustapi.SourceObjectKeySelector{IncludeAllKeys: new(true), Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"trust-bundle.certs": "includes"}}}},
+			sources: []trustmanagerapi.BundleSourceRef{
+				{Key: "*", SourceReference: trustmanagerapi.SourceReference{Kind: trustmanagerapi.SecretKind, Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"trust-bundle.certs": "includes"}}}},
 			},
 			objects: []runtime.Object{
 				&corev1.Secret{
@@ -335,8 +335,8 @@ func Test_BuildBundle(t *testing.T) {
 			expData: dummy.JoinCerts(dummy.TestCertificate2, dummy.TestCertificate1, dummy.TestCertificate4, dummy.TestCertificate3),
 		},
 		"if selects at least one Secret source of type TLS including all keys, return InvalidSecretError": {
-			sources: []trustapi.BundleSource{
-				{Secret: &trustapi.SourceObjectKeySelector{IncludeAllKeys: new(true), Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"trust-bundle.certs": "includes"}}}},
+			sources: []trustmanagerapi.BundleSourceRef{
+				{Key: "*", SourceReference: trustmanagerapi.SourceReference{Kind: trustmanagerapi.SecretKind, Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"trust-bundle.certs": "includes"}}}},
 			},
 			objects: []runtime.Object{
 				&corev1.Secret{
@@ -357,11 +357,11 @@ func Test_BuildBundle(t *testing.T) {
 			expInvalidSecretSourceError: true,
 		},
 		"if has any non-expired certificate, return data": {
-			sources: []trustapi.BundleSource{
-				// The first in-line source contains an expired certificate (only)
-				{InLine: dummy.TestExpiredCertificate},
-				{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "configmap", Key: "key"}},
+			sources: []trustmanagerapi.BundleSourceRef{
+				{SourceReference: trustmanagerapi.SourceReference{Name: "configmap", Kind: trustmanagerapi.ConfigMapKind}, Key: "key"},
 			},
+			// The in-line source contains an expired certificate (only)
+			inLineCAs:     dummy.TestExpiredCertificate,
 			filterExpired: true,
 			objects: []runtime.Object{
 				&corev1.ConfigMap{
@@ -394,7 +394,12 @@ func Test_BuildBundle(t *testing.T) {
 				Options: controller.Options{FilterExpiredCerts: tt.filterExpired},
 			}
 
-			resolvedBundle, err := b.BuildBundle(t.Context(), tt.sources)
+			spec := trustmanagerapi.BundleSpec{
+				SourceRefs: tt.sources,
+				DefaultCAs: tt.defaultCAs,
+				InLineCAs:  tt.inLineCAs,
+			}
+			resolvedBundle, err := b.BuildBundle(t.Context(), spec)
 
 			if (err != nil) != tt.expError {
 				t.Errorf("unexpected error, exp=%t got=%v", tt.expError, err)

--- a/pkg/bundle/internal/ssa_client/bundle_status.go
+++ b/pkg/bundle/internal/ssa_client/bundle_status.go
@@ -23,21 +23,21 @@ import (
 	v1 "k8s.io/client-go/applyconfigurations/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
+	trustmanagerapi "github.com/cert-manager/trust-manager/pkg/apis/trustmanager/v1alpha2"
 )
 
 type bundleStatusApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	Status                           *trustapi.BundleStatus `json:"status,omitempty"`
+	Status                           *trustmanagerapi.BundleStatus `json:"status,omitempty"`
 }
 
 func GenerateBundleStatusPatch(
 	name string,
-	status *trustapi.BundleStatus,
-) (*trustapi.Bundle, client.Patch, error) {
+	status *trustmanagerapi.BundleStatus,
+) (*trustmanagerapi.ClusterBundle, client.Patch, error) {
 	// This object is used to deduce the name & namespace + unmarshall the return value in
-	bundle := &trustapi.Bundle{
+	bundle := &trustmanagerapi.ClusterBundle{
 		ObjectMeta: metav1.ObjectMeta{Name: name},
 	}
 
@@ -46,8 +46,8 @@ func GenerateBundleStatusPatch(
 		ObjectMetaApplyConfiguration: &v1.ObjectMetaApplyConfiguration{},
 	}
 	b.WithName(name)
-	b.WithKind(trustapi.BundleKind)
-	b.WithAPIVersion(trustapi.SchemeGroupVersion.Identifier())
+	b.WithKind(trustmanagerapi.ClusterBundleKind)
+	b.WithAPIVersion(trustmanagerapi.SchemeGroupVersion.Identifier())
 	b.Status = status
 
 	encodedPatch, err := json.Marshal(b)

--- a/pkg/bundle/internal/target/target.go
+++ b/pkg/bundle/internal/target/target.go
@@ -35,11 +35,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	coreapplyconfig "k8s.io/client-go/applyconfigurations/core/v1"
 	metav1applyconfig "k8s.io/client-go/applyconfigurations/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
 
 	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
+	trustmanagerapi "github.com/cert-manager/trust-manager/pkg/apis/trustmanager/v1alpha2"
 	"github.com/cert-manager/trust-manager/pkg/bundle/internal/source"
 	"github.com/cert-manager/trust-manager/pkg/bundle/internal/ssa_client"
 	"github.com/cert-manager/trust-manager/pkg/bundle/internal/truststore"
@@ -65,7 +67,7 @@ type Reconciler struct {
 func (r *Reconciler) CleanupTarget(
 	ctx context.Context,
 	target Resource,
-	bundle *trustapi.Bundle,
+	bundle *trustmanagerapi.ClusterBundle,
 ) (bool, error) {
 	switch target.Kind {
 	case KindConfigMap:
@@ -103,7 +105,7 @@ func (r *Reconciler) CleanupTarget(
 func (r *Reconciler) ApplyTarget(
 	ctx context.Context,
 	target Resource,
-	bundle *trustapi.Bundle,
+	bundle *trustmanagerapi.ClusterBundle,
 	resolvedBundle source.BundleData,
 ) (bool, error) {
 	switch target.Kind {
@@ -119,7 +121,7 @@ func (r *Reconciler) ApplyTarget(
 func (r *Reconciler) applyConfigMap(
 	ctx context.Context,
 	target Resource,
-	bundle *trustapi.Bundle,
+	bundle *trustmanagerapi.ClusterBundle,
 	resolvedBundle source.BundleData,
 ) (bool, error) {
 	targetObj := &metav1.PartialObjectMetadata{
@@ -141,7 +143,7 @@ func (r *Reconciler) applyConfigMap(
 	bundlePEM := resolvedBundle.CertPool.PEM()
 	// Generated PKCS #12 is not deterministic - best we can do here is update if the pem cert has
 	// changed (hence not checking if PKCS #12 matches)
-	bundleHash := TrustBundleHash([]byte(bundlePEM), bundleTarget.AdditionalFormats, bundleTarget.ConfigMap)
+	bundleHash := TrustBundleHash([]byte(bundlePEM), bundleTarget.ConfigMap)
 	// If the resource exists, check if it is up-to-date.
 	if !apierrors.IsNotFound(err) {
 		// Exit early if no update is needed
@@ -152,11 +154,14 @@ func (r *Reconciler) applyConfigMap(
 		}
 	}
 
-	data := map[string]string{
-		bundleTarget.ConfigMap.Key: bundlePEM,
+	data := map[string]string{}
+	for _, keyValue := range bundleTarget.ConfigMap.Data {
+		if keyValue.Format == "" || keyValue.Format == trustmanagerapi.BundleFormatPEM {
+			data[keyValue.Key] = bundlePEM
+		}
 	}
 
-	binData, err := binaryData(resolvedBundle.CertPool, bundleTarget.AdditionalFormats)
+	binData, err := binaryData(resolvedBundle.CertPool, bundle.Annotations, bundleTarget.ConfigMap.Data)
 	if err != nil {
 		return false, err
 	}
@@ -164,7 +169,7 @@ func (r *Reconciler) applyConfigMap(
 	patch := prepareTargetPatch(coreapplyconfig.ConfigMap(target.Name, target.Namespace), *bundle).
 		WithAnnotations(bundleTarget.ConfigMap.GetAnnotations()).
 		WithAnnotations(map[string]string{
-			trustapi.BundleHashAnnotationKey: bundleHash,
+			trustmanagerapi.BundleHashAnnotationKey: bundleHash,
 		}).
 		WithLabels(bundleTarget.ConfigMap.GetLabels()).
 		WithData(data).
@@ -182,7 +187,7 @@ func (r *Reconciler) applyConfigMap(
 func (r *Reconciler) applySecret(
 	ctx context.Context,
 	target Resource,
-	bundle *trustapi.Bundle,
+	bundle *trustmanagerapi.ClusterBundle,
 	resolvedBundle source.BundleData,
 ) (bool, error) {
 	targetObj := &metav1.PartialObjectMetadata{
@@ -204,7 +209,7 @@ func (r *Reconciler) applySecret(
 	bundlePEM := resolvedBundle.CertPool.PEM()
 	// Generated PKCS #12 is not deterministic - best we can do here is update if the pem cert has
 	// changed (hence not checking if PKCS #12 matches)
-	bundleHash := TrustBundleHash([]byte(bundlePEM), bundleTarget.AdditionalFormats, bundleTarget.Secret)
+	bundleHash := TrustBundleHash([]byte(bundlePEM), bundleTarget.Secret)
 	// If the resource exists, check if it is up-to-date.
 	if !apierrors.IsNotFound(err) {
 		// Exit early if no update is needed
@@ -215,11 +220,14 @@ func (r *Reconciler) applySecret(
 		}
 	}
 
-	data := map[string][]byte{
-		bundleTarget.Secret.Key: []byte(bundlePEM),
+	data := map[string][]byte{}
+	for _, keyValue := range bundleTarget.Secret.Data {
+		if keyValue.Format == "" || keyValue.Format == trustmanagerapi.BundleFormatPEM {
+			data[keyValue.Key] = []byte(bundlePEM)
+		}
 	}
 
-	binData, err := binaryData(resolvedBundle.CertPool, bundleTarget.AdditionalFormats)
+	binData, err := binaryData(resolvedBundle.CertPool, bundle.Annotations, bundleTarget.Secret.Data)
 	if err != nil {
 		return false, err
 	}
@@ -228,7 +236,7 @@ func (r *Reconciler) applySecret(
 	patch := prepareTargetPatch(coreapplyconfig.Secret(target.Name, target.Namespace), *bundle).
 		WithAnnotations(bundleTarget.Secret.GetAnnotations()).
 		WithAnnotations(map[string]string{
-			trustapi.BundleHashAnnotationKey: bundleHash,
+			trustmanagerapi.BundleHashAnnotationKey: bundleHash,
 		}).
 		WithLabels(bundleTarget.Secret.GetLabels()).
 		WithData(data)
@@ -249,21 +257,21 @@ const (
 	KindSecret    Kind = "Secret"
 )
 
-func (r *Reconciler) needsUpdate(kind Kind, obj *metav1.PartialObjectMetadata, bundle *trustapi.Bundle, bundleHash string) (bool, error) {
+func (r *Reconciler) needsUpdate(kind Kind, obj *metav1.PartialObjectMetadata, bundle *trustmanagerapi.ClusterBundle, bundleHash string) (bool, error) {
 	needsUpdate := false ||
 		!metav1.IsControlledBy(obj, bundle) ||
-		obj.GetLabels()[trustapi.BundleLabelKey] != bundle.Name ||
-		obj.GetAnnotations()[trustapi.BundleHashAnnotationKey] != bundleHash
+		obj.GetLabels()[trustmanagerapi.BundleLabelKey] != bundle.Name ||
+		obj.GetAnnotations()[trustmanagerapi.BundleHashAnnotationKey] != bundleHash
 
 	{
-		var key string
+		var target *trustmanagerapi.KeyValueTarget
 		var targetFieldNames []string
 		switch kind {
 		case KindConfigMap:
-			key = bundle.Spec.Target.ConfigMap.Key
+			target = bundle.Spec.Target.ConfigMap
 			targetFieldNames = []string{"data", "binaryData"}
 		case KindSecret:
-			key = bundle.Spec.Target.Secret.Key
+			target = bundle.Spec.Target.Secret
 			targetFieldNames = []string{"data"}
 		default:
 			return false, fmt.Errorf("unknown targetType: %s", kind)
@@ -273,12 +281,9 @@ func (r *Reconciler) needsUpdate(kind Kind, obj *metav1.PartialObjectMetadata, b
 		if err != nil {
 			return false, fmt.Errorf("failed to list managed properties: %w", err)
 		}
-		expectedProperties := sets.New(key)
-		if bundle.Spec.Target.AdditionalFormats != nil && bundle.Spec.Target.AdditionalFormats.JKS != nil {
-			expectedProperties.Insert(bundle.Spec.Target.AdditionalFormats.JKS.Key)
-		}
-		if bundle.Spec.Target.AdditionalFormats != nil && bundle.Spec.Target.AdditionalFormats.PKCS12 != nil {
-			expectedProperties.Insert(bundle.Spec.Target.AdditionalFormats.PKCS12.Key)
+		expectedProperties := sets.New[string]()
+		for _, keyValue := range target.Data {
+			expectedProperties.Insert(keyValue.Key)
 		}
 		if !properties.Equal(expectedProperties) {
 			needsUpdate = true
@@ -376,15 +381,15 @@ type targetApplyConfiguration[T any] interface {
 	WithOwnerReferences(values ...*metav1applyconfig.OwnerReferenceApplyConfiguration) T
 }
 
-func prepareTargetPatch[T targetApplyConfiguration[T]](target T, bundle trustapi.Bundle) T {
+func prepareTargetPatch[T targetApplyConfiguration[T]](target T, bundle trustmanagerapi.ClusterBundle) T {
 	return target.
 		WithLabels(map[string]string{
-			trustapi.BundleLabelKey: bundle.Name,
+			trustmanagerapi.BundleLabelKey: bundle.Name,
 		}).
 		WithOwnerReferences(
 			metav1applyconfig.OwnerReference().
-				WithAPIVersion(trustapi.SchemeGroupVersion.String()).
-				WithKind(trustapi.BundleKind).
+				WithAPIVersion(trustmanagerapi.SchemeGroupVersion.String()).
+				WithKind(trustmanagerapi.ClusterBundleKind).
 				WithName(bundle.GetName()).
 				WithUID(bundle.GetUID()).
 				WithBlockOwnerDeletion(true).
@@ -397,16 +402,20 @@ type Resource struct {
 	types.NamespacedName
 }
 
-func TrustBundleHash(data []byte, additionalFormats *trustapi.AdditionalFormats, target *trustapi.TargetTemplate) string {
+func TrustBundleHash(data []byte, target *trustmanagerapi.KeyValueTarget) string {
 	hash := sha256.New()
 
 	_, _ = hash.Write(data)
 
-	if additionalFormats != nil && additionalFormats.JKS != nil && additionalFormats.JKS.Password != "" {
-		_, _ = hash.Write([]byte(additionalFormats.JKS.Password))
-	}
-	if additionalFormats != nil && additionalFormats.PKCS12 != nil && additionalFormats.PKCS12.Password != nil {
-		_, _ = hash.Write([]byte(*additionalFormats.PKCS12.Password))
+	if target != nil {
+		for _, keyValue := range target.Data {
+			if keyValue.PKCS12.Password != nil {
+				_, _ = hash.Write([]byte(*keyValue.PKCS12.Password))
+			}
+			if keyValue.PKCS12.Profile != "" {
+				_, _ = hash.Write([]byte(keyValue.PKCS12.Profile))
+			}
+		}
 	}
 
 	// Add Target annotations and labels to the hash so it becomes aware of changes
@@ -427,24 +436,31 @@ func TrustBundleHash(data []byte, additionalFormats *trustapi.AdditionalFormats,
 	return hex.EncodeToString(hashValue[:])
 }
 
-func binaryData(pool *util.CertPool, formats *trustapi.AdditionalFormats) (binData map[string][]byte, err error) {
-	if formats != nil {
-		binData = make(map[string][]byte)
+func binaryData(pool *util.CertPool, annotations map[string]string, targetKeys []trustmanagerapi.TargetKeyValue) (binData map[string][]byte, err error) {
+	for _, targetKey := range targetKeys {
+		if targetKey.Format == trustmanagerapi.BundleFormatPKCS12 {
+			var encoded []byte
 
-		if formats.JKS != nil {
-			encoded, err := truststore.NewJKSEncoder(formats.JKS.Password).Encode(pool)
-			if err != nil {
-				return nil, fmt.Errorf("failed to encode JKS: %w", err)
+			switch targetKey.Key {
+			case annotations[trustapi.AnnotationKeyJKSKey]:
+				if targetKey.PKCS12.Password == nil {
+					return nil, errors.New("missing password for deprecated JKS, and this is probably a bug in conversion")
+				}
+				encoded, err = truststore.NewJKSEncoder(*targetKey.PKCS12.Password).Encode(pool)
+				if err != nil {
+					return nil, fmt.Errorf("failed to encode JKS: %w", err)
+				}
+			default:
+				encoded, err = truststore.NewPKCS12Encoder(ptr.Deref(targetKey.PKCS12.Password, ""), targetKey.PKCS12.Profile).Encode(pool)
+				if err != nil {
+					return nil, fmt.Errorf("failed to encode PKCS12: %w", err)
+				}
 			}
-			binData[formats.JKS.Key] = encoded
-		}
 
-		if formats.PKCS12 != nil {
-			encoded, err := truststore.NewPKCS12Encoder(*formats.PKCS12.Password, formats.PKCS12.Profile).Encode(pool)
-			if err != nil {
-				return nil, fmt.Errorf("failed to encode PKCS12: %w", err)
+			if binData == nil {
+				binData = make(map[string][]byte)
 			}
-			binData[formats.PKCS12.Key] = encoded
+			binData[targetKey.Key] = encoded
 		}
 	}
 	return binData, nil

--- a/pkg/bundle/internal/target/target.go
+++ b/pkg/bundle/internal/target/target.go
@@ -35,11 +35,13 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	coreapplyconfig "k8s.io/client-go/applyconfigurations/core/v1"
 	metav1applyconfig "k8s.io/client-go/applyconfigurations/meta/v1"
+	"k8s.io/utils/ptr"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/structured-merge-diff/v6/fieldpath"
 
 	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
+	trustmanagerapi "github.com/cert-manager/trust-manager/pkg/apis/trustmanager/v1alpha2"
 	"github.com/cert-manager/trust-manager/pkg/bundle/internal/source"
 	"github.com/cert-manager/trust-manager/pkg/bundle/internal/ssa_client"
 	"github.com/cert-manager/trust-manager/pkg/bundle/internal/truststore"
@@ -65,7 +67,7 @@ type Reconciler struct {
 func (r *Reconciler) CleanupTarget(
 	ctx context.Context,
 	target Resource,
-	bundle *trustapi.Bundle,
+	bundle *trustmanagerapi.ClusterBundle,
 ) (bool, error) {
 	switch target.Kind {
 	case KindConfigMap:
@@ -103,7 +105,7 @@ func (r *Reconciler) CleanupTarget(
 func (r *Reconciler) ApplyTarget(
 	ctx context.Context,
 	target Resource,
-	bundle *trustapi.Bundle,
+	bundle *trustmanagerapi.ClusterBundle,
 	resolvedBundle source.BundleData,
 ) (bool, error) {
 	switch target.Kind {
@@ -119,7 +121,7 @@ func (r *Reconciler) ApplyTarget(
 func (r *Reconciler) applyConfigMap(
 	ctx context.Context,
 	target Resource,
-	bundle *trustapi.Bundle,
+	bundle *trustmanagerapi.ClusterBundle,
 	resolvedBundle source.BundleData,
 ) (bool, error) {
 	targetObj := &metav1.PartialObjectMetadata{
@@ -141,7 +143,7 @@ func (r *Reconciler) applyConfigMap(
 	bundlePEM := resolvedBundle.CertPool.PEM()
 	// Generated PKCS #12 is not deterministic - best we can do here is update if the pem cert has
 	// changed (hence not checking if PKCS #12 matches)
-	bundleHash := TrustBundleHash([]byte(bundlePEM), bundleTarget.AdditionalFormats, bundleTarget.ConfigMap)
+	bundleHash := TrustBundleHash([]byte(bundlePEM), bundleTarget.ConfigMap)
 	// If the resource exists, check if it is up-to-date.
 	if !apierrors.IsNotFound(err) {
 		// Exit early if no update is needed
@@ -152,11 +154,14 @@ func (r *Reconciler) applyConfigMap(
 		}
 	}
 
-	data := map[string]string{
-		bundleTarget.ConfigMap.Key: bundlePEM,
+	data := map[string]string{}
+	for _, keyValue := range bundleTarget.ConfigMap.Data {
+		if keyValue.Format == "" || keyValue.Format == trustmanagerapi.BundleFormatPEM {
+			data[keyValue.Key] = bundlePEM
+		}
 	}
 
-	binData, err := binaryData(resolvedBundle.CertPool, bundleTarget.AdditionalFormats)
+	binData, err := binaryData(resolvedBundle.CertPool, bundle.Annotations, bundleTarget.ConfigMap.Data)
 	if err != nil {
 		return false, err
 	}
@@ -164,7 +169,7 @@ func (r *Reconciler) applyConfigMap(
 	patch := prepareTargetPatch(coreapplyconfig.ConfigMap(target.Name, target.Namespace), *bundle).
 		WithAnnotations(bundleTarget.ConfigMap.GetAnnotations()).
 		WithAnnotations(map[string]string{
-			trustapi.BundleHashAnnotationKey: bundleHash,
+			trustmanagerapi.BundleHashAnnotationKey: bundleHash,
 		}).
 		WithLabels(bundleTarget.ConfigMap.GetLabels()).
 		WithData(data).
@@ -188,7 +193,7 @@ func (r *Reconciler) applyConfigMap(
 func (r *Reconciler) applySecret(
 	ctx context.Context,
 	target Resource,
-	bundle *trustapi.Bundle,
+	bundle *trustmanagerapi.ClusterBundle,
 	resolvedBundle source.BundleData,
 ) (bool, error) {
 	targetObj := &metav1.PartialObjectMetadata{
@@ -210,7 +215,7 @@ func (r *Reconciler) applySecret(
 	bundlePEM := resolvedBundle.CertPool.PEM()
 	// Generated PKCS #12 is not deterministic - best we can do here is update if the pem cert has
 	// changed (hence not checking if PKCS #12 matches)
-	bundleHash := TrustBundleHash([]byte(bundlePEM), bundleTarget.AdditionalFormats, bundleTarget.Secret)
+	bundleHash := TrustBundleHash([]byte(bundlePEM), bundleTarget.Secret)
 	// If the resource exists, check if it is up-to-date.
 	if !apierrors.IsNotFound(err) {
 		// Exit early if no update is needed
@@ -221,11 +226,14 @@ func (r *Reconciler) applySecret(
 		}
 	}
 
-	data := map[string][]byte{
-		bundleTarget.Secret.Key: []byte(bundlePEM),
+	data := map[string][]byte{}
+	for _, keyValue := range bundleTarget.Secret.Data {
+		if keyValue.Format == "" || keyValue.Format == trustmanagerapi.BundleFormatPEM {
+			data[keyValue.Key] = []byte(bundlePEM)
+		}
 	}
 
-	binData, err := binaryData(resolvedBundle.CertPool, bundleTarget.AdditionalFormats)
+	binData, err := binaryData(resolvedBundle.CertPool, bundle.Annotations, bundleTarget.Secret.Data)
 	if err != nil {
 		return false, err
 	}
@@ -234,7 +242,7 @@ func (r *Reconciler) applySecret(
 	patch := prepareTargetPatch(coreapplyconfig.Secret(target.Name, target.Namespace), *bundle).
 		WithAnnotations(bundleTarget.Secret.GetAnnotations()).
 		WithAnnotations(map[string]string{
-			trustapi.BundleHashAnnotationKey: bundleHash,
+			trustmanagerapi.BundleHashAnnotationKey: bundleHash,
 		}).
 		WithLabels(bundleTarget.Secret.GetLabels()).
 		WithData(data)
@@ -259,21 +267,21 @@ const (
 	KindSecret    Kind = "Secret"
 )
 
-func (r *Reconciler) needsUpdate(kind Kind, obj *metav1.PartialObjectMetadata, bundle *trustapi.Bundle, bundleHash string) (bool, error) {
+func (r *Reconciler) needsUpdate(kind Kind, obj *metav1.PartialObjectMetadata, bundle *trustmanagerapi.ClusterBundle, bundleHash string) (bool, error) {
 	needsUpdate := false ||
 		!metav1.IsControlledBy(obj, bundle) ||
-		obj.GetLabels()[trustapi.BundleLabelKey] != bundle.Name ||
-		obj.GetAnnotations()[trustapi.BundleHashAnnotationKey] != bundleHash
+		obj.GetLabels()[trustmanagerapi.BundleLabelKey] != bundle.Name ||
+		obj.GetAnnotations()[trustmanagerapi.BundleHashAnnotationKey] != bundleHash
 
 	{
-		var key string
+		var target *trustmanagerapi.KeyValueTarget
 		var targetFieldNames []string
 		switch kind {
 		case KindConfigMap:
-			key = bundle.Spec.Target.ConfigMap.Key
+			target = bundle.Spec.Target.ConfigMap
 			targetFieldNames = []string{"data", "binaryData"}
 		case KindSecret:
-			key = bundle.Spec.Target.Secret.Key
+			target = bundle.Spec.Target.Secret
 			targetFieldNames = []string{"data"}
 		default:
 			return false, fmt.Errorf("unknown targetType: %s", kind)
@@ -283,12 +291,9 @@ func (r *Reconciler) needsUpdate(kind Kind, obj *metav1.PartialObjectMetadata, b
 		if err != nil {
 			return false, fmt.Errorf("failed to list managed properties: %w", err)
 		}
-		expectedProperties := sets.New(key)
-		if bundle.Spec.Target.AdditionalFormats != nil && bundle.Spec.Target.AdditionalFormats.JKS != nil {
-			expectedProperties.Insert(bundle.Spec.Target.AdditionalFormats.JKS.Key)
-		}
-		if bundle.Spec.Target.AdditionalFormats != nil && bundle.Spec.Target.AdditionalFormats.PKCS12 != nil {
-			expectedProperties.Insert(bundle.Spec.Target.AdditionalFormats.PKCS12.Key)
+		expectedProperties := sets.New[string]()
+		for _, keyValue := range target.Data {
+			expectedProperties.Insert(keyValue.Key)
 		}
 		if !properties.Equal(expectedProperties) {
 			needsUpdate = true
@@ -386,15 +391,15 @@ type targetApplyConfiguration[T any] interface {
 	WithOwnerReferences(values ...*metav1applyconfig.OwnerReferenceApplyConfiguration) T
 }
 
-func prepareTargetPatch[T targetApplyConfiguration[T]](target T, bundle trustapi.Bundle) T {
+func prepareTargetPatch[T targetApplyConfiguration[T]](target T, bundle trustmanagerapi.ClusterBundle) T {
 	return target.
 		WithLabels(map[string]string{
-			trustapi.BundleLabelKey: bundle.Name,
+			trustmanagerapi.BundleLabelKey: bundle.Name,
 		}).
 		WithOwnerReferences(
 			metav1applyconfig.OwnerReference().
-				WithAPIVersion(trustapi.SchemeGroupVersion.String()).
-				WithKind(trustapi.BundleKind).
+				WithAPIVersion(trustmanagerapi.SchemeGroupVersion.String()).
+				WithKind(trustmanagerapi.ClusterBundleKind).
 				WithName(bundle.GetName()).
 				WithUID(bundle.GetUID()).
 				WithBlockOwnerDeletion(true).
@@ -407,19 +412,20 @@ type Resource struct {
 	types.NamespacedName
 }
 
-func TrustBundleHash(data []byte, additionalFormats *trustapi.AdditionalFormats, target *trustapi.TargetTemplate) string {
+func TrustBundleHash(data []byte, target *trustmanagerapi.KeyValueTarget) string {
 	hash := sha256.New()
 
 	_, _ = hash.Write(data)
 
-	if additionalFormats != nil && additionalFormats.JKS != nil && additionalFormats.JKS.Password != "" {
-		_, _ = hash.Write([]byte(additionalFormats.JKS.Password))
-	}
-	if additionalFormats != nil && additionalFormats.PKCS12 != nil && additionalFormats.PKCS12.Password != nil {
-		_, _ = hash.Write([]byte(*additionalFormats.PKCS12.Password))
-	}
-	if additionalFormats != nil && additionalFormats.PKCS12 != nil && additionalFormats.PKCS12.Profile != "" {
-		_, _ = hash.Write([]byte(additionalFormats.PKCS12.Profile))
+	if target != nil {
+		for _, keyValue := range target.Data {
+			if keyValue.PKCS12.Password != nil {
+				_, _ = hash.Write([]byte(*keyValue.PKCS12.Password))
+			}
+			if keyValue.PKCS12.Profile != "" {
+				_, _ = hash.Write([]byte(keyValue.PKCS12.Profile))
+			}
+		}
 	}
 
 	// Add Target annotations and labels to the hash so it becomes aware of changes
@@ -440,24 +446,31 @@ func TrustBundleHash(data []byte, additionalFormats *trustapi.AdditionalFormats,
 	return hex.EncodeToString(hashValue[:])
 }
 
-func binaryData(pool *util.CertPool, formats *trustapi.AdditionalFormats) (binData map[string][]byte, err error) {
-	if formats != nil {
-		binData = make(map[string][]byte)
+func binaryData(pool *util.CertPool, annotations map[string]string, targetKeys []trustmanagerapi.TargetKeyValue) (binData map[string][]byte, err error) {
+	for _, targetKey := range targetKeys {
+		if targetKey.Format == trustmanagerapi.BundleFormatPKCS12 {
+			var encoded []byte
 
-		if formats.JKS != nil {
-			encoded, err := truststore.NewJKSEncoder(formats.JKS.Password).Encode(pool)
-			if err != nil {
-				return nil, fmt.Errorf("failed to encode JKS: %w", err)
+			switch targetKey.Key {
+			case annotations[trustapi.AnnotationKeyJKSKey]:
+				if targetKey.PKCS12.Password == nil {
+					return nil, errors.New("missing password for deprecated JKS, and this is probably a bug in conversion")
+				}
+				encoded, err = truststore.NewJKSEncoder(*targetKey.PKCS12.Password).Encode(pool)
+				if err != nil {
+					return nil, fmt.Errorf("failed to encode JKS: %w", err)
+				}
+			default:
+				encoded, err = truststore.NewPKCS12Encoder(ptr.Deref(targetKey.PKCS12.Password, ""), targetKey.PKCS12.Profile).Encode(pool)
+				if err != nil {
+					return nil, fmt.Errorf("failed to encode PKCS12: %w", err)
+				}
 			}
-			binData[formats.JKS.Key] = encoded
-		}
 
-		if formats.PKCS12 != nil {
-			encoded, err := truststore.NewPKCS12Encoder(*formats.PKCS12.Password, formats.PKCS12.Profile).Encode(pool)
-			if err != nil {
-				return nil, fmt.Errorf("failed to encode PKCS12: %w", err)
+			if binData == nil {
+				binData = make(map[string][]byte)
 			}
-			binData[formats.PKCS12.Key] = encoded
+			binData[targetKey.Key] = encoded
 		}
 	}
 	return binData, nil

--- a/pkg/bundle/internal/target/target_test.go
+++ b/pkg/bundle/internal/target/target_test.go
@@ -37,6 +37,7 @@ import (
 	"software.sslmate.com/src/go-pkcs12"
 
 	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
+	trustmanagerapi "github.com/cert-manager/trust-manager/pkg/apis/trustmanager/v1alpha2"
 	"github.com/cert-manager/trust-manager/pkg/bundle/internal/source"
 	"github.com/cert-manager/trust-manager/pkg/bundle/internal/ssa_client"
 	"github.com/cert-manager/trust-manager/pkg/util"
@@ -56,7 +57,7 @@ const (
 )
 
 func Test_ApplyTarget_ConfigMap(t *testing.T) {
-	bundleHash := TrustBundleHash([]byte(data), nil, nil)
+	bundleHash := TrustBundleHash([]byte(data), nil)
 
 	tests := map[string]struct {
 		object runtime.Object
@@ -99,8 +100,8 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:          bundleName,
 					Namespace:     namespace,
-					Labels:        map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations:   map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:        map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations:   map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					ManagedFields: ssa_client.ManagedFieldEntries(nil, nil),
 				},
 			},
@@ -111,8 +112,8 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:          bundleName,
 					Namespace:     namespace,
-					Labels:        map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations:   map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:        map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations:   map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					ManagedFields: ssa_client.ManagedFieldEntries([]string{key}, nil),
 				},
 				Data: map[string]string{key: data},
@@ -124,8 +125,8 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Kind:               "Bundle",
@@ -144,8 +145,8 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: "wrong hash"},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: "wrong hash"},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Kind:               "Bundle",
@@ -166,8 +167,8 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Kind:               "Bundle",
@@ -190,8 +191,8 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Kind:               "Bundle",
@@ -214,8 +215,8 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Kind:               "Bundle",
@@ -236,8 +237,8 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Kind:               "Bundle",
@@ -263,8 +264,8 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Kind:               "Bundle",
@@ -290,8 +291,8 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Kind:               "Bundle",
@@ -312,8 +313,8 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Kind:               "Bundle",
@@ -336,8 +337,8 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Kind:               "Bundle",
@@ -360,8 +361,8 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Kind:               "Bundle",
@@ -392,8 +393,8 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Kind:               "Bundle",
@@ -416,8 +417,8 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Kind:               "Bundle",
@@ -471,28 +472,29 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 			err := certPool.AddCertsFromPEM([]byte(data))
 			assert.NoError(t, err)
 
-			spec := trustapi.BundleSpec{
-				Target: trustapi.BundleTarget{
-					ConfigMap:         &trustapi.TargetTemplate{Key: key},
-					AdditionalFormats: &trustapi.AdditionalFormats{},
+			var annotations map[string]string
+			spec := trustmanagerapi.BundleSpec{
+				Target: trustmanagerapi.BundleTarget{
+					ConfigMap: &trustmanagerapi.KeyValueTarget{
+						Data: []trustmanagerapi.TargetKeyValue{{Key: key}},
+					},
 				},
 			}
 			resolvedBundle := source.BundleData{CertPool: certPool}
 			if tt.withJKS {
-				spec.Target.AdditionalFormats.JKS = &trustapi.JKS{
-					KeySelector: trustapi.KeySelector{
-						Key: jksKey,
-					},
-					Password: trustapi.DefaultJKSPassword,
-				}
+				spec.Target.ConfigMap.Data = append(spec.Target.ConfigMap.Data, trustmanagerapi.TargetKeyValue{
+					Key:    jksKey,
+					Format: trustmanagerapi.BundleFormatPKCS12,
+					PKCS12: trustmanagerapi.PKCS12{Password: ptr.To(trustapi.DefaultJKSPassword)},
+				})
+				annotations = map[string]string{trustapi.AnnotationKeyJKSKey: jksKey}
 			}
 			if tt.withPKCS12 {
-				spec.Target.AdditionalFormats.PKCS12 = &trustapi.PKCS12{
-					KeySelector: trustapi.KeySelector{
-						Key: pkcs12Key,
-					},
-					Password: ptr.To(trustapi.DefaultPKCS12Password),
-				}
+				spec.Target.ConfigMap.Data = append(spec.Target.ConfigMap.Data, trustmanagerapi.TargetKeyValue{
+					Key:    pkcs12Key,
+					Format: trustmanagerapi.BundleFormatPKCS12,
+					PKCS12: trustmanagerapi.PKCS12{Password: ptr.To(trustmanagerapi.DefaultPKCS12Password)},
+				})
 			}
 			if tt.withTargetAnnotation {
 				spec.Target.ConfigMap.Metadata.Annotations = map[string]string{targetAnnotation: "true"}
@@ -505,8 +507,8 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 			needsUpdate, err := r.ApplyTarget(ctx, Resource{
 				Kind:           KindConfigMap,
 				NamespacedName: types.NamespacedName{Name: bundleName, Namespace: namespace},
-			}, &trustapi.Bundle{
-				ObjectMeta: metav1.ObjectMeta{Name: bundleName},
+			}, &trustmanagerapi.ClusterBundle{
+				ObjectMeta: metav1.ObjectMeta{Name: bundleName, Annotations: annotations},
 				Spec:       spec,
 			}, resolvedBundle)
 			assert.NoError(t, err)
@@ -524,8 +526,8 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 
 				expectedOwnerReference := metav1applyconfig.
 					OwnerReference().
-					WithAPIVersion(trustapi.SchemeGroupVersion.String()).
-					WithKind(trustapi.BundleKind).
+					WithAPIVersion(trustmanagerapi.SchemeGroupVersion.String()).
+					WithKind(trustmanagerapi.ClusterBundleKind).
 					WithName(bundleName).
 					WithUID("").
 					WithBlockOwnerDeletion(true).
@@ -543,7 +545,7 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				assert.Equal(t, tt.expPKCS12, pkcs12Exists)
 
 				if tt.expPKCS12 {
-					assertPKCS12Data(t, binData, trustapi.DefaultPKCS12Password)
+					assertPKCS12Data(t, binData, trustmanagerapi.DefaultPKCS12Password)
 				}
 
 				if tt.expTargetLabel {
@@ -558,7 +560,7 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 }
 
 func Test_ApplyTarget_Secret(t *testing.T) {
-	bundleHash := TrustBundleHash([]byte(data), nil, nil)
+	bundleHash := TrustBundleHash([]byte(data), nil)
 
 	tests := map[string]struct {
 		object runtime.Object
@@ -593,8 +595,8 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:          bundleName,
 					Namespace:     namespace,
-					Labels:        map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations:   map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:        map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations:   map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					ManagedFields: ssa_client.ManagedFieldEntries(nil, nil),
 				},
 			},
@@ -605,8 +607,8 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:          bundleName,
 					Namespace:     namespace,
-					Labels:        map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations:   map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:        map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations:   map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					ManagedFields: ssa_client.ManagedFieldEntries([]string{key}, nil),
 				},
 				Data: map[string][]byte{key: []byte(data)},
@@ -618,8 +620,8 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Kind:               "Bundle",
@@ -638,8 +640,8 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: "wrong hash"},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: "wrong hash"},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Kind:               "Bundle",
@@ -660,8 +662,8 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Kind:               "Bundle",
@@ -684,8 +686,8 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Kind:               "Bundle",
@@ -708,8 +710,8 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Kind:               "Bundle",
@@ -730,8 +732,8 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Kind:               "Bundle",
@@ -757,8 +759,8 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Kind:               "Bundle",
@@ -784,8 +786,8 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Kind:               "Bundle",
@@ -806,8 +808,8 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Kind:               "Bundle",
@@ -830,8 +832,8 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Kind:               "Bundle",
@@ -854,8 +856,8 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
 							Kind:               "Bundle",
@@ -917,36 +919,37 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 			err := certPool.AddCertsFromPEM([]byte(data))
 			assert.NoError(t, err)
 
-			spec := trustapi.BundleSpec{
-				Target: trustapi.BundleTarget{
-					Secret:            &trustapi.TargetTemplate{Key: key},
-					AdditionalFormats: &trustapi.AdditionalFormats{},
+			var annotations map[string]string
+			spec := trustmanagerapi.BundleSpec{
+				Target: trustmanagerapi.BundleTarget{
+					Secret: &trustmanagerapi.KeyValueTarget{
+						Data: []trustmanagerapi.TargetKeyValue{{Key: key}},
+					},
 				},
 			}
 			resolvedBundle := source.BundleData{CertPool: certPool}
 			if tt.withJKS {
-				spec.Target.AdditionalFormats.JKS = &trustapi.JKS{
-					KeySelector: trustapi.KeySelector{
-						Key: jksKey,
-					},
-					Password: trustapi.DefaultJKSPassword,
-				}
+				spec.Target.Secret.Data = append(spec.Target.Secret.Data, trustmanagerapi.TargetKeyValue{
+					Key:    jksKey,
+					Format: trustmanagerapi.BundleFormatPKCS12,
+					PKCS12: trustmanagerapi.PKCS12{Password: ptr.To(trustapi.DefaultJKSPassword)},
+				})
+				annotations = map[string]string{trustapi.AnnotationKeyJKSKey: jksKey}
 			}
 			if tt.withPKCS12 {
-				spec.Target.AdditionalFormats.PKCS12 = &trustapi.PKCS12{
-					KeySelector: trustapi.KeySelector{
-						Key: pkcs12Key,
-					},
-					Password: ptr.To(trustapi.DefaultPKCS12Password),
-				}
+				spec.Target.Secret.Data = append(spec.Target.Secret.Data, trustmanagerapi.TargetKeyValue{
+					Key:    pkcs12Key,
+					Format: trustmanagerapi.BundleFormatPKCS12,
+					PKCS12: trustmanagerapi.PKCS12{Password: ptr.To(trustmanagerapi.DefaultPKCS12Password)},
+				})
 			}
 
 			_, ctx := ktesting.NewTestContext(t)
 			needsUpdate, err := r.ApplyTarget(ctx, Resource{
 				Kind:           KindSecret,
 				NamespacedName: types.NamespacedName{Name: bundleName, Namespace: namespace},
-			}, &trustapi.Bundle{
-				ObjectMeta: metav1.ObjectMeta{Name: bundleName},
+			}, &trustmanagerapi.ClusterBundle{
+				ObjectMeta: metav1.ObjectMeta{Name: bundleName, Annotations: annotations},
 				Spec:       spec,
 			}, resolvedBundle)
 			assert.NoError(t, err)
@@ -964,8 +967,8 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 
 				expectedOwnerReference := metav1applyconfig.
 					OwnerReference().
-					WithAPIVersion(trustapi.SchemeGroupVersion.String()).
-					WithKind(trustapi.BundleKind).
+					WithAPIVersion(trustmanagerapi.SchemeGroupVersion.String()).
+					WithKind(trustmanagerapi.ClusterBundleKind).
 					WithName(bundleName).
 					WithUID("").
 					WithBlockOwnerDeletion(true).
@@ -983,7 +986,7 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				assert.Equal(t, tt.expPKCS12, pkcs12Exists)
 
 				if tt.expPKCS12 {
-					assertPKCS12Data(t, binData, trustapi.DefaultPKCS12Password)
+					assertPKCS12Data(t, binData, trustmanagerapi.DefaultPKCS12Password)
 				}
 			}
 		})
@@ -992,9 +995,8 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 
 func Test_TrustBundleHash(t *testing.T) {
 	type inputArgs struct {
-		data              []byte
-		additionalFormats *trustapi.AdditionalFormats
-		targetTemplate    *trustapi.TargetTemplate
+		data   []byte
+		target *trustmanagerapi.KeyValueTarget
 	}
 	tests := map[string]struct {
 		input      inputArgs
@@ -1002,55 +1004,40 @@ func Test_TrustBundleHash(t *testing.T) {
 		mismatches []inputArgs
 	}{
 		"empty data": {
-			input: inputArgs{data: []byte{}, additionalFormats: nil},
+			input: inputArgs{data: []byte{}},
 			matches: []inputArgs{
-				{data: []byte{}, additionalFormats: nil},
-				{data: []byte{}, additionalFormats: &trustapi.AdditionalFormats{}},
-				{data: []byte{}, additionalFormats: &trustapi.AdditionalFormats{JKS: &trustapi.JKS{}}},
+				{data: []byte{}},
+				{data: []byte{}, target: &trustmanagerapi.KeyValueTarget{}},
+				{data: []byte{}, target: &trustmanagerapi.KeyValueTarget{Data: []trustmanagerapi.TargetKeyValue{{PKCS12: trustmanagerapi.PKCS12{}}}}},
 				// NOTE: default passwords are applied by openapi, so the input arguments for the function
 				// will never have a password of "". And we don't have to account for it in the test.
-				{data: []byte{}, additionalFormats: &trustapi.AdditionalFormats{JKS: &trustapi.JKS{Password: ""}}},
-				{data: []byte{}, additionalFormats: &trustapi.AdditionalFormats{PKCS12: &trustapi.PKCS12{}}},
-				// NOTE: default passwords are applied by openapi, so the input arguments for the function
-				// will never have a password of "". And we don't have to account for it in the test.
-				{data: []byte{}, additionalFormats: &trustapi.AdditionalFormats{PKCS12: &trustapi.PKCS12{Password: new("")}}},
+				{data: []byte{}, target: &trustmanagerapi.KeyValueTarget{Data: []trustmanagerapi.TargetKeyValue{{PKCS12: trustmanagerapi.PKCS12{Password: new("")}}}}},
 			},
 			mismatches: []inputArgs{
-				{data: []byte("data"), additionalFormats: nil},
-				{data: []byte{}, additionalFormats: &trustapi.AdditionalFormats{JKS: &trustapi.JKS{Password: "nonempty"}}},
-				{data: []byte{}, additionalFormats: &trustapi.AdditionalFormats{PKCS12: &trustapi.PKCS12{Password: new("nonempty")}}},
+				{data: []byte("data")},
+				{data: []byte{}, target: &trustmanagerapi.KeyValueTarget{Data: []trustmanagerapi.TargetKeyValue{{PKCS12: trustmanagerapi.PKCS12{Password: new("nonempty")}}}}},
 			},
 		},
 		"non-empty data": {
-			input: inputArgs{data: []byte("data"), additionalFormats: nil},
+			input: inputArgs{data: []byte("data")},
 			matches: []inputArgs{
-				{data: []byte("data"), additionalFormats: nil},
-			},
-		},
-		"jks password": {
-			input: inputArgs{data: []byte("data"), additionalFormats: &trustapi.AdditionalFormats{JKS: &trustapi.JKS{Password: "password"}}},
-			matches: []inputArgs{
-				{data: []byte("data"), additionalFormats: &trustapi.AdditionalFormats{JKS: &trustapi.JKS{Password: "password"}}},
-			},
-			mismatches: []inputArgs{
-				{data: []byte("data"), additionalFormats: &trustapi.AdditionalFormats{JKS: &trustapi.JKS{Password: "wrong"}}},
+				{data: []byte("data")},
 			},
 		},
 		"pkcs12 password": {
-			input: inputArgs{data: []byte("data"), additionalFormats: &trustapi.AdditionalFormats{PKCS12: &trustapi.PKCS12{Password: new("password")}}},
+			input: inputArgs{data: []byte("data"), target: &trustmanagerapi.KeyValueTarget{Data: []trustmanagerapi.TargetKeyValue{{PKCS12: trustmanagerapi.PKCS12{Password: new("password")}}}}},
 			matches: []inputArgs{
-				{data: []byte("data"), additionalFormats: &trustapi.AdditionalFormats{PKCS12: &trustapi.PKCS12{Password: new("password")}}},
+				{data: []byte("data"), target: &trustmanagerapi.KeyValueTarget{Data: []trustmanagerapi.TargetKeyValue{{PKCS12: trustmanagerapi.PKCS12{Password: new("password")}}}}},
 			},
 			mismatches: []inputArgs{
-				{data: []byte("data"), additionalFormats: &trustapi.AdditionalFormats{PKCS12: &trustapi.PKCS12{Password: new("wrong")}}},
+				{data: []byte("data"), target: &trustmanagerapi.KeyValueTarget{Data: []trustmanagerapi.TargetKeyValue{{PKCS12: trustmanagerapi.PKCS12{Password: new("wrong")}}}}},
 			},
 		},
 		"target metadata": {
 			input: inputArgs{
-				data:              []byte("data"),
-				additionalFormats: &trustapi.AdditionalFormats{},
-				targetTemplate: &trustapi.TargetTemplate{
-					Metadata: trustapi.TargetMetadata{
+				data: []byte("data"),
+				target: &trustmanagerapi.KeyValueTarget{
+					Metadata: trustmanagerapi.TargetMetadata{
 						Annotations: map[string]string{"annotation1": "value1"},
 						Labels:      map[string]string{"annotation1": "value1"},
 					},
@@ -1058,10 +1045,9 @@ func Test_TrustBundleHash(t *testing.T) {
 			},
 			matches: []inputArgs{
 				{
-					data:              []byte("data"),
-					additionalFormats: &trustapi.AdditionalFormats{},
-					targetTemplate: &trustapi.TargetTemplate{
-						Metadata: trustapi.TargetMetadata{
+					data: []byte("data"),
+					target: &trustmanagerapi.KeyValueTarget{
+						Metadata: trustmanagerapi.TargetMetadata{
 							Annotations: map[string]string{"annotation1": "value1"},
 							Labels:      map[string]string{"annotation1": "value1"},
 						},
@@ -1070,38 +1056,34 @@ func Test_TrustBundleHash(t *testing.T) {
 			},
 			mismatches: []inputArgs{
 				{
-					data:              []byte("data"),
-					additionalFormats: &trustapi.AdditionalFormats{},
-					targetTemplate: &trustapi.TargetTemplate{
-						Metadata: trustapi.TargetMetadata{
+					data: []byte("data"),
+					target: &trustmanagerapi.KeyValueTarget{
+						Metadata: trustmanagerapi.TargetMetadata{
 							Annotations: map[string]string{"annotation1": "value1"},
 						},
 					},
 				},
 				{
-					data:              []byte("data"),
-					additionalFormats: &trustapi.AdditionalFormats{},
-					targetTemplate: &trustapi.TargetTemplate{
-						Metadata: trustapi.TargetMetadata{
+					data: []byte("data"),
+					target: &trustmanagerapi.KeyValueTarget{
+						Metadata: trustmanagerapi.TargetMetadata{
 							Labels: map[string]string{"annotation1": "value1"},
 						},
 					},
 				},
 				{
-					data:              []byte("data"),
-					additionalFormats: &trustapi.AdditionalFormats{},
-					targetTemplate: &trustapi.TargetTemplate{
-						Metadata: trustapi.TargetMetadata{
+					data: []byte("data"),
+					target: &trustmanagerapi.KeyValueTarget{
+						Metadata: trustmanagerapi.TargetMetadata{
 							Annotations: map[string]string{"annotation1": "value2"},
 							Labels:      map[string]string{"annotation1": "value1"},
 						},
 					},
 				},
 				{
-					data:              []byte("data"),
-					additionalFormats: &trustapi.AdditionalFormats{},
-					targetTemplate: &trustapi.TargetTemplate{
-						Metadata: trustapi.TargetMetadata{
+					data: []byte("data"),
+					target: &trustmanagerapi.KeyValueTarget{
+						Metadata: trustmanagerapi.TargetMetadata{
 							Annotations: map[string]string{"annotation1": "value1"},
 							Labels:      map[string]string{"annotation1": "value2"},
 						},
@@ -1115,14 +1097,14 @@ func Test_TrustBundleHash(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			inputHash := TrustBundleHash(test.input.data, test.input.additionalFormats, test.input.targetTemplate)
+			inputHash := TrustBundleHash(test.input.data, test.input.target)
 			for _, match := range test.matches {
-				matchHash := TrustBundleHash(match.data, match.additionalFormats, match.targetTemplate)
+				matchHash := TrustBundleHash(match.data, match.target)
 				assert.Equal(t, inputHash, matchHash)
 			}
 
 			for _, mismatch := range test.mismatches {
-				mismatchHash := TrustBundleHash(mismatch.data, mismatch.additionalFormats, mismatch.targetTemplate)
+				mismatchHash := TrustBundleHash(mismatch.data, mismatch.target)
 				assert.NotEqual(t, inputHash, mismatchHash)
 			}
 		})
@@ -1173,8 +1155,8 @@ func Test_TrustBundleHash_Deterministic(t *testing.T) {
 	//
 	// Note: this needs multiple keys to expose the bug — a single annotation/label
 	// (as in the existing integration tests) cannot trigger the randomization.
-	target := &trustapi.TargetTemplate{
-		Metadata: trustapi.TargetMetadata{
+	target := &trustmanagerapi.KeyValueTarget{
+		Metadata: trustmanagerapi.TargetMetadata{
 			Annotations: map[string]string{
 				"annotation1": "value1",
 				"annotation2": "value2",
@@ -1192,9 +1174,9 @@ func Test_TrustBundleHash_Deterministic(t *testing.T) {
 		},
 	}
 
-	want := TrustBundleHash([]byte("data"), nil, target)
+	want := TrustBundleHash([]byte("data"), target)
 	for i := range 1000 {
-		if got := TrustBundleHash([]byte("data"), nil, target); got != want {
+		if got := TrustBundleHash([]byte("data"), target); got != want {
 			t.Fatalf("TrustBundleHash must be deterministic, but iteration %d produced %q, want %q", i, got, want)
 		}
 	}

--- a/pkg/bundle/internal/target/target_test.go
+++ b/pkg/bundle/internal/target/target_test.go
@@ -38,6 +38,7 @@ import (
 	"software.sslmate.com/src/go-pkcs12"
 
 	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
+	trustmanagerapi "github.com/cert-manager/trust-manager/pkg/apis/trustmanager/v1alpha2"
 	"github.com/cert-manager/trust-manager/pkg/bundle/internal/source"
 	"github.com/cert-manager/trust-manager/pkg/bundle/internal/ssa_client"
 	"github.com/cert-manager/trust-manager/pkg/util"
@@ -61,7 +62,7 @@ const (
 )
 
 func Test_ApplyTarget_ConfigMap(t *testing.T) {
-	bundleHash := TrustBundleHash([]byte(data), nil, nil)
+	bundleHash := TrustBundleHash([]byte(data), nil)
 
 	tests := map[string]struct {
 		object runtime.Object
@@ -72,7 +73,7 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 		// Password of the PKCS12 truststore, empty means the default password
 		pkcs12Password string
 		// Encryption profile of the PKCS12 truststore
-		pkcs12Profile trustapi.PKCS12Profile
+		pkcs12Profile trustmanagerapi.PKCS12Profile
 		// Add annotation to target metadata
 		withTargetAnnotation bool
 		// Add label to target metadata
@@ -108,8 +109,8 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:          bundleName,
 					Namespace:     namespace,
-					Labels:        map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations:   map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:        map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations:   map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					ManagedFields: ssa_client.ManagedFieldEntries(nil, nil),
 				},
 			},
@@ -120,8 +121,8 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:          bundleName,
 					Namespace:     namespace,
-					Labels:        map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations:   map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:        map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations:   map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					ManagedFields: ssa_client.ManagedFieldEntries([]string{key}, nil),
 				},
 				Data: map[string]string{key: data},
@@ -133,12 +134,12 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               bundleName,
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
@@ -153,12 +154,12 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: "wrong hash"},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: "wrong hash"},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               bundleName,
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
@@ -175,12 +176,12 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               bundleName,
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
@@ -199,12 +200,12 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               bundleName,
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
@@ -223,12 +224,12 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               bundleName,
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
@@ -245,12 +246,12 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               bundleName,
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
@@ -272,12 +273,12 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               bundleName,
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
@@ -299,12 +300,12 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: pkcs12ProfileHash(trustapi.LegacyRC2PKCS12Profile)},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: pkcs12ProfileHash(trustmanagerapi.LegacyRC2PKCS12Profile)},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               bundleName,
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
@@ -317,7 +318,7 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 			},
 			withPKCS12:     true,
 			pkcs12Password: customPKCS12Password,
-			pkcs12Profile:  trustapi.Modern2023PKCS12Profile,
+			pkcs12Profile:  trustmanagerapi.Modern2023PKCS12Profile,
 			expPKCS12:      true,
 			expNeedsUpdate: true,
 		},
@@ -326,12 +327,12 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: pkcs12ProfileHash(trustapi.Modern2023PKCS12Profile)},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: pkcs12ProfileHash(trustmanagerapi.Modern2023PKCS12Profile)},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               bundleName,
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
@@ -344,7 +345,7 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 			},
 			withPKCS12:     true,
 			pkcs12Password: customPKCS12Password,
-			pkcs12Profile:  trustapi.Modern2023PKCS12Profile,
+			pkcs12Profile:  trustmanagerapi.Modern2023PKCS12Profile,
 			expNeedsUpdate: false,
 		},
 		"if object exists with correct data, expect no update": {
@@ -352,12 +353,12 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               bundleName,
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
@@ -374,12 +375,12 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               bundleName,
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
@@ -398,12 +399,12 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               bundleName,
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
@@ -422,19 +423,19 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               bundleName,
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
 						},
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               "another-bundle",
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
@@ -454,12 +455,12 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               bundleName,
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
@@ -478,12 +479,12 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               bundleName,
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
@@ -533,33 +534,33 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 			err := certPool.AddCertsFromPEM([]byte(data))
 			assert.NoError(t, err)
 
-			spec := trustapi.BundleSpec{
-				Target: trustapi.BundleTarget{
-					ConfigMap:         &trustapi.TargetTemplate{Key: key},
-					AdditionalFormats: &trustapi.AdditionalFormats{},
+			var annotations map[string]string
+			spec := trustmanagerapi.BundleSpec{
+				Target: trustmanagerapi.BundleTarget{
+					ConfigMap: &trustmanagerapi.KeyValueTarget{
+						Data: []trustmanagerapi.TargetKeyValue{{Key: key}},
+					},
 				},
 			}
 			resolvedBundle := source.BundleData{CertPool: certPool}
 			if tt.withJKS {
-				spec.Target.AdditionalFormats.JKS = &trustapi.JKS{
-					KeySelector: trustapi.KeySelector{
-						Key: jksKey,
-					},
-					Password: trustapi.DefaultJKSPassword,
-				}
+				spec.Target.ConfigMap.Data = append(spec.Target.ConfigMap.Data, trustmanagerapi.TargetKeyValue{
+					Key:    jksKey,
+					Format: trustmanagerapi.BundleFormatPKCS12,
+					PKCS12: trustmanagerapi.PKCS12{Password: ptr.To(trustapi.DefaultJKSPassword)},
+				})
+				annotations = map[string]string{trustapi.AnnotationKeyJKSKey: jksKey}
 			}
-			pkcs12Password := trustapi.DefaultPKCS12Password
+			pkcs12Password := trustmanagerapi.DefaultPKCS12Password
 			if tt.pkcs12Password != "" {
 				pkcs12Password = tt.pkcs12Password
 			}
 			if tt.withPKCS12 {
-				spec.Target.AdditionalFormats.PKCS12 = &trustapi.PKCS12{
-					KeySelector: trustapi.KeySelector{
-						Key: pkcs12Key,
-					},
-					Password: new(pkcs12Password),
-					Profile:  tt.pkcs12Profile,
-				}
+				spec.Target.ConfigMap.Data = append(spec.Target.ConfigMap.Data, trustmanagerapi.TargetKeyValue{
+					Key:    pkcs12Key,
+					Format: trustmanagerapi.BundleFormatPKCS12,
+					PKCS12: trustmanagerapi.PKCS12{Password: new(pkcs12Password), Profile: tt.pkcs12Profile},
+				})
 			}
 			if tt.withTargetAnnotation {
 				spec.Target.ConfigMap.Metadata.Annotations = map[string]string{targetAnnotation: "true"}
@@ -572,8 +573,8 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 			needsUpdate, err := r.ApplyTarget(ctx, Resource{
 				Kind:           KindConfigMap,
 				NamespacedName: types.NamespacedName{Name: bundleName, Namespace: namespace},
-			}, &trustapi.Bundle{
-				ObjectMeta: metav1.ObjectMeta{Name: bundleName},
+			}, &trustmanagerapi.ClusterBundle{
+				ObjectMeta: metav1.ObjectMeta{Name: bundleName, Annotations: annotations},
 				Spec:       spec,
 			}, resolvedBundle)
 			assert.NoError(t, err)
@@ -591,8 +592,8 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 
 				expectedOwnerReference := metav1applyconfig.
 					OwnerReference().
-					WithAPIVersion(trustapi.SchemeGroupVersion.String()).
-					WithKind(trustapi.BundleKind).
+					WithAPIVersion(trustmanagerapi.SchemeGroupVersion.String()).
+					WithKind(trustmanagerapi.ClusterBundleKind).
 					WithName(bundleName).
 					WithUID("").
 					WithBlockOwnerDeletion(true).
@@ -625,7 +626,7 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 }
 
 func Test_ApplyTarget_Secret(t *testing.T) {
-	bundleHash := TrustBundleHash([]byte(data), nil, nil)
+	bundleHash := TrustBundleHash([]byte(data), nil)
 
 	tests := map[string]struct {
 		object runtime.Object
@@ -636,7 +637,7 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 		// Password of the PKCS12 truststore, empty means the default password
 		pkcs12Password string
 		// Encryption profile of the PKCS12 truststore
-		pkcs12Profile trustapi.PKCS12Profile
+		pkcs12Profile trustmanagerapi.PKCS12Profile
 		// Expect JKS to exist in the secret at the end of the sync.
 		expJKS bool
 		// Expect PKCS12 to exist in the secret at the end of the sync.
@@ -664,8 +665,8 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:          bundleName,
 					Namespace:     namespace,
-					Labels:        map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations:   map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:        map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations:   map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					ManagedFields: ssa_client.ManagedFieldEntries(nil, nil),
 				},
 			},
@@ -676,8 +677,8 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:          bundleName,
 					Namespace:     namespace,
-					Labels:        map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations:   map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:        map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations:   map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					ManagedFields: ssa_client.ManagedFieldEntries([]string{key}, nil),
 				},
 				Data: map[string][]byte{key: []byte(data)},
@@ -689,12 +690,12 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               bundleName,
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
@@ -709,12 +710,12 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: "wrong hash"},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: "wrong hash"},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               bundleName,
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
@@ -731,12 +732,12 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               bundleName,
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
@@ -755,12 +756,12 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               bundleName,
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
@@ -779,12 +780,12 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               bundleName,
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
@@ -801,12 +802,12 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               bundleName,
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
@@ -828,12 +829,12 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               bundleName,
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
@@ -855,12 +856,12 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: pkcs12ProfileHash(trustapi.LegacyRC2PKCS12Profile)},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: pkcs12ProfileHash(trustmanagerapi.LegacyRC2PKCS12Profile)},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               bundleName,
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
@@ -875,7 +876,7 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 			},
 			withPKCS12:     true,
 			pkcs12Password: customPKCS12Password,
-			pkcs12Profile:  trustapi.Modern2023PKCS12Profile,
+			pkcs12Profile:  trustmanagerapi.Modern2023PKCS12Profile,
 			expPKCS12:      true,
 			expNeedsUpdate: true,
 		},
@@ -884,12 +885,12 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: pkcs12ProfileHash(trustapi.Modern2023PKCS12Profile)},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: pkcs12ProfileHash(trustmanagerapi.Modern2023PKCS12Profile)},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               bundleName,
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
@@ -904,7 +905,7 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 			},
 			withPKCS12:     true,
 			pkcs12Password: customPKCS12Password,
-			pkcs12Profile:  trustapi.Modern2023PKCS12Profile,
+			pkcs12Profile:  trustmanagerapi.Modern2023PKCS12Profile,
 			expNeedsUpdate: false,
 		},
 		"if object exists with correct data, expect no update": {
@@ -912,12 +913,12 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               bundleName,
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
@@ -934,12 +935,12 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               bundleName,
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
@@ -958,12 +959,12 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               bundleName,
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
@@ -982,19 +983,19 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:        bundleName,
 					Namespace:   namespace,
-					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
-					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: bundleHash},
+					Labels:      map[string]string{trustmanagerapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustmanagerapi.BundleHashAnnotationKey: bundleHash},
 					OwnerReferences: []metav1.OwnerReference{
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               bundleName,
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
 						},
 						{
-							Kind:               "Bundle",
-							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Kind:               trustmanagerapi.ClusterBundleKind,
+							APIVersion:         trustmanagerapi.SchemeGroupVersion.String(),
 							Name:               "another-bundle",
 							Controller:         new(true),
 							BlockOwnerDeletion: new(true),
@@ -1045,41 +1046,41 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 			err := certPool.AddCertsFromPEM([]byte(data))
 			assert.NoError(t, err)
 
-			spec := trustapi.BundleSpec{
-				Target: trustapi.BundleTarget{
-					Secret:            &trustapi.TargetTemplate{Key: key},
-					AdditionalFormats: &trustapi.AdditionalFormats{},
+			var annotations map[string]string
+			spec := trustmanagerapi.BundleSpec{
+				Target: trustmanagerapi.BundleTarget{
+					Secret: &trustmanagerapi.KeyValueTarget{
+						Data: []trustmanagerapi.TargetKeyValue{{Key: key}},
+					},
 				},
 			}
 			resolvedBundle := source.BundleData{CertPool: certPool}
 			if tt.withJKS {
-				spec.Target.AdditionalFormats.JKS = &trustapi.JKS{
-					KeySelector: trustapi.KeySelector{
-						Key: jksKey,
-					},
-					Password: trustapi.DefaultJKSPassword,
-				}
+				spec.Target.Secret.Data = append(spec.Target.Secret.Data, trustmanagerapi.TargetKeyValue{
+					Key:    jksKey,
+					Format: trustmanagerapi.BundleFormatPKCS12,
+					PKCS12: trustmanagerapi.PKCS12{Password: ptr.To(trustapi.DefaultJKSPassword)},
+				})
+				annotations = map[string]string{trustapi.AnnotationKeyJKSKey: jksKey}
 			}
-			pkcs12Password := trustapi.DefaultPKCS12Password
+			pkcs12Password := trustmanagerapi.DefaultPKCS12Password
 			if tt.pkcs12Password != "" {
 				pkcs12Password = tt.pkcs12Password
 			}
 			if tt.withPKCS12 {
-				spec.Target.AdditionalFormats.PKCS12 = &trustapi.PKCS12{
-					KeySelector: trustapi.KeySelector{
-						Key: pkcs12Key,
-					},
-					Password: new(pkcs12Password),
-					Profile:  tt.pkcs12Profile,
-				}
+				spec.Target.Secret.Data = append(spec.Target.Secret.Data, trustmanagerapi.TargetKeyValue{
+					Key:    pkcs12Key,
+					Format: trustmanagerapi.BundleFormatPKCS12,
+					PKCS12: trustmanagerapi.PKCS12{Password: new(pkcs12Password), Profile: tt.pkcs12Profile},
+				})
 			}
 
 			_, ctx := ktesting.NewTestContext(t)
 			needsUpdate, err := r.ApplyTarget(ctx, Resource{
 				Kind:           KindSecret,
 				NamespacedName: types.NamespacedName{Name: bundleName, Namespace: namespace},
-			}, &trustapi.Bundle{
-				ObjectMeta: metav1.ObjectMeta{Name: bundleName},
+			}, &trustmanagerapi.ClusterBundle{
+				ObjectMeta: metav1.ObjectMeta{Name: bundleName, Annotations: annotations},
 				Spec:       spec,
 			}, resolvedBundle)
 			assert.NoError(t, err)
@@ -1097,8 +1098,8 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 
 				expectedOwnerReference := metav1applyconfig.
 					OwnerReference().
-					WithAPIVersion(trustapi.SchemeGroupVersion.String()).
-					WithKind(trustapi.BundleKind).
+					WithAPIVersion(trustmanagerapi.SchemeGroupVersion.String()).
+					WithKind(trustmanagerapi.ClusterBundleKind).
 					WithName(bundleName).
 					WithUID("").
 					WithBlockOwnerDeletion(true).
@@ -1129,41 +1130,38 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 // Kubernetes UIs. The log allows verifying from the logs alone that additional formats
 // were synced (see issue #800).
 func Test_ApplyTarget_LogsAppliedKeys(t *testing.T) {
-	additionalFormats := &trustapi.AdditionalFormats{
-		JKS: &trustapi.JKS{
-			KeySelector: trustapi.KeySelector{Key: jksKey},
-			Password:    trustapi.DefaultJKSPassword,
-		},
-		PKCS12: &trustapi.PKCS12{
-			KeySelector: trustapi.KeySelector{Key: pkcs12Key},
-			Password:    ptr.To(trustapi.DefaultPKCS12Password),
-		},
+	keyValueTarget := &trustmanagerapi.KeyValueTarget{
+		Data: []trustmanagerapi.TargetKeyValue{{
+			Key: key,
+		}, {
+			Key:    pkcs12Key,
+			Format: trustmanagerapi.BundleFormatPKCS12,
+			PKCS12: trustmanagerapi.PKCS12{Password: new(trustmanagerapi.DefaultPKCS12Password)},
+		}},
 	}
 
 	tests := map[string]struct {
 		kind       Kind
-		target     trustapi.BundleTarget
+		target     trustmanagerapi.BundleTarget
 		expLogArgs []any
 	}{
 		"ConfigMap target should log data and binaryData keys": {
 			kind: KindConfigMap,
-			target: trustapi.BundleTarget{
-				ConfigMap:         &trustapi.TargetTemplate{Key: key},
-				AdditionalFormats: additionalFormats,
+			target: trustmanagerapi.BundleTarget{
+				ConfigMap: keyValueTarget,
 			},
 			expLogArgs: []any{
 				"dataKeys", []string{key},
-				"binaryDataKeys", []string{jksKey, pkcs12Key},
+				"binaryDataKeys", []string{pkcs12Key},
 			},
 		},
 		"Secret target should log data keys": {
 			kind: KindSecret,
-			target: trustapi.BundleTarget{
-				Secret:            &trustapi.TargetTemplate{Key: key},
-				AdditionalFormats: additionalFormats,
+			target: trustmanagerapi.BundleTarget{
+				Secret: keyValueTarget,
 			},
 			expLogArgs: []any{
-				"dataKeys", []string{jksKey, pkcs12Key, key},
+				"dataKeys", []string{pkcs12Key, key},
 			},
 		},
 	}
@@ -1194,9 +1192,9 @@ func Test_ApplyTarget_LogsAppliedKeys(t *testing.T) {
 			synced, err := r.ApplyTarget(ctx, Resource{
 				Kind:           tt.kind,
 				NamespacedName: types.NamespacedName{Name: bundleName, Namespace: namespace},
-			}, &trustapi.Bundle{
+			}, &trustmanagerapi.ClusterBundle{
 				ObjectMeta: metav1.ObjectMeta{Name: bundleName},
-				Spec:       trustapi.BundleSpec{Target: tt.target},
+				Spec:       trustmanagerapi.BundleSpec{Target: tt.target},
 			}, source.BundleData{CertPool: certPool})
 			assert.NoError(t, err)
 			assert.True(t, synced)
@@ -1221,9 +1219,8 @@ func Test_ApplyTarget_LogsAppliedKeys(t *testing.T) {
 
 func Test_TrustBundleHash(t *testing.T) {
 	type inputArgs struct {
-		data              []byte
-		additionalFormats *trustapi.AdditionalFormats
-		targetTemplate    *trustapi.TargetTemplate
+		data   []byte
+		target *trustmanagerapi.KeyValueTarget
 	}
 	tests := map[string]struct {
 		input      inputArgs
@@ -1231,65 +1228,50 @@ func Test_TrustBundleHash(t *testing.T) {
 		mismatches []inputArgs
 	}{
 		"empty data": {
-			input: inputArgs{data: []byte{}, additionalFormats: nil},
+			input: inputArgs{data: []byte{}},
 			matches: []inputArgs{
-				{data: []byte{}, additionalFormats: nil},
-				{data: []byte{}, additionalFormats: &trustapi.AdditionalFormats{}},
-				{data: []byte{}, additionalFormats: &trustapi.AdditionalFormats{JKS: &trustapi.JKS{}}},
+				{data: []byte{}},
+				{data: []byte{}, target: &trustmanagerapi.KeyValueTarget{}},
+				{data: []byte{}, target: &trustmanagerapi.KeyValueTarget{Data: []trustmanagerapi.TargetKeyValue{{PKCS12: trustmanagerapi.PKCS12{}}}}},
 				// NOTE: default passwords are applied by openapi, so the input arguments for the function
 				// will never have a password of "". And we don't have to account for it in the test.
-				{data: []byte{}, additionalFormats: &trustapi.AdditionalFormats{JKS: &trustapi.JKS{Password: ""}}},
-				{data: []byte{}, additionalFormats: &trustapi.AdditionalFormats{PKCS12: &trustapi.PKCS12{}}},
-				// NOTE: default passwords are applied by openapi, so the input arguments for the function
-				// will never have a password of "". And we don't have to account for it in the test.
-				{data: []byte{}, additionalFormats: &trustapi.AdditionalFormats{PKCS12: &trustapi.PKCS12{Password: new("")}}},
+				{data: []byte{}, target: &trustmanagerapi.KeyValueTarget{Data: []trustmanagerapi.TargetKeyValue{{PKCS12: trustmanagerapi.PKCS12{Password: new("")}}}}},
 			},
 			mismatches: []inputArgs{
-				{data: []byte("data"), additionalFormats: nil},
-				{data: []byte{}, additionalFormats: &trustapi.AdditionalFormats{JKS: &trustapi.JKS{Password: "nonempty"}}},
-				{data: []byte{}, additionalFormats: &trustapi.AdditionalFormats{PKCS12: &trustapi.PKCS12{Password: new("nonempty")}}},
+				{data: []byte("data")},
+				{data: []byte{}, target: &trustmanagerapi.KeyValueTarget{Data: []trustmanagerapi.TargetKeyValue{{PKCS12: trustmanagerapi.PKCS12{Password: new("nonempty")}}}}},
 			},
 		},
 		"non-empty data": {
-			input: inputArgs{data: []byte("data"), additionalFormats: nil},
+			input: inputArgs{data: []byte("data")},
 			matches: []inputArgs{
-				{data: []byte("data"), additionalFormats: nil},
-			},
-		},
-		"jks password": {
-			input: inputArgs{data: []byte("data"), additionalFormats: &trustapi.AdditionalFormats{JKS: &trustapi.JKS{Password: "password"}}},
-			matches: []inputArgs{
-				{data: []byte("data"), additionalFormats: &trustapi.AdditionalFormats{JKS: &trustapi.JKS{Password: "password"}}},
-			},
-			mismatches: []inputArgs{
-				{data: []byte("data"), additionalFormats: &trustapi.AdditionalFormats{JKS: &trustapi.JKS{Password: "wrong"}}},
+				{data: []byte("data")},
 			},
 		},
 		"pkcs12 password": {
-			input: inputArgs{data: []byte("data"), additionalFormats: &trustapi.AdditionalFormats{PKCS12: &trustapi.PKCS12{Password: new("password")}}},
+			input: inputArgs{data: []byte("data"), target: &trustmanagerapi.KeyValueTarget{Data: []trustmanagerapi.TargetKeyValue{{PKCS12: trustmanagerapi.PKCS12{Password: new("password")}}}}},
 			matches: []inputArgs{
-				{data: []byte("data"), additionalFormats: &trustapi.AdditionalFormats{PKCS12: &trustapi.PKCS12{Password: new("password")}}},
+				{data: []byte("data"), target: &trustmanagerapi.KeyValueTarget{Data: []trustmanagerapi.TargetKeyValue{{PKCS12: trustmanagerapi.PKCS12{Password: new("password")}}}}},
 			},
 			mismatches: []inputArgs{
-				{data: []byte("data"), additionalFormats: &trustapi.AdditionalFormats{PKCS12: &trustapi.PKCS12{Password: new("wrong")}}},
+				{data: []byte("data"), target: &trustmanagerapi.KeyValueTarget{Data: []trustmanagerapi.TargetKeyValue{{PKCS12: trustmanagerapi.PKCS12{Password: new("wrong")}}}}},
 			},
 		},
 		"pkcs12 profile": {
-			input: inputArgs{data: []byte("data"), additionalFormats: &trustapi.AdditionalFormats{PKCS12: &trustapi.PKCS12{Password: new("password"), Profile: trustapi.LegacyRC2PKCS12Profile}}},
+			input: inputArgs{data: []byte("data"), target: &trustmanagerapi.KeyValueTarget{Data: []trustmanagerapi.TargetKeyValue{{PKCS12: trustmanagerapi.PKCS12{Password: new("password"), Profile: trustmanagerapi.LegacyRC2PKCS12Profile}}}}},
 			matches: []inputArgs{
-				{data: []byte("data"), additionalFormats: &trustapi.AdditionalFormats{PKCS12: &trustapi.PKCS12{Password: new("password"), Profile: trustapi.LegacyRC2PKCS12Profile}}},
+				{data: []byte("data"), target: &trustmanagerapi.KeyValueTarget{Data: []trustmanagerapi.TargetKeyValue{{PKCS12: trustmanagerapi.PKCS12{Password: new("password"), Profile: trustmanagerapi.LegacyRC2PKCS12Profile}}}}},
 			},
 			mismatches: []inputArgs{
-				{data: []byte("data"), additionalFormats: &trustapi.AdditionalFormats{PKCS12: &trustapi.PKCS12{Password: new("password"), Profile: trustapi.LegacyDESPKCS12Profile}}},
-				{data: []byte("data"), additionalFormats: &trustapi.AdditionalFormats{PKCS12: &trustapi.PKCS12{Password: new("password"), Profile: trustapi.Modern2023PKCS12Profile}}},
+				{data: []byte("data"), target: &trustmanagerapi.KeyValueTarget{Data: []trustmanagerapi.TargetKeyValue{{PKCS12: trustmanagerapi.PKCS12{Password: new("password"), Profile: trustmanagerapi.LegacyDESPKCS12Profile}}}}},
+				{data: []byte("data"), target: &trustmanagerapi.KeyValueTarget{Data: []trustmanagerapi.TargetKeyValue{{PKCS12: trustmanagerapi.PKCS12{Password: new("password"), Profile: trustmanagerapi.Modern2023PKCS12Profile}}}}},
 			},
 		},
 		"target metadata": {
 			input: inputArgs{
-				data:              []byte("data"),
-				additionalFormats: &trustapi.AdditionalFormats{},
-				targetTemplate: &trustapi.TargetTemplate{
-					Metadata: trustapi.TargetMetadata{
+				data: []byte("data"),
+				target: &trustmanagerapi.KeyValueTarget{
+					Metadata: trustmanagerapi.TargetMetadata{
 						Annotations: map[string]string{"annotation1": "value1"},
 						Labels:      map[string]string{"annotation1": "value1"},
 					},
@@ -1297,10 +1279,9 @@ func Test_TrustBundleHash(t *testing.T) {
 			},
 			matches: []inputArgs{
 				{
-					data:              []byte("data"),
-					additionalFormats: &trustapi.AdditionalFormats{},
-					targetTemplate: &trustapi.TargetTemplate{
-						Metadata: trustapi.TargetMetadata{
+					data: []byte("data"),
+					target: &trustmanagerapi.KeyValueTarget{
+						Metadata: trustmanagerapi.TargetMetadata{
 							Annotations: map[string]string{"annotation1": "value1"},
 							Labels:      map[string]string{"annotation1": "value1"},
 						},
@@ -1309,38 +1290,34 @@ func Test_TrustBundleHash(t *testing.T) {
 			},
 			mismatches: []inputArgs{
 				{
-					data:              []byte("data"),
-					additionalFormats: &trustapi.AdditionalFormats{},
-					targetTemplate: &trustapi.TargetTemplate{
-						Metadata: trustapi.TargetMetadata{
+					data: []byte("data"),
+					target: &trustmanagerapi.KeyValueTarget{
+						Metadata: trustmanagerapi.TargetMetadata{
 							Annotations: map[string]string{"annotation1": "value1"},
 						},
 					},
 				},
 				{
-					data:              []byte("data"),
-					additionalFormats: &trustapi.AdditionalFormats{},
-					targetTemplate: &trustapi.TargetTemplate{
-						Metadata: trustapi.TargetMetadata{
+					data: []byte("data"),
+					target: &trustmanagerapi.KeyValueTarget{
+						Metadata: trustmanagerapi.TargetMetadata{
 							Labels: map[string]string{"annotation1": "value1"},
 						},
 					},
 				},
 				{
-					data:              []byte("data"),
-					additionalFormats: &trustapi.AdditionalFormats{},
-					targetTemplate: &trustapi.TargetTemplate{
-						Metadata: trustapi.TargetMetadata{
+					data: []byte("data"),
+					target: &trustmanagerapi.KeyValueTarget{
+						Metadata: trustmanagerapi.TargetMetadata{
 							Annotations: map[string]string{"annotation1": "value2"},
 							Labels:      map[string]string{"annotation1": "value1"},
 						},
 					},
 				},
 				{
-					data:              []byte("data"),
-					additionalFormats: &trustapi.AdditionalFormats{},
-					targetTemplate: &trustapi.TargetTemplate{
-						Metadata: trustapi.TargetMetadata{
+					data: []byte("data"),
+					target: &trustmanagerapi.KeyValueTarget{
+						Metadata: trustmanagerapi.TargetMetadata{
 							Annotations: map[string]string{"annotation1": "value1"},
 							Labels:      map[string]string{"annotation1": "value2"},
 						},
@@ -1354,14 +1331,14 @@ func Test_TrustBundleHash(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			inputHash := TrustBundleHash(test.input.data, test.input.additionalFormats, test.input.targetTemplate)
+			inputHash := TrustBundleHash(test.input.data, test.input.target)
 			for _, match := range test.matches {
-				matchHash := TrustBundleHash(match.data, match.additionalFormats, match.targetTemplate)
+				matchHash := TrustBundleHash(match.data, match.target)
 				assert.Equal(t, inputHash, matchHash)
 			}
 
 			for _, mismatch := range test.mismatches {
-				mismatchHash := TrustBundleHash(mismatch.data, mismatch.additionalFormats, mismatch.targetTemplate)
+				mismatchHash := TrustBundleHash(mismatch.data, mismatch.target)
 				assert.NotEqual(t, inputHash, mismatchHash)
 			}
 		})
@@ -1393,14 +1370,14 @@ func assertJKSData(t *testing.T, binData []byte, password string) {
 
 // pkcs12ProfileHash returns the hash a target would carry after being synced with the given
 // PKCS12 profile, so a test case can start from a target synced with an older profile.
-func pkcs12ProfileHash(profile trustapi.PKCS12Profile) string {
-	return TrustBundleHash([]byte(data), &trustapi.AdditionalFormats{
-		PKCS12: &trustapi.PKCS12{
-			KeySelector: trustapi.KeySelector{Key: pkcs12Key},
-			Password:    new(customPKCS12Password),
-			Profile:     profile,
-		},
-	}, nil)
+func pkcs12ProfileHash(profile trustmanagerapi.PKCS12Profile) string {
+	return TrustBundleHash([]byte(data), &trustmanagerapi.KeyValueTarget{
+		Data: []trustmanagerapi.TargetKeyValue{{
+			Key:    pkcs12Key,
+			Format: trustmanagerapi.BundleFormatPKCS12,
+			PKCS12: trustmanagerapi.PKCS12{Password: new(customPKCS12Password), Profile: profile},
+		}},
+	})
 }
 
 func assertPKCS12Data(t *testing.T, binData []byte, password string) {
@@ -1424,8 +1401,8 @@ func Test_TrustBundleHash_Deterministic(t *testing.T) {
 	//
 	// Note: this needs multiple keys to expose the bug — a single annotation/label
 	// (as in the existing integration tests) cannot trigger the randomization.
-	target := &trustapi.TargetTemplate{
-		Metadata: trustapi.TargetMetadata{
+	target := &trustmanagerapi.KeyValueTarget{
+		Metadata: trustmanagerapi.TargetMetadata{
 			Annotations: map[string]string{
 				"annotation1": "value1",
 				"annotation2": "value2",
@@ -1443,9 +1420,9 @@ func Test_TrustBundleHash_Deterministic(t *testing.T) {
 		},
 	}
 
-	want := TrustBundleHash([]byte("data"), nil, target)
+	want := TrustBundleHash([]byte("data"), target)
 	for i := range 1000 {
-		if got := TrustBundleHash([]byte("data"), nil, target); got != want {
+		if got := TrustBundleHash([]byte("data"), target); got != want {
 			t.Fatalf("TrustBundleHash must be deterministic, but iteration %d produced %q, want %q", i, got, want)
 		}
 	}

--- a/pkg/bundle/internal/truststore/types.go
+++ b/pkg/bundle/internal/truststore/types.go
@@ -25,7 +25,7 @@ import (
 	"github.com/pavlo-v-chernykh/keystore-go/v4"
 	"software.sslmate.com/src/go-pkcs12"
 
-	"github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
+	trustmanagerapi "github.com/cert-manager/trust-manager/pkg/apis/trustmanager/v1alpha2"
 	"github.com/cert-manager/trust-manager/pkg/util"
 )
 
@@ -82,13 +82,13 @@ func (e jksEncoder) Encode(trustBundle *util.CertPool) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func NewPKCS12Encoder(password string, profile v1alpha1.PKCS12Profile) Encoder {
+func NewPKCS12Encoder(password string, profile trustmanagerapi.PKCS12Profile) Encoder {
 	return &pkcs12Encoder{password: password, profile: profile}
 }
 
 type pkcs12Encoder struct {
 	password string
-	profile  v1alpha1.PKCS12Profile
+	profile  trustmanagerapi.PKCS12Profile
 }
 
 func (e pkcs12Encoder) Encode(trustBundle *util.CertPool) ([]byte, error) {
@@ -102,14 +102,14 @@ func (e pkcs12Encoder) Encode(trustBundle *util.CertPool) ([]byte, error) {
 
 	var encoder *pkcs12.Encoder
 	switch e.profile {
-	case v1alpha1.LegacyRC2PKCS12Profile:
+	case trustmanagerapi.LegacyRC2PKCS12Profile:
 		encoder = pkcs12.LegacyRC2
-	case v1alpha1.LegacyDESPKCS12Profile:
+	case trustmanagerapi.LegacyDESPKCS12Profile:
 		encoder = pkcs12.LegacyDES
-	case v1alpha1.Modern2023PKCS12Profile:
+	case trustmanagerapi.Modern2023PKCS12Profile:
 		encoder = pkcs12.Modern2023
 	default: // Default when PKCS12 Profile is unpopulated
-		encoder = pkcs12.LegacyRC2
+		encoder = pkcs12.LegacyDES
 	}
 
 	if e.password == "" {

--- a/pkg/bundle/util.go
+++ b/pkg/bundle/util.go
@@ -19,7 +19,7 @@ package bundle
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
+	trustmanagerapi "github.com/cert-manager/trust-manager/pkg/apis/trustmanager/v1alpha2"
 )
 
 // bundleHasCondition returns true if the bundle has an exact matching condition.
@@ -91,7 +91,7 @@ func (b *bundle) setBundleCondition(
 // reflects the defaultCAVersion represented by requiredID.
 // Returns true if the bundle status needs updating.
 func (b *bundle) setBundleStatusDefaultCAVersion(
-	bundleStatus *trustapi.BundleStatus,
+	bundleStatus *trustmanagerapi.BundleStatus,
 	requiredID string,
 ) bool {
 	currentVersion := bundleStatus.DefaultCAPackageVersion

--- a/pkg/bundle/util_test.go
+++ b/pkg/bundle/util_test.go
@@ -24,7 +24,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	fakeclock "k8s.io/utils/clock/testing"
 
-	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
+	trustmanagerapi "github.com/cert-manager/trust-manager/pkg/apis/trustmanager/v1alpha2"
 )
 
 func Test_bundleHasCondition(t *testing.T) {
@@ -187,11 +187,11 @@ func Test_setBundleCondition(t *testing.T) {
 	for name, test := range tests {
 		t.Run(name, func(t *testing.T) {
 			b := &bundle{clock: fixedclock}
-			bundle := &trustapi.Bundle{
+			bundle := &trustmanagerapi.ClusterBundle{
 				ObjectMeta: metav1.ObjectMeta{
 					Generation: bundleGeneration,
 				},
-				Status: trustapi.BundleStatus{
+				Status: trustmanagerapi.BundleStatus{
 					Conditions: test.existingConditions,
 				},
 			}
@@ -223,14 +223,14 @@ func Test_setBundleStatusDefaultCAVersion(t *testing.T) {
 	)
 
 	tests := map[string]struct {
-		inputBundle                     trustapi.Bundle
+		inputBundle                     trustmanagerapi.ClusterBundle
 		requiredID                      string
 		expectedDefaultCAPackageVersion string
 		expectUpdate                    bool
 	}{
 		"requiredID empty but status populated; should update": {
-			inputBundle: trustapi.Bundle{
-				Status: trustapi.BundleStatus{
+			inputBundle: trustmanagerapi.ClusterBundle{
+				Status: trustmanagerapi.BundleStatus{
 					DefaultCAPackageVersion: "abc123",
 				},
 			},
@@ -239,8 +239,8 @@ func Test_setBundleStatusDefaultCAVersion(t *testing.T) {
 			expectUpdate:                    true,
 		},
 		"requiredID empty and status empty; should not update": {
-			inputBundle: trustapi.Bundle{
-				Status: trustapi.BundleStatus{
+			inputBundle: trustmanagerapi.ClusterBundle{
+				Status: trustmanagerapi.BundleStatus{
 					DefaultCAPackageVersion: "",
 				},
 			},
@@ -249,8 +249,8 @@ func Test_setBundleStatusDefaultCAVersion(t *testing.T) {
 			expectUpdate:                    false,
 		},
 		"requiredID not empty and status nil; should update": {
-			inputBundle: trustapi.Bundle{
-				Status: trustapi.BundleStatus{
+			inputBundle: trustmanagerapi.ClusterBundle{
+				Status: trustmanagerapi.BundleStatus{
 					DefaultCAPackageVersion: "",
 				},
 			},
@@ -259,8 +259,8 @@ func Test_setBundleStatusDefaultCAVersion(t *testing.T) {
 			expectUpdate:                    true,
 		},
 		"requiredID not empty and status populated but incorrect; should update": {
-			inputBundle: trustapi.Bundle{
-				Status: trustapi.BundleStatus{
+			inputBundle: trustmanagerapi.ClusterBundle{
+				Status: trustmanagerapi.BundleStatus{
 					DefaultCAPackageVersion: "def456",
 				},
 			},
@@ -269,8 +269,8 @@ func Test_setBundleStatusDefaultCAVersion(t *testing.T) {
 			expectUpdate:                    true,
 		},
 		"requiredID not empty and status populated currently; should not update": {
-			inputBundle: trustapi.Bundle{
-				Status: trustapi.BundleStatus{
+			inputBundle: trustmanagerapi.ClusterBundle{
+				Status: trustmanagerapi.BundleStatus{
 					DefaultCAPackageVersion: "abc123",
 				},
 			},

--- a/pkg/webhook/validation.go
+++ b/pkg/webhook/validation.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:staticcheck // SA1019 staticcheck will warn about our use of the deprecated Bundle resource, but we still need to validate it so people can migrate
 package webhook
 
 import (

--- a/pkg/webhook/validation_test.go
+++ b/pkg/webhook/validation_test.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:staticcheck // SA1019 staticcheck will warn about our use of the deprecated Bundle resource, but we still need to test it so people can migrate
 package webhook
 
 import (

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:staticcheck // SA1019 staticcheck will warn about our use of the deprecated Bundle resource, but we still need to validate it so people can migrate
 package webhook
 
 import (

--- a/test/env/data.go
+++ b/test/env/data.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:staticcheck // SA1019 staticcheck will warn about our use of the deprecated Bundle resource, but we still need to test it so people can migrate
 package env
 
 import (

--- a/test/gen/bundle.go
+++ b/test/gen/bundle.go
@@ -19,18 +19,18 @@ package gen
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
+	trustmanagerapi "github.com/cert-manager/trust-manager/pkg/apis/trustmanager/v1alpha2"
 )
 
 // BundleModifier is used to modify a Bundle object in-line. Intended for
 // testing.
-type BundleModifier func(*trustapi.Bundle)
+type BundleModifier func(bundle *trustmanagerapi.ClusterBundle)
 
 // Bundle constructs a Bundle object with BundleModifiers which can be defined
 // in-line. Intended for testing.
-func Bundle(name string, mods ...BundleModifier) *trustapi.Bundle {
-	bundle := &trustapi.Bundle{
-		TypeMeta: metav1.TypeMeta{Kind: "Bundle", APIVersion: "trust.cert-manager.io/v1alpha1"},
+func Bundle(name string, mods ...BundleModifier) *trustmanagerapi.ClusterBundle {
+	bundle := &trustmanagerapi.ClusterBundle{
+		TypeMeta: metav1.TypeMeta{Kind: "ClusterBundle", APIVersion: "trust-manager.io/v1alpha2"},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        name,
 			Annotations: make(map[string]string),
@@ -45,7 +45,7 @@ func Bundle(name string, mods ...BundleModifier) *trustapi.Bundle {
 
 // BundleFrom deep copies a Bundle object and applies the given
 // BundleModifiers.
-func BundleFrom(bundle *trustapi.Bundle, mods ...BundleModifier) *trustapi.Bundle {
+func BundleFrom(bundle *trustmanagerapi.ClusterBundle, mods ...BundleModifier) *trustmanagerapi.ClusterBundle {
 	bundle = bundle.DeepCopy()
 	for _, mod := range mods {
 		mod(bundle)
@@ -54,22 +54,22 @@ func BundleFrom(bundle *trustapi.Bundle, mods ...BundleModifier) *trustapi.Bundl
 }
 
 // SetBundleStatus sets the Bundle object's status as a BundleModifier.
-func SetBundleStatus(status trustapi.BundleStatus) BundleModifier {
-	return func(bundle *trustapi.Bundle) {
+func SetBundleStatus(status trustmanagerapi.BundleStatus) BundleModifier {
+	return func(bundle *trustmanagerapi.ClusterBundle) {
 		bundle.Status = status
 	}
 }
 
-func SetBundleTargetAdditionalFormats(formats trustapi.AdditionalFormats) BundleModifier {
-	return func(bundle *trustapi.Bundle) {
-		bundle.Spec.Target.AdditionalFormats = &formats
+func SetBundleKeyValueTarget(keyValue trustmanagerapi.KeyValueTarget) BundleModifier {
+	return func(bundle *trustmanagerapi.ClusterBundle) {
+		bundle.Spec.Target.ConfigMap = &keyValue
 	}
 }
 
 // SetResourceVersion sets the Bundle object's resource version as a
 // BundleModifier.
 func SetBundleResourceVersion(resourceVersion string) BundleModifier {
-	return func(bundle *trustapi.Bundle) {
+	return func(bundle *trustmanagerapi.ClusterBundle) {
 		bundle.ResourceVersion = resourceVersion
 	}
 }
@@ -77,16 +77,18 @@ func SetBundleResourceVersion(resourceVersion string) BundleModifier {
 // SetBundleTargetNamespaceSelectorMatchLabels sets the Bundle object's spec
 // target namespace selector.
 func SetBundleTargetNamespaceSelectorMatchLabels(matchLabels map[string]string) BundleModifier {
-	return func(bundle *trustapi.Bundle) {
+	return func(bundle *trustmanagerapi.ClusterBundle) {
 		bundle.Spec.Target.NamespaceSelector = &metav1.LabelSelector{
 			MatchLabels: matchLabels,
 		}
 	}
 }
 
-// AppendBundleUsesDefaultPackage appends a source to the bundle which requests the default bundle package.
-func AppendBundleUsesDefaultPackage() BundleModifier {
-	return func(bundle *trustapi.Bundle) {
-		bundle.Spec.Sources = append(bundle.Spec.Sources, trustapi.BundleSource{UseDefaultCAs: new(true)})
+// IncludeDefaultCAs updates the bundle spec to include the default bundle package.
+func IncludeDefaultCAs() BundleModifier {
+	return func(bundle *trustmanagerapi.ClusterBundle) {
+		bundle.Spec.DefaultCAs = trustmanagerapi.DefaultCAsSource{
+			Provider: trustmanagerapi.DefaultCAsProviderSystem,
+		}
 	}
 }

--- a/test/integration/bundle/controller_test.go
+++ b/test/integration/bundle/controller_test.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:staticcheck // SA1019 staticcheck will warn about our use of the deprecated Bundle resource, but we still need to test it so people can migrate
 package test
 
 import (
@@ -28,6 +29,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
 
 	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
+	trustmanagerapi "github.com/cert-manager/trust-manager/pkg/apis/trustmanager/v1alpha2"
 	"github.com/cert-manager/trust-manager/test/dummy"
 	testenv "github.com/cert-manager/trust-manager/test/env"
 
@@ -486,6 +488,9 @@ var _ = Describe("Integration", func() {
 	})
 
 	It("should re-add the owner reference of a target ConfigMap if it has been removed", func() {
+		var testClusterBundle trustmanagerapi.ClusterBundle
+		Expect(cl.Get(ctx, client.ObjectKey{Name: testBundle.Name}, &testClusterBundle)).ToNot(HaveOccurred())
+
 		var configMap corev1.ConfigMap
 		Expect(cl.Get(ctx, client.ObjectKey{Namespace: "kube-system", Name: testBundle.Name}, &configMap)).ToNot(HaveOccurred())
 
@@ -497,10 +502,10 @@ var _ = Describe("Integration", func() {
 			var configMap corev1.ConfigMap
 			Expect(cl.Get(ctx, client.ObjectKey{Namespace: "kube-system", Name: testBundle.Name}, &configMap)).ToNot(HaveOccurred())
 			return len(configMap.OwnerReferences) == 1 && apiequality.Semantic.DeepEqual(configMap.OwnerReferences[0], metav1.OwnerReference{
-				Kind:               "Bundle",
-				APIVersion:         "trust.cert-manager.io/v1alpha1",
-				UID:                testBundle.UID,
-				Name:               testBundle.Name,
+				Kind:               "ClusterBundle",
+				APIVersion:         "trust-manager.io/v1alpha2",
+				UID:                testClusterBundle.UID,
+				Name:               testClusterBundle.Name,
 				Controller:         new(true),
 				BlockOwnerDeletion: new(true),
 			})

--- a/test/integration/bundle/controller_test.go
+++ b/test/integration/bundle/controller_test.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:staticcheck // SA1019 staticcheck will warn about our use of the deprecated Bundle resource, but we still need to test it so people can migrate
 package test
 
 import (
@@ -30,6 +31,7 @@ import (
 	"software.sslmate.com/src/go-pkcs12"
 
 	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
+	trustmanagerapi "github.com/cert-manager/trust-manager/pkg/apis/trustmanager/v1alpha2"
 	"github.com/cert-manager/trust-manager/test/dummy"
 	testenv "github.com/cert-manager/trust-manager/test/env"
 
@@ -529,6 +531,9 @@ var _ = Describe("Integration", func() {
 	})
 
 	It("should re-add the owner reference of a target ConfigMap if it has been removed", func() {
+		var testClusterBundle trustmanagerapi.ClusterBundle
+		Expect(cl.Get(ctx, client.ObjectKey{Name: testBundle.Name}, &testClusterBundle)).ToNot(HaveOccurred())
+
 		var configMap corev1.ConfigMap
 		Expect(cl.Get(ctx, client.ObjectKey{Namespace: "kube-system", Name: testBundle.Name}, &configMap)).ToNot(HaveOccurred())
 
@@ -540,10 +545,10 @@ var _ = Describe("Integration", func() {
 			var configMap corev1.ConfigMap
 			Expect(cl.Get(ctx, client.ObjectKey{Namespace: "kube-system", Name: testBundle.Name}, &configMap)).ToNot(HaveOccurred())
 			return len(configMap.OwnerReferences) == 1 && apiequality.Semantic.DeepEqual(configMap.OwnerReferences[0], metav1.OwnerReference{
-				Kind:               "Bundle",
-				APIVersion:         "trust.cert-manager.io/v1alpha1",
-				UID:                testBundle.UID,
-				Name:               testBundle.Name,
+				Kind:               "ClusterBundle",
+				APIVersion:         "trust-manager.io/v1alpha2",
+				UID:                testClusterBundle.UID,
+				Name:               testClusterBundle.Name,
 				Controller:         new(true),
 				BlockOwnerDeletion: new(true),
 			})

--- a/test/integration/bundle/env.go
+++ b/test/integration/bundle/env.go
@@ -96,6 +96,7 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 
 	Expect(webhook.SetupWebhookWithManager(mgr)).Should(Succeed())
+	Expect((&webhook.ClusterBundle{}).SetupWebhookWithManager(mgr)).Should(Succeed())
 
 	By("Writing default package")
 	tmpFileName, err = writeDefaultPackage()

--- a/test/integration/bundle/validation_test.go
+++ b/test/integration/bundle/validation_test.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:staticcheck // SA1019 staticcheck will warn about our use of the deprecated Bundle resource, but we still need to test it so people can migrate
 package test
 
 import (

--- a/test/integration/clusterbundle/migration_test.go
+++ b/test/integration/clusterbundle/migration_test.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:staticcheck // SA1019 staticcheck will warn about our use of the deprecated Bundle resource, but we still need to test it so people can migrate
 package test
 
 import (

--- a/test/smoke/suite_test.go
+++ b/test/smoke/suite_test.go
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
+//nolint:staticcheck // SA1019 staticcheck will warn about our use of the deprecated Bundle resource, but we still need to reconcile it so people can migrate
 package smoke
 
 import (


### PR DESCRIPTION
This PR introduces the new _ClusterBundle_ CRD and enables the migration controller according to the accepted [design](https://github.com/cert-manager/trust-manager/blob/main/design/20241124-rename-bunde-to-clusterbundle.md).

The main controller is changed to reconcile _ClusterBundle_ instead of _Bundle_.

I've tried to keep this PR as small as possible to make it easier to review. We will likely need to add additional tests for the new features in the _ClusterBundle_ API (e.g., multiple keys) and consolidate the existing tests due to the more generic API. However, I suggest handling this in follow-up PRs. Let me know what you think!