### PR TITLE
Fix modernize linter errors

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -4,10 +4,6 @@ linters:
   exclusions:
     generated: lax
     presets: [comments, common-false-positives, legacy, std-error-handling]
-    rules:
-      - linters:
-          - modernize
-        text: .*
     paths: [third_party, builtin$, examples$]
     warn-unused: true
   settings:

--- a/deploy/charts/trust-manager/templates/crd-trust.cert-manager.io_bundles.yaml
+++ b/deploy/charts/trust-manager/templates/crd-trust.cert-manager.io_bundles.yaml
@@ -237,7 +237,7 @@ spec:
                             JKS requests a JKS-formatted binary trust bundle to be written to the target.
                             The bundle has "changeit" as the default password.
                             For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
-                            Deprecated: Writing JKS is subject for removal. Please migrate to PKCS12.
+                            Format is deprecated: Writing JKS is subject for removal. Please migrate to PKCS12.
                             PKCS#12 trust stores created by trust-manager are compatible with Java.
                           properties:
                             key:

--- a/pkg/apis/trust/v1alpha1/conversion_test.go
+++ b/pkg/apis/trust/v1alpha1/conversion_test.go
@@ -37,8 +37,8 @@ func TestFuzzyConversion(t *testing.T) {
 	}))
 }
 
