### PR TITLE
Bump default CAs bundle version to trigger release

### DIFF
--- a/make/00_debian_bookworm_version.mk
+++ b/make/00_debian_bookworm_version.mk
@@ -17,5 +17,5 @@
 # This file is used to store the latest version of the debian trust package and the DEBIAN_BUNDLE_BOOKWORM_VERSION
 # variable is automatically updated by the `upgrade-debian-trust-package-bookworm-version` target and cron GH action.
 
-DEBIAN_BUNDLE_BOOKWORM_VERSION := 20230311+deb12u1.0
+DEBIAN_BUNDLE_BOOKWORM_VERSION := 20230311+deb12u1.1
 DEBIAN_BUNDLE_BOOKWORM_SOURCE_IMAGE=docker.io/library/debian:12-slim

--- a/make/00_debian_version.mk
+++ b/make/00_debian_version.mk
@@ -16,5 +16,5 @@
 # This file is used to store the latest version of the debian trust package and the DEBIAN_BUNDLE_VERSION
 # variable is automatically updated by the `upgrade-debian-trust-package-version` target and cron GH action.
 
-DEBIAN_BUNDLE_VERSION := 20210119.0
+DEBIAN_BUNDLE_VERSION := 20210119.1
 DEBIAN_BUNDLE_SOURCE_IMAGE=docker.io/library/debian:11-slim


### PR DESCRIPTION
As shown in https://artifacthub.io/packages/helm/cert-manager/trust-manager?modal=security-report, which I have also verified locally (see below), we have vulnerabilities in our default CA images. This PR bumps the default CA images which I "think" should trigger a new release of these images automatically.

````
Report Summary

┌──────────────────────────────────────────────────────────────────────────────────┬──────────┬─────────────────┬─────────┐
│                                      Target                                      │   Type   │ Vulnerabilities │ Secrets │
├──────────────────────────────────────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ quay.io/jetstack/trust-pkg-debian-bookworm:20230311-deb12u1.0@sha256:4e46f31af8- │  alpine  │        0        │    -    │
│ ab4aedb861b997be37e2004ba5313a187d0f0a3cdb4680937a98a3 (alpine 3.21)             │          │                 │         │
├──────────────────────────────────────────────────────────────────────────────────┼──────────┼─────────────────┼─────────┤
│ ko-app/debian-bundle-static                                                      │ gobinary │        2        │    -    │
└──────────────────────────────────────────────────────────────────────────────────┴──────────┴─────────────────┴─────────┘
Legend:
- '-': Not scanned
- '0': Clean (no security findings detected)


ko-app/debian-bundle-static (gobinary)

Total: 2 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 1, CRITICAL: 0)

┌─────────┬────────────────┬──────────┬────────┬───────────────────┬─────────────────┬─────────────────────────────────────────────────────────────┐
│ Library │ Vulnerability  │ Severity │ Status │ Installed Version │  Fixed Version  │                            Title                            │
├─────────┼────────────────┼──────────┼────────┼───────────────────┼─────────────────┼─────────────────────────────────────────────────────────────┤
│ stdlib  │ CVE-2025-47907 │ HIGH     │ fixed  │ v1.24.5           │ 1.23.12, 1.24.6 │ database/sql: Postgres Scan Race Condition                  │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-47907                  │
│         ├────────────────┼──────────┤        │                   │                 ├─────────────────────────────────────────────────────────────┤
│         │ CVE-2025-47906 │ MEDIUM   │        │                   │                 │ os/exec: Unexpected paths returned from LookPath in os/exec │
│         │                │          │        │                   │                 │ https://avd.aquasec.com/nvd/cve-2025-47906                  │
└─────────┴────────────────┴──────────┴────────┴───────────────────┴─────────────────┴─────────────────────────────────────────────────────────────┘
````