### PR TITLE
Don't set the tag in values.yaml, since it is overwritten at chart build time

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -174,12 +174,8 @@ repository: jetstack/cert-manager-package-debian
 
 The repository for the default package image. This image enables the 'useDefaultCAs' source on Bundles.
 #### **defaultPackageImage.tag** ~ `string`
-> Default value:
-> ```yaml
-> 20230311-deb12u1.0@sha256:4e46f31af8ab4aedb861b997be37e2004ba5313a187d0f0a3cdb4680937a98a3
-> ```
 
-Override the image tag of the default package image. If no value is set, the chart's appVersion is used.
+Override the image tag of the default package image. Is set at chart build time to the version specified in ./make/00_debian_bookworm_version.mk.
 
 #### **defaultPackageImage.digest** ~ `string`
 

--- a/deploy/charts/trust-manager/values.schema.json
+++ b/deploy/charts/trust-manager/values.schema.json
@@ -613,8 +613,7 @@
       "type": "string"
     },
     "helm-values.defaultPackageImage.tag": {
-      "default": "20230311-deb12u1.0@sha256:4e46f31af8ab4aedb861b997be37e2004ba5313a187d0f0a3cdb4680937a98a3",
-      "description": "Override the image tag of the default package image. If no value is set, the chart's appVersion is used.",
+      "description": "Override the image tag of the default package image. Is set at chart build time to the version specified in ./make/00_debian_bookworm_version.mk.",
       "type": "string"
     },
     "helm-values.enabled": {

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -102,9 +102,9 @@ defaultPackageImage:
   repository: quay.io/jetstack/trust-pkg-debian-bookworm
 
   # Override the image tag of the default package image.
-  # If no value is set, the chart's appVersion is used.
+  # Is set at chart build time to the version specified in ./make/00_debian_bookworm_version.mk.
   # +docs:property
-  tag: "20230311-deb12u1.0@sha256:4e46f31af8ab4aedb861b997be37e2004ba5313a187d0f0a3cdb4680937a98a3"
+  # tag: vX.Y.Z
 
   # Target image digest. Override any tag, if set.
   # For example:


### PR DESCRIPTION
If we keep this unused value in `values.yaml`, it confuses users and developers.