-func fuzzFuncs(_ runtimeserializer.CodecFactory) []interface{} {
-	return []interface{}{
+func fuzzFuncs(_ runtimeserializer.CodecFactory) []any {
+	return []any{
 		spokeBundleSpecFuzzer,
 		spokeSourceObjectKeySelectorFuzzer,
 		spokeBundleTargetFuzzer,

--- a/pkg/apis/trust/v1alpha1/types_bundle.go
+++ b/pkg/apis/trust/v1alpha1/types_bundle.go
@@ -37,8 +37,9 @@ var BundleHashAnnotationKey = "trust.cert-manager.io/hash"
 // +genclient:nonNamespaced
 
 type Bundle struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta `json:",inline"`
+	// +optional
+	metav1.ObjectMeta `json:"metadata"`
 
 	// Desired state of the Bundle resource.
 	Spec BundleSpec `json:"spec"`

--- a/pkg/apis/trustmanager/v1alpha2/types_cluster_bundle.go
+++ b/pkg/apis/trustmanager/v1alpha2/types_cluster_bundle.go
@@ -37,8 +37,9 @@ var BundleHashAnnotationKey = "trust-manager.io/hash"
 // +genclient:nonNamespaced
 
 type ClusterBundle struct {
-	metav1.TypeMeta   `json:",inline"`
-	metav1.ObjectMeta `json:"metadata,omitempty"`
+	metav1.TypeMeta `json:",inline"`
+	// +optional
+	metav1.ObjectMeta `json:"metadata"`
 
 	// Desired state of the Bundle resource.
 	Spec BundleSpec `json:"spec"`

--- a/pkg/bundle/bundle_test.go
+++ b/pkg/bundle/bundle_test.go
@@ -295,7 +295,7 @@ func Test_Reconcile(t *testing.T) {
 		disableSecretTargets    bool
 		expResult               ctrl.Result
 		expError                bool
-		expPatches              []interface{}
+		expPatches              []any
 		expBundlePatch          *trustapi.BundleStatus
 		expEvent                string
 		targetNamespaces        []string
@@ -405,7 +405,7 @@ func Test_Reconcile(t *testing.T) {
 			},
 			existingSecrets: []client.Object{sourceSecret},
 			expError:        false,
-			expPatches: []interface{}{
+			expPatches: []any{
 				configMapPatch(baseBundle.Name, trustNamespace, map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 				configMapPatch(baseBundle.Name, "ns-1", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 				configMapPatch(baseBundle.Name, "ns-2", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
@@ -458,7 +458,7 @@ func Test_Reconcile(t *testing.T) {
 				),
 			},
 			expError: false,
-			expPatches: []interface{}{
+			expPatches: []any{
 				secretPatch(baseBundle.Name, trustNamespace, map[string]string{targetKey: dummy.DefaultJoinedCerts()}, ptr.To(targetKey), nil),
 				secretPatch(baseBundle.Name, "ns-1", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, ptr.To(targetKey), nil),
 				secretPatch(baseBundle.Name, "ns-2", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, ptr.To(targetKey), nil),
@@ -511,7 +511,7 @@ func Test_Reconcile(t *testing.T) {
 					gen.SetBundleTargetAdditionalFormats(pkcs12DefaultAdditionalFormats),
 				)},
 			expError: false,
-			expPatches: []interface{}{
+			expPatches: []any{
 				configMapPatch(baseBundle.Name, "trust-namespace", map[string]string{
 					targetKey: dummy.DefaultJoinedCerts(),
 				}, map[string][]byte{
@@ -577,7 +577,7 @@ func Test_Reconcile(t *testing.T) {
 				),
 			},
 			expError: false,
-			expPatches: []interface{}{
+			expPatches: []any{
 				configMapPatch(baseBundle.Name, "trust-namespace", map[string]string{
 					targetKey: dummy.DefaultJoinedCerts(),
 				}, map[string][]byte{
@@ -652,7 +652,7 @@ func Test_Reconcile(t *testing.T) {
 				),
 			},
 			expError:   false,
-			expPatches: []interface{}{},
+			expPatches: []any{},
 			expBundlePatch: &trustapi.BundleStatus{
 				Conditions: []metav1.Condition{
 					{
@@ -711,7 +711,7 @@ func Test_Reconcile(t *testing.T) {
 				),
 			},
 			expError: false,
-			expPatches: []interface{}{
+			expPatches: []any{
 				configMapPatch(baseBundle.Name, "trust-namespace", map[string]string{
 					targetKey: dummy.DefaultJoinedCerts(),
 				}, map[string][]byte{
@@ -748,7 +748,7 @@ func Test_Reconcile(t *testing.T) {
 				},
 			)},
 			expError: false,
-			expPatches: []interface{}{
+			expPatches: []any{
 				configMapPatch(baseBundle.Name, trustNamespace, map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 				configMapPatch(baseBundle.Name, "ns-1", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 				configMapPatch(baseBundle.Name, "ns-2", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
@@ -782,7 +782,7 @@ func Test_Reconcile(t *testing.T) {
 			existingSecrets:    []client.Object{sourceSecret},
 			existingBundles:    []client.Object{gen.BundleFrom(baseBundle)},
 			expError:           false,
-			expPatches: []interface{}{
+			expPatches: []any{
 				configMapPatch(baseBundle.Name, trustNamespace, map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 				configMapPatch(baseBundle.Name, "ns-1", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 				configMapPatch(baseBundle.Name, "ns-2", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
@@ -821,7 +821,7 @@ func Test_Reconcile(t *testing.T) {
 			existingBundles: []client.Object{gen.BundleFrom(baseBundle,
 				gen.SetBundleTargetNamespaceSelectorMatchLabels(map[string]string{"foo": "bar"}))},
 			expError: false,
-			expPatches: []interface{}{
+			expPatches: []any{
 				configMapPatch(baseBundle.Name, "random-namespace", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 				configMapPatch(baseBundle.Name, "another-random-namespace", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 			},
@@ -873,7 +873,7 @@ func Test_Reconcile(t *testing.T) {
 				gen.SetBundleTargetNamespaceSelectorMatchLabels(map[string]string{"foo": "bar"}),
 			)},
 			expError: false,
-			expPatches: []interface{}{
+			expPatches: []any{
 				configMapPatch(baseBundle.Name, trustNamespace, map[string]string{}, nil, nil, nil),
 				configMapPatch(baseBundle.Name, "ns-1", map[string]string{}, nil, nil, nil),
 				configMapPatch(baseBundle.Name, "ns-2", map[string]string{}, nil, nil, nil),
@@ -938,7 +938,7 @@ func Test_Reconcile(t *testing.T) {
 					})),
 			},
 			expError: false,
-			expPatches: []interface{}{
+			expPatches: []any{
 				configMapPatch(baseBundle.Name, trustNamespace, map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 				configMapPatch(baseBundle.Name, "ns-1", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 				configMapPatch(baseBundle.Name, "ns-2", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
@@ -1130,7 +1130,7 @@ func Test_Reconcile(t *testing.T) {
 			},
 			configureDefaultPackage: true,
 			expError:                false,
-			expPatches: []interface{}{
+			expPatches: []any{
 				configMapPatch(baseBundle.Name, trustNamespace, map[string]string{targetKey: dummy.JoinCerts(dummy.TestCertificate2, dummy.TestCertificate1, dummy.TestCertificate3, dummy.TestCertificate5)}, nil, ptr.To(targetKey), nil),
 				configMapPatch(baseBundle.Name, "ns-1", map[string]string{targetKey: dummy.JoinCerts(dummy.TestCertificate2, dummy.TestCertificate1, dummy.TestCertificate3, dummy.TestCertificate5)}, nil, ptr.To(targetKey), nil),
 				configMapPatch(baseBundle.Name, "ns-2", map[string]string{targetKey: dummy.JoinCerts(dummy.TestCertificate2, dummy.TestCertificate1, dummy.TestCertificate3, dummy.TestCertificate5)}, nil, ptr.To(targetKey), nil),
@@ -1199,7 +1199,7 @@ func Test_Reconcile(t *testing.T) {
 			)},
 			configureDefaultPackage: true,
 			expError:                false,
-			expPatches: []interface{}{
+			expPatches: []any{
 				configMapPatch(baseBundle.Name, trustNamespace, map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 				configMapPatch(baseBundle.Name, "ns-1", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 				configMapPatch(baseBundle.Name, "ns-2", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
@@ -1271,7 +1271,7 @@ func Test_Reconcile(t *testing.T) {
 			)},
 			configureDefaultPackage: true,
 			expError:                false,
-			expPatches: []interface{}{
+			expPatches: []any{
 				configMapPatch(baseBundle.Name, trustNamespace, nil, nil, nil, nil),
 				configMapPatch(baseBundle.Name, "ns-1", nil, nil, nil, nil),
 				configMapPatch(baseBundle.Name, "ns-2", nil, nil, nil, nil),
@@ -1346,7 +1346,7 @@ func Test_Reconcile(t *testing.T) {
 			)},
 			configureDefaultPackage: true,
 			expError:                false,
-			expPatches: []interface{}{
+			expPatches: []any{
 				secretPatch(baseBundle.Name, trustNamespace, map[string]string{targetKey: dummy.DefaultJoinedCerts()}, ptr.To(targetKey), nil),
 				secretPatch(baseBundle.Name, "ns-1", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, ptr.To(targetKey), nil),
 				secretPatch(baseBundle.Name, "ns-2", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, ptr.To(targetKey), nil),
@@ -1394,7 +1394,7 @@ func Test_Reconcile(t *testing.T) {
 			)},
 			configureDefaultPackage: true,
 			expError:                false,
-			expPatches:              []interface{}{},
+			expPatches:              []any{},
 			expBundlePatch: &trustapi.BundleStatus{
 				Conditions: []metav1.Condition{
 					{
@@ -1457,7 +1457,7 @@ func Test_Reconcile(t *testing.T) {
 				}),
 			)},
 			expError: false,
-			expPatches: []interface{}{
+			expPatches: []any{
 				configMapPatch(baseBundle.Name, trustNamespace, map[string]string{targetKey: dummy.JoinCerts(dummy.TestCertificate2, dummy.TestCertificate1, dummy.TestCertificate3)}, nil, ptr.To(targetKey), nil),
 				configMapPatch(baseBundle.Name, "ns-1", map[string]string{targetKey: dummy.JoinCerts(dummy.TestCertificate2, dummy.TestCertificate1, dummy.TestCertificate3)}, nil, ptr.To(targetKey), nil),
 				configMapPatch(baseBundle.Name, "ns-2", map[string]string{targetKey: dummy.JoinCerts(dummy.TestCertificate2, dummy.TestCertificate1, dummy.TestCertificate3)}, nil, ptr.To(targetKey), nil),
@@ -1488,7 +1488,7 @@ func Test_Reconcile(t *testing.T) {
 			},
 			targetNamespaces: []string{"ns-1", "ns-2"},
 			expError:         false,
-			expPatches: []interface{}{
+			expPatches: []any{
 				configMapPatch(baseBundle.Name, "ns-1", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 				configMapPatch(baseBundle.Name, "ns-2", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 			},
@@ -1548,7 +1548,7 @@ func Test_Reconcile(t *testing.T) {
 			},
 			targetNamespaces: []string{"ns-1", "ns-2"},
 			expError:         false,
-			expPatches: []interface{}{
+			expPatches: []any{
 				configMapPatch(baseBundle.Name, "ns-1", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 				configMapPatch(baseBundle.Name, "ns-2", map[string]string{targetKey: dummy.DefaultJoinedCerts()}, nil, ptr.To(targetKey), nil),
 			},
@@ -1594,7 +1594,7 @@ func Test_Reconcile(t *testing.T) {
 
 			var (
 				logMutex        sync.Mutex
-				resourcePatches []interface{}
+				resourcePatches []any
 			)
 
 			_, ctx := ktesting.NewTestContext(t)
@@ -1615,7 +1615,7 @@ func Test_Reconcile(t *testing.T) {
 				targetReconciler: &target.Reconciler{
 					Client: fakeClient,
 					Cache:  fakeClient,
-					PatchResourceOverwrite: func(ctx context.Context, obj interface{}) error {
+					PatchResourceOverwrite: func(ctx context.Context, obj any) error {
 						logMutex.Lock()
 						defer logMutex.Unlock()
 

--- a/pkg/bundle/internal/target/target.go
+++ b/pkg/bundle/internal/target/target.go
@@ -23,6 +23,7 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -55,7 +56,7 @@ type Reconciler struct {
 
 	// PatchResourceOverwrite allows use to override the patchResource function
 	// it is used for testing purposes
-	PatchResourceOverwrite func(ctx context.Context, obj interface{}) error
+	PatchResourceOverwrite func(ctx context.Context, obj any) error
 }
 
 // CleanupTarget ensures the obsolete bundle target is cleanup up.
@@ -222,9 +223,7 @@ func (r *Reconciler) applySecret(
 	if err != nil {
 		return false, err
 	}
-	for k, v := range binData {
-		data[k] = v
-	}
+	maps.Copy(data, binData)
 
 	patch := prepareTargetPatch(coreapplyconfig.Secret(target.Name, target.Namespace), *bundle).
 		WithAnnotations(bundleTarget.Secret.GetAnnotations()).

--- a/pkg/bundle/internal/target/target_test.go
+++ b/pkg/bundle/internal/target/target_test.go
@@ -452,13 +452,13 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 
 			var (
 				logMutex        sync.Mutex
-				resourcePatches []interface{}
+				resourcePatches []any
 			)
 
 			r := &Reconciler{
 				Client: fakeClient,
 				Cache:  fakeClient,
-				PatchResourceOverwrite: func(ctx context.Context, obj interface{}) error {
+				PatchResourceOverwrite: func(ctx context.Context, obj any) error {
 					logMutex.Lock()
 					defer logMutex.Unlock()
 
@@ -904,13 +904,13 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 
 			var (
 				logMutex        sync.Mutex
-				resourcePatches []interface{}
+				resourcePatches []any
 			)
 
 			r := &Reconciler{
 				Client: fakeClient,
 				Cache:  fakeClient,
-				PatchResourceOverwrite: func(ctx context.Context, obj interface{}) error {
+				PatchResourceOverwrite: func(ctx context.Context, obj any) error {
 					logMutex.Lock()
 					defer logMutex.Unlock()
 

--- a/pkg/util/conversion/conversion.go
+++ b/pkg/util/conversion/conversion.go
@@ -37,8 +37,8 @@ import (
 func GetFuzzer(scheme *runtime.Scheme, funcs ...fuzzer.FuzzerFuncs) *randfill.Filler {
 	funcs = append([]fuzzer.FuzzerFuncs{
 		metafuzzer.Funcs,
-		func(_ runtimeserializer.CodecFactory) []interface{} {
-			return []interface{}{
+		func(_ runtimeserializer.CodecFactory) []any {
+			return []any{
 				// Custom fuzzer for metav1.Time pointers which weren't
 				// fuzzed and always resulted in `nil` values.
 				// This implementation is somewhat similar to the one provided

--- a/pkg/util/pem_test.go
+++ b/pkg/util/pem_test.go
@@ -144,7 +144,7 @@ func TestAddCertsFromPEM(t *testing.T) {
 				t.Errorf("expected sanitizedBundle not to end with a newline")
 			}
 
-			for _, line := range strings.Split(sanitizedBundle, "\n") {
+			for line := range strings.SplitSeq(sanitizedBundle, "\n") {
 				// Check that each "encapsulation boundary" (-----BEGIN/END <x>-----) is on its
 				// own line. ("Encapsulation boundary" is apparently the name according to rfc7468)
 				if !strings.HasPrefix(line, "-----") {

--- a/trust-packages/debian/main.go
+++ b/trust-packages/debian/main.go
@@ -42,7 +42,7 @@ func usage(logger *log.Logger) func() {
 		flag.CommandLine.SetOutput(buf)
 		flag.PrintDefaults()
 
-		for _, line := range strings.Split(buf.String(), "\n") {
+		for line := range strings.SplitSeq(buf.String(), "\n") {
 			if strings.TrimSpace(line) == "" {
 				continue
 			}


### PR DESCRIPTION
This enables the `modernize` linter and fixes new errors by applying the principles laid out in https://github.com/cert-manager/approver-policy/pull/740.

In addition to run `make fix-golangci-lint` after enabling the linter, I manually modified the `metadata` API field markers.