### PR TITLE
Bump trust package suffix, forcing a new go 1.25.3 build

### DIFF
--- a/make/00_debian_bookworm_version.mk
+++ b/make/00_debian_bookworm_version.mk
@@ -17,5 +17,5 @@
 # This file is used to store the latest version of the debian trust package and the DEBIAN_BUNDLE_BOOKWORM_VERSION
 # variable is automatically updated by the `upgrade-debian-trust-package-bookworm-version` target and cron GH action.
 
-DEBIAN_BUNDLE_BOOKWORM_VERSION := 20230311+deb12u1.1
+DEBIAN_BUNDLE_BOOKWORM_VERSION := 20230311+deb12u1.2
 DEBIAN_BUNDLE_BOOKWORM_SOURCE_IMAGE=docker.io/library/debian:12-slim

--- a/make/00_debian_version.mk
+++ b/make/00_debian_version.mk
@@ -16,5 +16,5 @@
 # This file is used to store the latest version of the debian trust package and the DEBIAN_BUNDLE_VERSION
 # variable is automatically updated by the `upgrade-debian-trust-package-version` target and cron GH action.
 
-DEBIAN_BUNDLE_VERSION := 20210119.1
+DEBIAN_BUNDLE_VERSION := 20210119.2
 DEBIAN_BUNDLE_SOURCE_IMAGE=docker.io/library/debian:11-slim


### PR DESCRIPTION
Since 1.25.2 had some unexpected breaking changes, I think we should bump the sufix again to build using go 1.25.3 instead of go 1.25.2.

(see https://github.com/cert-manager/trust-manager/pull/768 for last suffix bump)