### PR TITLE
Introduce Kube API linter

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,0 +1,5 @@
+version: v2.8.0
+name: golangci-kube-api-linter
+plugins:
+- module: 'sigs.k8s.io/kube-api-linter'
+  version: 'v0.0.0-20260114104534-18147eee9c49' # Pin to a commit while there's no tag

--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -1,0 +1,41 @@
+version: "2"
+linters:
+  default: none
+  enable:
+    - kubeapilinter
+  settings:
+    custom:
+      kubeapilinter:
+        type: module
+        description: Kube API Linter lints Kube like APIs based on API conventions and best practices.
+        settings:
+          linters:
+            enable:
+              - statusoptional # Ensures status fields are marked as optional
+              - statussubresource # Validates status subresource configuration
+            # Linters that are not enabled by default, but recommended
+            #  - maxlength # Checks for maximum length constraints on strings and arrays
+            #  - minlength # Checks for minium length constraints on strings, arrays, maps and structs
+            #  - nobools # Prevents usage of boolean types
+            disable:
+              - arrayofstruct # Ensures arrays of structs have at least one required field
+              - commentstart # Ensures comments start with the serialized form of the type
+              - nonpointerstructs # Ensures non-pointer structs are marked correctly with required/optional markers
+              - optionalfields # Validates optional field conventions
+              - requiredfields # Validates required field conventions
+          lintersConfig:
+            conditions:
+              useProtobuf: Forbid
+              usePatchStrategy: Forbid
+            defaults:
+              preferredDefaultMarker: kubebuilder:default
+  exclusions:
+    generated: strict
+    paths-except:
+      - pkg/apis/
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+run:
+  timeout: 5m
+  tests: false

--- a/deploy/crds/trust-manager.io_clusterbundles.yaml
+++ b/deploy/crds/trust-manager.io_clusterbundles.yaml
@@ -493,8 +493,6 @@ spec:
                   and will be the same for the same version of a bundle with identical certificates.
                 type: string
             type: object
-        required:
-        - spec
         type: object
     served: true
     storage: true

--- a/make/02_mod.mk
+++ b/make/02_mod.mk
@@ -101,3 +101,5 @@ generate-conversion: | $(NEEDS_CONVERSION-GEN)
 		./pkg/apis/trust/v1alpha1
 
 shared_generate_targets += generate-conversion
+
+include make/kube-api-lint.mk

--- a/make/kube-api-lint.mk
+++ b/make/kube-api-lint.mk
@@ -1,0 +1,40 @@
+# Copyright 2026 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+KUBE_API_LINT := $(bin_dir)/tools/kube-api-lint
+
+$(KUBE_API_LINT): | $(NEEDS_GO) $(NEEDS_GOLANGCI-LINT) $(bin_dir)/scratch
+	@echo "Building kube-api-lint custom golangci-lint binary"
+	GOVERSION=$(VENDORED_GO_VERSION) \
+		$(GOLANGCI-LINT) custom -v \
+		--destination $(bin_dir)/tools \
+		--name kube-api-lint
+
+.PHONY: verify-kube-api-lint
+## Verify all APIs using Kube API Linter
+## @category [shared] Generate/ Verify
+verify-kube-api-lint: | $(NEEDS_GO) $(KUBE_API_LINT)
+	@echo "Running kube-api-lint"
+	GOVERSION=$(VENDORED_GO_VERSION) \
+		$(KUBE_API_LINT) run -c $(CURDIR)/.golangci-kal.yml
+
+shared_verify_targets_dirty += verify-kube-api-lint
+
+.PHONY: fix-kube-api-lint
+## Fix all APIs using Kube API Linter
+## @category [shared] Generate/ Verify
+fix-kube-api-lint: | $(NEEDS_GO) $(KUBE_API_LINT)
+	@echo "Running kube-api-lint with --fix"
+	GOVERSION=$(VENDORED_GO_VERSION) \
+		$(KUBE_API_LINT) run --fix -c $(CURDIR)/.golangci-kal.yml

