### PR TITLE
Make: missing quote breaking CI

### DIFF
--- a/make/02_mod.mk
+++ b/make/02_mod.mk
@@ -61,7 +61,7 @@ release-debian-trust-package:
 	@echo "RELEASE_OCI_PACKAGE_DEBIAN_IMAGE=$(oci_package_debian_image_name)" >> "$(GITHUB_OUTPUT)"
 	@echo "RELEASE_OCI_PACKAGE_DEBIAN_TAG=$(oci_package_debian_image_tag)" >> "$(GITHUB_OUTPUT)"
 
-	@echo "Release complete!
+	@echo "Release complete!"
 
 .PHONY: release-debian-bookworm-trust-package
 release-debian-bookworm-trust-package: | $(NEEDS_CRANE)


### PR DESCRIPTION
Even though the images and signatures are pushed, the build unexpectedly fails. e.g.,

https://github.com/cert-manager/trust-manager/actions/runs/18372810166/job/52339841243#step:6:176

Slack thread: https://kubernetes.slack.com/archives/CDEQJ0Q8M/p1760008358776049