### PR TITLE
Fix conversion Bundle->ClusterBundle

### DIFF
--- a/pkg/apis/trust/v1alpha1/conversion.go
+++ b/pkg/apis/trust/v1alpha1/conversion.go
@@ -17,7 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
 	"slices"
+	"strings"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	apimachineryconversion "k8s.io/apimachinery/pkg/conversion"
@@ -27,10 +29,19 @@ import (
 	trustv1alpha2 "github.com/cert-manager/trust-manager/pkg/apis/trustmanager/v1alpha2"
 )
 
-const annotationKeyJKSKey = "internal.trust-manager.io/jks-key"
+// AnnotationKeyJKSKey is the controller-internal annotation key used to indicate the key (if any)
+// in the ClusterBundle target specification that should be encoded with the legacy JKS encoder.
+// The JKS additional format is deprecated in the Bundle API, but we don't want to break users
+// when upgrading to a trust-manager to a release with support for ClusterBundle.
+// Support for this annotation using the legacy encoder will be removed together with the removal
+// of the v1alpha1 Bundle API.
+const AnnotationKeyJKSKey = "internal.trust-manager.io/jks-key"
 
 func (src *Bundle) ConvertTo(dstRaw conversion.Hub) error {
-	dst := dstRaw.(*trustv1alpha2.ClusterBundle)
+	dst, ok := dstRaw.(*trustv1alpha2.ClusterBundle)
+	if !ok {
+		return fmt.Errorf("expected a ClusterBundle, but got a %T", dstRaw)
+	}
 	dst.ObjectMeta = src.ObjectMeta
 
 	scheme := runtime.NewScheme()
@@ -53,6 +64,9 @@ func (src *Bundle) ConvertTo(dstRaw conversion.Hub) error {
 	dst.Spec.Sources = slices.DeleteFunc(dst.Spec.Sources, func(bs trustv1alpha2.BundleSource) bool {
 		return bs == trustv1alpha2.BundleSource{}
 	})
+	if len(dst.Spec.Sources) == 0 {
+		dst.Spec.Sources = nil
+	}
 
 	return nil
 }
@@ -78,7 +92,16 @@ func Convert_v1alpha1_BundleSource_To_v1alpha2_BundleSource(in *BundleSource, ou
 
 	if in.InLine != nil {
 		obj := scope.Meta().Context.(*trustv1alpha2.ClusterBundle)
-		obj.Spec.InLineCAs = in.InLine
+		if obj.Spec.InLineCAs == nil {
+			obj.Spec.InLineCAs = in.InLine
+		} else {
+			// The following logic is not pretty, but is required as we allow multiple inline sources
+			// in the Bundle sources array.
+			// It breaks the round-trippable conversion Bundle->ClusterBundle->Bundle,
+			// but works for converting Bundle->ClusterBundle, and that's what we need for the migration.
+			cas := strings.TrimSuffix(*obj.Spec.InLineCAs, "\n") + "\n" + *in.InLine
+			obj.Spec.InLineCAs = &cas
+		}
 	}
 	if in.UseDefaultCAs != nil {
 		obj := scope.Meta().Context.(*trustv1alpha2.ClusterBundle)
@@ -122,7 +145,7 @@ func Convert_v1alpha1_BundleTarget_To_v1alpha2_BundleTarget(in *BundleTarget, ou
 			if obj.Annotations == nil {
 				obj.Annotations = map[string]string{}
 			}
-			obj.Annotations[annotationKeyJKSKey] = targetKV.Key
+			obj.Annotations[AnnotationKeyJKSKey] = targetKV.Key
 		}
 		if in.AdditionalFormats.PKCS12 != nil {
 			targetKV := trustv1alpha2.TargetKeyValue{
@@ -166,7 +189,10 @@ func Convert_v1alpha1_PKCS12_To_v1alpha2_PKCS12(in *PKCS12, out *trustv1alpha2.P
 }
 
 func (dst *Bundle) ConvertFrom(srcRaw conversion.Hub) error {
-	src := srcRaw.(*trustv1alpha2.ClusterBundle)
+	src, ok := srcRaw.(*trustv1alpha2.ClusterBundle)
+	if !ok {
+		return fmt.Errorf("expected a ClusterBundle, but got a %T", srcRaw)
+	}
 	dst.ObjectMeta = src.ObjectMeta
 
 	scheme := runtime.NewScheme()
@@ -243,7 +269,7 @@ func Convert_v1alpha2_BundleTarget_To_v1alpha1_BundleTarget(in *trustv1alpha2.Bu
 	var pkcs12 *PKCS12
 	for _, tkv := range targetKeyValues {
 		if tkv.Format == trustv1alpha2.BundleFormatPKCS12 {
-			if k, ok := obj.Annotations[annotationKeyJKSKey]; ok && k == tkv.Key {
+			if k, ok := obj.Annotations[AnnotationKeyJKSKey]; ok && k == tkv.Key {
 				jks = &JKS{}
 				jks.Key = tkv.Key
 				jks.Password = tkv.PKCS12.Password
@@ -269,7 +295,7 @@ func Convert_v1alpha2_BundleTarget_To_v1alpha1_BundleTarget(in *trustv1alpha2.Bu
 		}
 	}
 
-	delete(obj.Annotations, annotationKeyJKSKey)
+	delete(obj.Annotations, AnnotationKeyJKSKey)
 	if len(obj.Annotations) == 0 {
 		obj.Annotations = nil
 	}

--- a/pkg/bundle/controller/bundle_controller.go
+++ b/pkg/bundle/controller/bundle_controller.go
@@ -103,6 +103,8 @@ func (r *BundleReconciler) applyClusterBundle(ctx context.Context, bundle *trust
 		return fmt.Errorf("failed to set ClusterBundle controller reference: %w", err)
 	}
 
+	clusterBundle.APIVersion = "trust-manager.io/v1alpha2"
+	clusterBundle.Kind = "ClusterBundle"
 	encodedPatch, err := json.Marshal(clusterBundle)
 	if err != nil {
 		return fmt.Errorf("failed to marshal ClusterBundle patch: %w", err)
@@ -157,9 +159,10 @@ func convertBundleToClusterBundle(bundle *trustapi.Bundle) (*trustmanagerapi.Clu
 	}
 
 	clusterBundle := &trustmanagerapi.ClusterBundle{}
-	clusterBundle.APIVersion = "trust-manager.io/v1alpha2"
-	clusterBundle.Kind = "ClusterBundle"
-	clusterBundle.Name = bundle.Name
+	clusterBundle.Name = cb.Name
+	if jksKey, ok := cb.Annotations[trustapi.AnnotationKeyJKSKey]; ok {
+		clusterBundle.Annotations = map[string]string{trustapi.AnnotationKeyJKSKey: jksKey}
+	}
 	clusterBundle.Spec = cb.Spec
 	return clusterBundle, nil
 }


### PR DESCRIPTION
This change is extracted from https://github.com/cert-manager/trust-manager/pull/702 to make that PR smaller and easier to review.

While working on the user-facing migration, I struggled to get some of the tests to pass. After investigation, I detected some bugs that need to be fixed:

1. We allow multiple source elements with in-line CA certificates in the `Bundle` sources array, while `ClusterBundle` only provides a single field for this. This mismatch (many-to-one) is a bit problematic; I considered several ways to fix this, but ended up with the simplest solution: concatenate all in-line source CA certificates into the `ClusterBundle` `inLineCAs` field when converting. This breaks round-trip conversion, but we only need conversion from `Bundle` to `ClusterBundle`.
2. One of our integration tests is asserting that we can produce the legacy JKS format. And this test breaks if using the PCKS#12 encoder to encode the JKS. To ensure we don't break any users, it is required to keep the legacy JKS encoder until we remove JKS support completely. To choose the correct encoder to use, we need an annotation to support the migrated bundle controller in https://github.com/cert-manager/trust-manager/pull/702