### PR TITLE
Bump trust package versions to address CVE-2025-61729

### DIFF
--- a/make/00_debian_bookworm_version.mk
+++ b/make/00_debian_bookworm_version.mk
@@ -17,5 +17,5 @@
 # This file is used to store the latest version of the debian trust package and the DEBIAN_BOOKWORM_BUNDLE_VERSION
 # variable is automatically updated by the `upgrade-debian-bookworm-trust-package-version` target and cron GH action.
 
-DEBIAN_BOOKWORM_BUNDLE_VERSION := 20230311+deb12u1.2
+DEBIAN_BOOKWORM_BUNDLE_VERSION := 20230311+deb12u1.3
 DEBIAN_BOOKWORM_BUNDLE_SOURCE_IMAGE=docker.io/library/debian:12-slim

--- a/make/00_debian_bullseye_version.mk
+++ b/make/00_debian_bullseye_version.mk
@@ -17,5 +17,5 @@
 # This file is used to store the latest version of the debian trust package and the DEBIAN_BULLSEYE_BUNDLE_VERSION
 # variable is automatically updated by the `upgrade-debian-bullseye-trust-package-version` target and cron GH action.
 
-DEBIAN_BULLSEYE_BUNDLE_VERSION := 20210119.2
+DEBIAN_BULLSEYE_BUNDLE_VERSION := 20210119.3
 DEBIAN_BULLSEYE_BUNDLE_SOURCE_IMAGE=docker.io/library/debian:11-slim


### PR DESCRIPTION
No reason to expect that this is exploitable but we'd like to patch anyway

I manually confirmed that the upstream versions listed (`20230311+deb12u1` and `20210119`) are indeed the latest available versions.