### PR TITLE
Move additional formats handling from source to target

### DIFF
--- a/pkg/bundle/bundle.go
+++ b/pkg/bundle/bundle.go
@@ -114,7 +114,7 @@ func (b *bundle) reconcileBundle(ctx context.Context, req ctrl.Request) (statusP
 	statusPatch = &trustapi.BundleStatus{
 		DefaultCAPackageVersion: bundle.Status.DefaultCAPackageVersion,
 	}
-	resolvedBundle, err := b.bundleBuilder.BuildBundle(ctx, bundle.Spec.Sources, bundle.Spec.Target.AdditionalFormats)
+	resolvedBundle, err := b.bundleBuilder.BuildBundle(ctx, bundle.Spec.Sources)
 
 	if err != nil {
 		var reason, message string

--- a/pkg/bundle/internal/source/source_test.go
+++ b/pkg/bundle/internal/source/source_test.go
@@ -36,10 +36,6 @@ import (
 	"github.com/cert-manager/trust-manager/test/dummy"
 )
 
-const (
-	data = dummy.TestCertificate1
-)
-
 func Test_BuildBundle(t *testing.T) {
 	tests := map[string]struct {
 		sources                     []trustapi.BundleSource
@@ -355,8 +351,9 @@ func Test_BuildBundle(t *testing.T) {
 				t.Errorf("unexpected InvalidSecretError, exp=%t got=%v", tt.expInvalidSecretSourceError, err)
 			}
 
-			if resolvedBundle.Data != tt.expData {
-				t.Errorf("unexpected data, exp=%q got=%q", tt.expData, resolvedBundle.Data)
+			data := resolvedBundle.CertPool.PEM()
+			if data != tt.expData {
+				t.Errorf("unexpected data, exp=%q got=%q", tt.expData, data)
 			}
 		})
 	}

--- a/pkg/bundle/internal/target/target_test.go
+++ b/pkg/bundle/internal/target/target_test.go
@@ -466,15 +466,16 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				},
 			}
 
+			certPool := util.NewCertPool()
+			err := certPool.AddCertsFromPEM([]byte(data))
+			assert.NoError(t, err)
+
 			spec := trustapi.BundleSpec{
 				Target: trustapi.BundleTarget{
 					ConfigMap:         &trustapi.TargetTemplate{Key: key},
 					AdditionalFormats: &trustapi.AdditionalFormats{},
 				},
 			}
-			certPool := util.NewCertPool()
-			err := certPool.AddCertsFromPEM([]byte(data))
-			assert.NoError(t, err)
 			resolvedBundle := source.BundleData{CertPool: certPool}
 			if tt.withJKS {
 				spec.Target.AdditionalFormats.JKS = &trustapi.JKS{
@@ -916,16 +917,16 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				},
 			}
 
+			certPool := util.NewCertPool()
+			err := certPool.AddCertsFromPEM([]byte(data))
+			assert.NoError(t, err)
+
 			spec := trustapi.BundleSpec{
 				Target: trustapi.BundleTarget{
 					Secret:            &trustapi.TargetTemplate{Key: key},
 					AdditionalFormats: &trustapi.AdditionalFormats{},
 				},
 			}
-			certPool := util.NewCertPool()
-			err := certPool.AddCertsFromPEM([]byte(data))
-			assert.NoError(t, err)
-
 			resolvedBundle := source.BundleData{CertPool: certPool}
 			if tt.withJKS {
 				spec.Target.AdditionalFormats.JKS = &trustapi.JKS{


### PR DESCRIPTION
This PR is a preparation for https://github.com/cert-manager/trust-manager/pull/702. As the new API is considerably more flexible, it makes sense to move the handling of "additional formats". In the `ClusterBundle` API, the format and password (in case of a truststore format) can be set per key in the target, so it doesn't make sense to prepare this in sources.

This PR is required before I can continue to migrate the current Bundle controller.

The test coverage is probably slightly reduced in this PR, as I am not testing with a custom password in the target test, just the default passwords. But we have other tests of the binary encoders, and I would prefer not spending extra time on the binary formats.