### PR TITLE
Refactor cache setup to controller package

### DIFF
--- a/test/integration/bundle/suite.go
+++ b/test/integration/bundle/suite.go
@@ -115,12 +115,13 @@ var _ = Describe("Integration", func() {
 				// since all tests need a dedicated controller
 				SkipNameValidation: ptr.To(true),
 			},
+			Cache: bundle.CacheOpts(controller.Options{}),
 		})
 		Expect(err).NotTo(HaveOccurred())
 
 		mgrStopped = make(chan struct{})
 
-		Expect(bundle.AddBundleController(ctx, mgr, opts, mgr.GetCache())).NotTo(HaveOccurred())
+		Expect(bundle.SetupWithManager(ctx, mgr, opts)).NotTo(HaveOccurred())
 
 		By("Running Bundle controller")
 		go func() {


### PR DESCRIPTION
This change was mainly triggered by https://github.com/cert-manager/trust-manager/issues/726. If we were to add this new feature, the cache setup would have to change. And by moving the code, we can include the caches in the integration test, which I think is a good thing anyway.

I also want to see if the custom cache for targets can be eliminated, and would like to avoid running the e2e-tests to test it.

/cc @inteon 