--- a/pkg/apis/trust/v1alpha1/types_bundle.go
+++ b/pkg/apis/trust/v1alpha1/types_bundle.go
@@ -42,6 +42,7 @@ type Bundle struct {
 	metav1.ObjectMeta `json:"metadata"`
 
 	// Desired state of the Bundle resource.
+	// +required
 	Spec BundleSpec `json:"spec"`
 
 	// Status of the Bundle. This is set and managed automatically.
@@ -60,6 +61,7 @@ type BundleList struct {
 // BundleSpec defines the desired state of a Bundle.
 type BundleSpec struct {
 	// Sources is a set of references to data whose data will sync to the target.
+	// +required
 	// +listType=atomic
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=100
@@ -147,11 +149,11 @@ type JKS struct {
 	KeySelector `json:",inline"`
 
 	// Password for JKS trust store
-	//+optional
-	//+kubebuilder:validation:MinLength=1
-	//+kubebuilder:validation:MaxLength=128
-	//+kubebuilder:default=changeit
-	Password *string `json:"password"`
+	// +optional
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=128
+	// +kubebuilder:default=changeit
+	Password *string `json:"password,omitempty"`
 }
 
 // PKCS12 specifies additional target PKCS#12 files
@@ -160,9 +162,9 @@ type PKCS12 struct {
 	KeySelector `json:",inline"`
 
 	// Password for PKCS12 trust store
-	//+optional
-	//+kubebuilder:validation:MaxLength=128
-	//+kubebuilder:default=""
+	// +optional
+	// +kubebuilder:validation:MaxLength=128
+	// +kubebuilder:default=""
 	Password *string `json:"password,omitempty"`
 
 	// Profile specifies the certificate encryption algorithms and the HMAC algorithm
@@ -198,29 +200,30 @@ const (
 type SourceObjectKeySelector struct {
 	// Name is the name of the source object in the trust Namespace.
 	// This field must be left empty when `selector` is set
-	//+optional
+	// +optional
 	// +kubebuilder:validation:MinLength=1
 	Name string `json:"name,omitempty"`
 
 	// Selector is the label selector to use to fetch a list of objects. Must not be set
 	// when `Name` is set.
-	//+optional
+	// +optional
 	Selector *metav1.LabelSelector `json:"selector,omitempty"`
 
 	// Key of the entry in the object's `data` field to be used.
-	//+optional
+	// +optional
 	// +kubebuilder:validation:MinLength=1
 	Key string `json:"key,omitempty"`
 
 	// IncludeAllKeys is a flag to include all keys in the object's `data` field to be used. False by default.
 	// This field must not be true when `Key` is set.
-	//+optional
+	// +optional
 	IncludeAllKeys bool `json:"includeAllKeys,omitempty"`
 }
 
 // TargetTemplate defines the form of the Kubernetes Secret or ConfigMap bundle targets.
 type TargetTemplate struct {
 	// Key is the key of the entry in the object's `data` field to be used.
+	// +required
 	// +kubebuilder:validation:MinLength=1
 	Key string `json:"key"`
 
@@ -248,6 +251,7 @@ func (t *TargetTemplate) GetLabels() map[string]string {
 // KeySelector is a reference to a key for some map data object.
 type KeySelector struct {
 	// Key is the key of the entry in the object's `data` field to be used.
+	// +required
 	// +kubebuilder:validation:MinLength=1
 	Key string `json:"key"`
 }

--- a/pkg/apis/trustmanager/v1alpha2/types_cluster_bundle.go
+++ b/pkg/apis/trustmanager/v1alpha2/types_cluster_bundle.go
@@ -42,7 +42,8 @@ type ClusterBundle struct {
 	metav1.ObjectMeta `json:"metadata"`
 
 	// Desired state of the Bundle resource.
-	Spec BundleSpec `json:"spec"`
+	// +optional
+	Spec BundleSpec `json:"spec,omitzero"`
 
 	// Status of the Bundle. This is set and managed automatically.
 	// +optional
@@ -95,6 +96,7 @@ type BundleSource struct {
 	// Key(s) of the entry in the object's `data` field to be used.
 	// Wildcards "*" in Key matches any sequence characters.
 	// A Key containing only "*" will match all data fields.
+	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:Pattern=`^[0-9A-Za-z_.\-*]+$`
 	Key string `json:"key"`
@@ -115,6 +117,7 @@ type BundleTarget struct {
 	Secret *KeyValueTarget `json:"secret,omitempty"`
 
 	// NamespaceSelector specifies the namespaces where target resources will be synced.
+	// +required
 	NamespaceSelector *metav1.LabelSelector `json:"namespaceSelector"`
 }
 
@@ -123,8 +126,8 @@ type BundleTarget struct {
 type PKCS12 struct {
 	// Password for PKCS12 trust store.
 	// By default, no password is used (password-less PKCS#12).
-	//+optional
-	//+kubebuilder:validation:MaxLength=128
+	// +optional
+	// +kubebuilder:validation:MaxLength=128
 	Password *string `json:"password,omitempty"`
 
 	// Profile specifies the certificate encryption algorithms and the HMAC algorithm
@@ -163,25 +166,27 @@ const (
 // +kubebuilder:validation:XValidation:rule="[has(self.name), has(self.selector)].exists_one(x,x)", message="exactly one of the following fields must be provided: [name, selector]"
 type SourceReference struct {
 	// Kind is the kind of the source object.
+	// +required
 	// +kubebuilder:validation:Enum=ConfigMap;Secret
 	Kind string `json:"kind"`
 
 	// Name is the name of the source object in the trust Namespace.
 	// This field must be left empty when `selector` is set
-	//+optional
+	// +optional
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
 	Name string `json:"name,omitempty"`
 
 	// Selector is the label selector to use to fetch a list of objects. Must not be set
 	// when `Name` is set.
-	//+optional
+	// +optional
 	Selector *metav1.LabelSelector `json:"selector,omitempty"`
 }
 
 // KeyValueTarget is the specification of key value target resources as ConfigMaps and Secrets.
 type KeyValueTarget struct {
 	// Data is the specification of the object's `data` field.
+	// +required
 	// +listType=map
 	// +listMapKey=key
 	// +kubebuilder:validation:MinItems=1
@@ -215,13 +220,14 @@ func (t *KeyValueTarget) GetLabels() map[string]string {
 // +kubebuilder:validation:XValidation:rule="!has(self.profile) || (has(self.format) && self.format == 'PKCS12')", reason=FieldValueForbidden, fieldPath=".profile", message="may only be set when format is 'PKCS12'"
 type TargetKeyValue struct {
 	// Key is the key of the entry in the object's `data` field to be used.
+	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:Pattern=`^[0-9A-Za-z_.\-]+$`
 	Key string `json:"key"`
 
 	// Format defines the format of the target value.
 	// The default format is PEM.
-	//+optional
+	// +optional
 	Format BundleFormat `json:"format,omitempty"`
 
 	// PKCS12 specifies configs for PKCS#12 files.


### PR DESCRIPTION
This PR introduces the relatively new Kube Sigs project [Kube API Linter](https://github.com/kubernetes-sigs/kube-api-linter). I personally think this linter adds a lot of value to the extended Kube operator community. It provides a growing list of useful [linters](https://github.com/kubernetes-sigs/kube-api-linter/blob/main/docs/linters.md).

My end-goal in cert-manager Org is to have a new module for this in makefile-modules and enable it on all our operators.
But let's start simple here in trust-manager, where I want to ensure that the new `ClusterBundle` API is passing Kube API lint checks before it's released to users.

In this initial PR, I am suggesting the following goals:

- Add initial plumbing: make targets, build config, and configuration.
- Enable, configure, and fix checks that do not greatly impact the final API spec (CRDs).
- Disable checks that are enabled by default, but will require a massive changeset and/or affect the API spec (CRDs) to fix.