### PR TITLE
Feat: add an option to enable or disable rbac resources

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -6,6 +6,15 @@
 
 <!-- AUTO-GENERATED -->
 
+### Global
+
+#### **global.rbac.create** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+Create required ClusterRoles, Roles, ClusterRoleBindings and RoleBindings for trust-manager.
 ### CRDs
 
 #### **crds.enabled** ~ `bool`

--- a/deploy/charts/trust-manager/templates/clusterrole.yaml
+++ b/deploy/charts/trust-manager/templates/clusterrole.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.rbac.create }}
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -38,4 +39,5 @@ rules:
 
 {{- if not .Values.app.targetNamespaces }}
 {{ include "trust-manager.rbac.namespacedResourcesRules" . }}
+{{- end -}}
 {{- end -}}

--- a/deploy/charts/trust-manager/templates/clusterrolebinding.yaml
+++ b/deploy/charts/trust-manager/templates/clusterrolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.rbac.create }}
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -16,3 +17,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "trust-manager.name" . }}
   namespace: {{ include "trust-manager.namespace" . }}
+{{- end -}}

--- a/deploy/charts/trust-manager/templates/rbac-per-namespace.yaml
+++ b/deploy/charts/trust-manager/templates/rbac-per-namespace.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.app.targetNamespaces }}
+{{- if and .Values.global.rbac.create .Values.app.targetNamespaces }}
 {{- $namespaces := append (append .Values.app.targetNamespaces .Values.app.trust.namespace) (include "trust-manager.namespace" . ) -}}
 {{- range $ns := uniq $namespaces }}
 ---

--- a/deploy/charts/trust-manager/templates/role.yaml
+++ b/deploy/charts/trust-manager/templates/role.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.rbac.create }}
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -41,3 +42,4 @@ rules:
   - "update"
   - "watch"
   - "list"
+{{- end -}}

--- a/deploy/charts/trust-manager/templates/rolebinding.yaml
+++ b/deploy/charts/trust-manager/templates/rolebinding.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.global.rbac.create }}
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
@@ -37,3 +38,4 @@ subjects:
 - kind: ServiceAccount
   name: {{ include "trust-manager.name" . }}
   namespace: {{ include "trust-manager.namespace" . }}
+{{- end -}}

--- a/deploy/charts/trust-manager/values.schema.json
+++ b/deploy/charts/trust-manager/values.schema.json
@@ -643,7 +643,26 @@
       "type": "boolean"
     },
     "helm-values.global": {
-      "description": "Global values shared across all (sub)charts"
+      "description": "Global values shared across all (sub)charts",
+      "properties": {
+        "rbac": {
+          "$ref": "#/$defs/helm-values.global.rbac"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.global.rbac": {
+      "properties": {
+        "create": {
+          "$ref": "#/$defs/helm-values.global.rbac.create"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.global.rbac.create": {
+      "default": true,
+      "description": "Create required ClusterRoles, Roles, ClusterRoleBindings and RoleBindings for trust-manager.",
+      "type": "boolean"
     },
     "helm-values.image": {
       "additionalProperties": false,

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -1,3 +1,9 @@
+# +docs:section=Global
+global:
+  rbac:
+    # Create required ClusterRoles, Roles, ClusterRoleBindings and RoleBindings for trust-manager.
+    create: true
+
 # +docs:section=CRDs
 crds:
   # This option decides if the CRDs should be installed


### PR DESCRIPTION
Closes: #748 

**Summary**

This PR adds a new option in trust-manager helm chart to enable/desable rbac resources.

**What’s in this PR**

New section in helm values:

```yaml
global:
  rbac:
    create: true
```

**Example usage**

```bash
helm upgrade --install trust-manager jetstack/trust-manager \
  --namespace trust-manager --create-namespace \
  --set global.rbac.create=false
```