### PR TITLE
Enable the CommentStart KAL check and fix violations

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -19,7 +19,6 @@ linters:
             #  - nobools # Prevents usage of boolean types
             disable:
               - arrayofstruct # Ensures arrays of structs have at least one required field
-              - commentstart # Ensures comments start with the serialized form of the type
               - nonpointerstructs # Ensures non-pointer structs are marked correctly with required/optional markers
               - optionalfields # Validates optional field conventions
               - requiredfields # Validates required field conventions

--- a/deploy/charts/trust-manager/templates/crd-trust.cert-manager.io_bundles.yaml
+++ b/deploy/charts/trust-manager/templates/crd-trust.cert-manager.io_bundles.yaml
@@ -61,10 +61,10 @@ spec:
             metadata:
               type: object
             spec:
-              description: Desired state of the Bundle resource.
+              description: spec represents the desired state of the Bundle resource.
               properties:
                 sources:
-                  description: Sources is a set of references to data whose data will sync to the target.
+                  description: sources is a set of references to data whose data will sync to the target.
                   items:
                     description: |-
                       BundleSource is the set of sources whose data will be appended and synced to
@@ -72,28 +72,28 @@ spec:
                     properties:
                       configMap:
                         description: |-
-                          ConfigMap is a reference (by name) to a ConfigMap's `data` key(s), or to a
-                          list of ConfigMap's `data` key(s) using label selector, in the trust Namespace.
+                          configMap is a reference (by name) to a ConfigMap's `data` key(s), or to a
+                          list of ConfigMap's `data` key(s) using label selector, in the trust namespace.
                         properties:
                           includeAllKeys:
                             description: |-
-                              IncludeAllKeys is a flag to include all keys in the object's `data` field to be used. False by default.
-                              This field must not be true when `Key` is set.
+                              includeAllKeys is a flag to include all keys in the object's `data` field to be used. False by default.
+                              This field must not be true when `key` is set.
                             type: boolean
                           key:
-                            description: Key of the entry in the object's `data` field to be used.
+                            description: key of the entry in the object's `data` field to be used.
                             minLength: 1
                             type: string
                           name:
                             description: |-
-                              Name is the name of the source object in the trust Namespace.
+                              name is the name of the source object in the trust namespace.
                               This field must be left empty when `selector` is set
                             minLength: 1
                             type: string
                           selector:
                             description: |-
-                              Selector is the label selector to use to fetch a list of objects. Must not be set
-                              when `Name` is set.
+                              selector is the label selector to use to fetch a list of objects. Must not be set
+                              when `name` is set.
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -139,32 +139,32 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                       inLine:
-                        description: InLine is a simple string to append as the source data.
+                        description: inLine is a simple string to append as the source data.
                         type: string
                       secret:
                         description: |-
-                          Secret is a reference (by name) to a Secret's `data` key(s), or to a
-                          list of Secret's `data` key(s) using label selector, in the trust Namespace.
+                          secret is a reference (by name) to a Secret's `data` key(s), or to a
+                          list of Secret's `data` key(s) using label selector, in the trust namespace.
                         properties:
                           includeAllKeys:
                             description: |-
-                              IncludeAllKeys is a flag to include all keys in the object's `data` field to be used. False by default.
-                              This field must not be true when `Key` is set.
+                              includeAllKeys is a flag to include all keys in the object's `data` field to be used. False by default.
+                              This field must not be true when `key` is set.
                             type: boolean
                           key:
-                            description: Key of the entry in the object's `data` field to be used.
+                            description: key of the entry in the object's `data` field to be used.
                             minLength: 1
                             type: string
                           name:
                             description: |-
-                              Name is the name of the source object in the trust Namespace.
+                              name is the name of the source object in the trust namespace.
                               This field must be left empty when `selector` is set
                             minLength: 1
                             type: string
                           selector:
                             description: |-
-                              Selector is the label selector to use to fetch a list of objects. Must not be set
-                              when `Name` is set.
+                              selector is the label selector to use to fetch a list of objects. Must not be set
+                              when `name` is set.
                             properties:
                               matchExpressions:
                                 description: matchExpressions is a list of label selector requirements. The requirements are ANDed.
@@ -211,14 +211,14 @@ spec:
                         x-kubernetes-map-type: atomic
                       useDefaultCAs:
                         description: |-
-                          UseDefaultCAs, when true, requests the default CA bundle to be used as a source.
-                          Default CAs are available if trust-manager was installed via Helm
-                          or was otherwise set up to include a package-injecting init container by using the
-                          "--default-package-location" flag when starting the trust-manager controller.
-                          If default CAs were not configured at start-up, any request to use the default
-                          CAs will fail.
-                          The version of the default CA package which is used for a Bundle is stored in the
-                          defaultCAPackageVersion field of the Bundle's status field.
+                          useDefaultCAs indicates whether the default CA bundle should be used as a source.
+                          The default CA bundle is available only if trust-manager was installed with
+                          default CA support enabled, either via the Helm chart or by starting the
+                          trust-manager controller with the "--default-package-location" flag.
+                          If default CA support was not enabled at startup, setting this field to true
+                          will result in reconciliation failure.
+                          The version of the default CA package used for this Bundle is reported in
+                          status.defaultCAVersion.
                         type: boolean
                     type: object
                     x-kubernetes-map-type: atomic
@@ -227,26 +227,26 @@ spec:
                   type: array
                   x-kubernetes-list-type: atomic
                 target:
-                  description: Target is the target location in all namespaces to sync source data to.
+                  description: target is the target location in all namespaces to sync source data to.
                   properties:
                     additionalFormats:
-                      description: AdditionalFormats specifies any additional formats to write to the target
+                      description: additionalFormats specifies any additional formats to write to the target
                       properties:
                         jks:
                           description: |-
-                            JKS requests a JKS-formatted binary trust bundle to be written to the target.
+                            jks requests a JKS-formatted binary trust bundle to be written to the target.
                             The bundle has "changeit" as the default password.
                             For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
                             Format is deprecated: Writing JKS is subject for removal. Please migrate to PKCS12.
                             PKCS#12 trust stores created by trust-manager are compatible with Java.
                           properties:
                             key:
-                              description: Key is the key of the entry in the object's `data` field to be used.
+                              description: key is the key of the entry in the object's `data` field to be used.
                               minLength: 1
                               type: string
                             password:
                               default: changeit
-                              description: Password for JKS trust store
+                              description: password for JKS trust store
                               maxLength: 128
                               minLength: 1
                               type: string
@@ -256,23 +256,23 @@ spec:
                           x-kubernetes-map-type: atomic
                         pkcs12:
                           description: |-
-                            PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the target.
+                            pkcs12 requests a PKCS12-formatted binary trust bundle to be written to the target.
 
                             The bundle is by default created without a password.
                             For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
                           properties:
                             key:
-                              description: Key is the key of the entry in the object's `data` field to be used.
+                              description: key is the key of the entry in the object's `data` field to be used.
                               minLength: 1
                               type: string
                             password:
                               default: ""
-                              description: Password for PKCS12 trust store
+                              description: password for PKCS12 trust store
                               maxLength: 128
                               type: string
                             profile:
                               description: |-
-                                Profile specifies the certificate encryption algorithms and the HMAC algorithm
+                                profile specifies the certificate encryption algorithms and the HMAC algorithm
                                 used to create the PKCS12 trust store.
 
                                 If provided, allowed values are:
@@ -293,25 +293,25 @@ spec:
                       type: object
                     configMap:
                       description: |-
-                        ConfigMap is the target ConfigMap in Namespaces that all Bundle source
+                        configMap is the target ConfigMap in Namespaces that all Bundle source
                         data will be synced to.
                       properties:
                         key:
-                          description: Key is the key of the entry in the object's `data` field to be used.
+                          description: key is the key of the entry in the object's `data` field to be used.
                           minLength: 1
                           type: string
                         metadata:
-                          description: Metadata is an optional set of labels and annotations to be copied to the target.
+                          description: metadata is an optional set of labels and annotations to be copied to the target.
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations is a key value map to be copied to the target.
+                              description: annotations is a key value map to be copied to the target.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
-                              description: Labels is a key value map to be copied to the target.
+                              description: labels is a key value map to be copied to the target.
                               type: object
                           type: object
                       required:
@@ -319,7 +319,7 @@ spec:
                       type: object
                     namespaceSelector:
                       description: |-
-                        NamespaceSelector will, if set, only sync the target resource in
+                        namespaceSelector will, if set, only sync the target resource in
                         Namespaces which match the selector.
                       properties:
                         matchExpressions:
@@ -365,26 +365,26 @@ spec:
                       x-kubernetes-map-type: atomic
                     secret:
                       description: |-
-                        Secret is the target Secret that all Bundle source data will be synced to.
+                        secret is the target Secret that all Bundle source data will be synced to.
                         Using Secrets as targets is only supported if enabled at trust-manager startup.
                         By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.
                       properties:
                         key:
-                          description: Key is the key of the entry in the object's `data` field to be used.
+                          description: key is the key of the entry in the object's `data` field to be used.
                           minLength: 1
                           type: string
                         metadata:
-                          description: Metadata is an optional set of labels and annotations to be copied to the target.
+                          description: metadata is an optional set of labels and annotations to be copied to the target.
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
-                              description: Annotations is a key value map to be copied to the target.
+                              description: annotations is a key value map to be copied to the target.
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
-                              description: Labels is a key value map to be copied to the target.
+                              description: labels is a key value map to be copied to the target.
                               type: object
                           type: object
                       required:
@@ -395,12 +395,10 @@ spec:
                 - sources
               type: object
             status:
-              description: Status of the Bundle. This is set and managed automatically.
+              description: status of the Bundle. This is set and managed automatically.
               properties:
                 conditions:
-                  description: |-
-                    List of status conditions to indicate the status of the Bundle.
-                    Known condition types are `Bundle`.
+                  description: conditions represent the latest available observations of the Bundle's current state.
                   items:
                     description: Condition contains details for one aspect of the current state of this API Resource.
                     properties:
@@ -460,10 +458,11 @@ spec:
                   x-kubernetes-list-type: map
                 defaultCAVersion:
                   description: |-
-                    DefaultCAPackageVersion, if set and non-empty, indicates the version information
-                    which was retrieved when the set of default CAs was requested in the bundle
-                    source. This should only be set if useDefaultCAs was set to "true" on a source,
-                    and will be the same for the same version of a bundle with identical certificates.
+                    defaultCAVersion is the version of the default CA package used when resolving
+                    the default CA source(s) for this Bundle (for example, when any source has
+                    useDefaultCAs set to true), if applicable.
+                    Bundles resolved from identical sets of default CA certificates will report
+                    the same defaultCAVersion value.
                   type: string
               type: object
           required:

--- a/deploy/crds/trust-manager.io_clusterbundles.yaml
+++ b/deploy/crds/trust-manager.io_clusterbundles.yaml
@@ -57,25 +57,26 @@ spec:
           metadata:
             type: object
           spec:
-            description: Desired state of the Bundle resource.
+            description: spec represents the desired state of the ClusterBundle resource.
             properties:
               inLineCAs:
-                description: InLine is a simple string to append as the source data.
+                description: inLineCAs is a simple string to append as the source
+                  data.
                 type: string
               includeDefaultCAs:
                 description: |-
-                  IncludeDefaultCAs, when true, requests the default CA bundle to be used as a source.
-                  Default CAs are available if trust-manager was installed via Helm
-                  or was otherwise set up to include a package-injecting init container by using the
-                  "--default-package-location" flag when starting the trust-manager controller.
-                  If default CAs were not configured at start-up, any request to use the default
-                  CAs will fail.
-                  The version of the default CA package which is used for a Bundle is stored in the
-                  defaultCAPackageVersion field of the Bundle's status field.
+                  includeDefaultCAs indicates whether the default CA bundle should be used as a source.
+                  The default CA bundle is available only if trust-manager was installed with
+                  default CA support enabled, either via the Helm chart or by starting the
+                  trust-manager controller with the "--default-package-location" flag.
+                  If default CA support was not enabled at startup, setting this field to true
+                  will result in reconciliation failure.
+                  The version of the default CA package used for this Bundle is reported in
+                  status.defaultCAVersion.
                 type: boolean
               sourceRefs:
                 description: |-
-                  SourceRefs is a list of references to resources whose data will be appended and synced into
+                  sourceRefs is a list of references to resources whose data will be appended and synced into
                   the bundle target resources.
                 items:
                   description: |-
@@ -84,29 +85,29 @@ spec:
                   properties:
                     key:
                       description: |-
-                        Key(s) of the entry in the object's `data` field to be used.
-                        Wildcards "*" in Key matches any sequence characters.
-                        A Key containing only "*" will match all data fields.
+                        key specifies one or more keys in the object's data field to be used.
+                        The "*" wildcard matches any sequence of characters within a key.
+                        A value of "*" matches all entries in the data field.
                       minLength: 1
                       pattern: ^[0-9A-Za-z_.\-*]+$
                       type: string
                     kind:
-                      description: Kind is the kind of the source object.
+                      description: kind is the kind of the source object.
                       enum:
                       - ConfigMap
                       - Secret
                       type: string
                     name:
                       description: |-
-                        Name is the name of the source object in the trust Namespace.
+                        name is the name of the source object in the trust namespace.
                         This field must be left empty when `selector` is set
                       maxLength: 253
                       minLength: 1
                       type: string
                     selector:
                       description: |-
-                        Selector is the label selector to use to fetch a list of objects. Must not be set
-                        when `Name` is set.
+                        selector is the label selector to use to fetch a list of objects. Must not be set
+                        when `name` is set.
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector
@@ -165,15 +166,15 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               target:
-                description: Target is the target location in all namespaces to sync
+                description: target is the target location in all namespaces to sync
                   source data to.
                 properties:
                   configMap:
-                    description: ConfigMap is the target ConfigMap in Namespaces that
+                    description: configMap is the target ConfigMap in Namespaces that
                       all Bundle source data will be synced to.
                     properties:
                       data:
-                        description: Data is the specification of the object's `data`
+                        description: data is the specification of the object's `data`
                           field.
                         items:
                           description: TargetKeyValue is the specification of a key
@@ -181,27 +182,27 @@ spec:
                           properties:
                             format:
                               description: |-
-                                Format defines the format of the target value.
+                                format defines the format of the target value.
                                 The default format is PEM.
                               enum:
                               - PEM
                               - PKCS12
                               type: string
                             key:
-                              description: Key is the key of the entry in the object's
+                              description: key is the key of the entry in the object's
                                 `data` field to be used.
                               minLength: 1
                               pattern: ^[0-9A-Za-z_.\-]+$
                               type: string
                             password:
                               description: |-
-                                Password for PKCS12 trust store.
+                                password for PKCS12 trust store.
                                 By default, no password is used (password-less PKCS#12).
                               maxLength: 128
                               type: string
                             profile:
                               description: |-
-                                Profile specifies the certificate encryption algorithms and the HMAC algorithm
+                                profile specifies the certificate encryption algorithms and the HMAC algorithm
                                 used to create the PKCS12 trust store.
 
                                 If provided, allowed values are:
@@ -237,13 +238,13 @@ spec:
                         - key
                         x-kubernetes-list-type: map
                       metadata:
-                        description: Metadata is an optional set of labels and annotations
+                        description: metadata is an optional set of labels and annotations
                           to be copied to the target.
                         properties:
                           annotations:
                             additionalProperties:
                               type: string
-                            description: Annotations is a key value map to be copied
+                            description: annotations is a key value map to be copied
                               to the target.
                             type: object
                             x-kubernetes-validations:
@@ -254,7 +255,7 @@ spec:
                           labels:
                             additionalProperties:
                               type: string
-                            description: Labels is a key value map to be copied to
+                            description: labels is a key value map to be copied to
                               the target.
                             type: object
                             x-kubernetes-validations:
@@ -267,7 +268,7 @@ spec:
                     - data
                     type: object
                   namespaceSelector:
-                    description: NamespaceSelector specifies the namespaces where
+                    description: namespaceSelector specifies the namespaces where
                       target resources will be synced.
                     properties:
                       matchExpressions:
@@ -315,12 +316,12 @@ spec:
                     x-kubernetes-map-type: atomic
                   secret:
                     description: |-
-                      Secret is the target Secret in Namespaces that all Bundle source data will be synced to.
+                      secret is the target Secret in Namespaces that all Bundle source data will be synced to.
                       Using Secrets as targets is only supported if enabled at trust-manager startup.
                       By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.
                     properties:
                       data:
-                        description: Data is the specification of the object's `data`
+                        description: data is the specification of the object's `data`
                           field.
                         items:
                           description: TargetKeyValue is the specification of a key
@@ -328,27 +329,27 @@ spec:
                           properties:
                             format:
                               description: |-
-                                Format defines the format of the target value.
+                                format defines the format of the target value.
                                 The default format is PEM.
                               enum:
                               - PEM
                               - PKCS12
                               type: string
                             key:
-                              description: Key is the key of the entry in the object's
+                              description: key is the key of the entry in the object's
                                 `data` field to be used.
                               minLength: 1
                               pattern: ^[0-9A-Za-z_.\-]+$
                               type: string
                             password:
                               description: |-
-                                Password for PKCS12 trust store.
+                                password for PKCS12 trust store.
                                 By default, no password is used (password-less PKCS#12).
                               maxLength: 128
                               type: string
                             profile:
                               description: |-
-                                Profile specifies the certificate encryption algorithms and the HMAC algorithm
+                                profile specifies the certificate encryption algorithms and the HMAC algorithm
                                 used to create the PKCS12 trust store.
 
                                 If provided, allowed values are:
@@ -384,13 +385,13 @@ spec:
                         - key
                         x-kubernetes-list-type: map
                       metadata:
-                        description: Metadata is an optional set of labels and annotations
+                        description: metadata is an optional set of labels and annotations
                           to be copied to the target.
                         properties:
                           annotations:
                             additionalProperties:
                               type: string
-                            description: Annotations is a key value map to be copied
+                            description: annotations is a key value map to be copied
                               to the target.
                             type: object
                             x-kubernetes-validations:
@@ -401,7 +402,7 @@ spec:
                           labels:
                             additionalProperties:
                               type: string
-                            description: Labels is a key value map to be copied to
+                            description: labels is a key value map to be copied to
                               the target.
                             type: object
                             x-kubernetes-validations:
@@ -422,12 +423,11 @@ spec:
                   rule: '[has(self.configMap), has(self.secret)].exists(x,x)'
             type: object
           status:
-            description: Status of the Bundle. This is set and managed automatically.
+            description: status of the ClusterBundle. This is set and managed automatically.
             properties:
               conditions:
-                description: |-
-                  List of status conditions to indicate the status of the Bundle.
-                  Known condition types are `Bundle`.
+                description: conditions represent the latest available observations
+                  of the ClusterBundle's current state.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -488,10 +488,11 @@ spec:
                 x-kubernetes-list-type: map
               defaultCAVersion:
                 description: |-
-                  DefaultCAPackageVersion, if set and non-empty, indicates the version information
-                  which was retrieved when the set of default CAs was requested in the bundle
-                  source. This should only be set if useDefaultCAs was set to "true" on a source,
-                  and will be the same for the same version of a bundle with identical certificates.
+                  defaultCAVersion is the version of the default CA package used for this ClusterBundle
+                  when resolving default CAs, if applicable.
+                  This field is populated only when spec.includeDefaultCAs is set to true.
+                  ClusterBundles resolved from identical sets of default CA certificates will report
+                  the same defaultCAVersion value.
                 type: string
             type: object
         type: object

--- a/deploy/crds/trust.cert-manager.io_bundles.yaml
+++ b/deploy/crds/trust.cert-manager.io_bundles.yaml
@@ -57,10 +57,10 @@ spec:
           metadata:
             type: object
           spec:
-            description: Desired state of the Bundle resource.
+            description: spec represents the desired state of the Bundle resource.
             properties:
               sources:
-                description: Sources is a set of references to data whose data will
+                description: sources is a set of references to data whose data will
                   sync to the target.
                 items:
                   description: |-
@@ -69,29 +69,29 @@ spec:
                   properties:
                     configMap:
                       description: |-
-                        ConfigMap is a reference (by name) to a ConfigMap's `data` key(s), or to a
-                        list of ConfigMap's `data` key(s) using label selector, in the trust Namespace.
+                        configMap is a reference (by name) to a ConfigMap's `data` key(s), or to a
+                        list of ConfigMap's `data` key(s) using label selector, in the trust namespace.
                       properties:
                         includeAllKeys:
                           description: |-
-                            IncludeAllKeys is a flag to include all keys in the object's `data` field to be used. False by default.
-                            This field must not be true when `Key` is set.
+                            includeAllKeys is a flag to include all keys in the object's `data` field to be used. False by default.
+                            This field must not be true when `key` is set.
                           type: boolean
                         key:
-                          description: Key of the entry in the object's `data` field
+                          description: key of the entry in the object's `data` field
                             to be used.
                           minLength: 1
                           type: string
                         name:
                           description: |-
-                            Name is the name of the source object in the trust Namespace.
+                            name is the name of the source object in the trust namespace.
                             This field must be left empty when `selector` is set
                           minLength: 1
                           type: string
                         selector:
                           description: |-
-                            Selector is the label selector to use to fetch a list of objects. Must not be set
-                            when `Name` is set.
+                            selector is the label selector to use to fetch a list of objects. Must not be set
+                            when `name` is set.
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector
@@ -139,34 +139,34 @@ spec:
                       type: object
                       x-kubernetes-map-type: atomic
                     inLine:
-                      description: InLine is a simple string to append as the source
+                      description: inLine is a simple string to append as the source
                         data.
                       type: string
                     secret:
                       description: |-
-                        Secret is a reference (by name) to a Secret's `data` key(s), or to a
-                        list of Secret's `data` key(s) using label selector, in the trust Namespace.
+                        secret is a reference (by name) to a Secret's `data` key(s), or to a
+                        list of Secret's `data` key(s) using label selector, in the trust namespace.
                       properties:
                         includeAllKeys:
                           description: |-
-                            IncludeAllKeys is a flag to include all keys in the object's `data` field to be used. False by default.
-                            This field must not be true when `Key` is set.
+                            includeAllKeys is a flag to include all keys in the object's `data` field to be used. False by default.
+                            This field must not be true when `key` is set.
                           type: boolean
                         key:
-                          description: Key of the entry in the object's `data` field
+                          description: key of the entry in the object's `data` field
                             to be used.
                           minLength: 1
                           type: string
                         name:
                           description: |-
-                            Name is the name of the source object in the trust Namespace.
+                            name is the name of the source object in the trust namespace.
                             This field must be left empty when `selector` is set
                           minLength: 1
                           type: string
                         selector:
                           description: |-
-                            Selector is the label selector to use to fetch a list of objects. Must not be set
-                            when `Name` is set.
+                            selector is the label selector to use to fetch a list of objects. Must not be set
+                            when `name` is set.
                           properties:
                             matchExpressions:
                               description: matchExpressions is a list of label selector
@@ -215,14 +215,14 @@ spec:
                       x-kubernetes-map-type: atomic
                     useDefaultCAs:
                       description: |-
-                        UseDefaultCAs, when true, requests the default CA bundle to be used as a source.
-                        Default CAs are available if trust-manager was installed via Helm
-                        or was otherwise set up to include a package-injecting init container by using the
-                        "--default-package-location" flag when starting the trust-manager controller.
-                        If default CAs were not configured at start-up, any request to use the default
-                        CAs will fail.
-                        The version of the default CA package which is used for a Bundle is stored in the
-                        defaultCAPackageVersion field of the Bundle's status field.
+                        useDefaultCAs indicates whether the default CA bundle should be used as a source.
+                        The default CA bundle is available only if trust-manager was installed with
+                        default CA support enabled, either via the Helm chart or by starting the
+                        trust-manager controller with the "--default-package-location" flag.
+                        If default CA support was not enabled at startup, setting this field to true
+                        will result in reconciliation failure.
+                        The version of the default CA package used for this Bundle is reported in
+                        status.defaultCAVersion.
                       type: boolean
                   type: object
                   x-kubernetes-map-type: atomic
@@ -231,29 +231,29 @@ spec:
                 type: array
                 x-kubernetes-list-type: atomic
               target:
-                description: Target is the target location in all namespaces to sync
+                description: target is the target location in all namespaces to sync
                   source data to.
                 properties:
                   additionalFormats:
-                    description: AdditionalFormats specifies any additional formats
+                    description: additionalFormats specifies any additional formats
                       to write to the target
                     properties:
                       jks:
                         description: |-
-                          JKS requests a JKS-formatted binary trust bundle to be written to the target.
+                          jks requests a JKS-formatted binary trust bundle to be written to the target.
                           The bundle has "changeit" as the default password.
                           For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
                           Format is deprecated: Writing JKS is subject for removal. Please migrate to PKCS12.
                           PKCS#12 trust stores created by trust-manager are compatible with Java.
                         properties:
                           key:
-                            description: Key is the key of the entry in the object's
+                            description: key is the key of the entry in the object's
                               `data` field to be used.
                             minLength: 1
                             type: string
                           password:
                             default: changeit
-                            description: Password for JKS trust store
+                            description: password for JKS trust store
                             maxLength: 128
                             minLength: 1
                             type: string
@@ -263,24 +263,24 @@ spec:
                         x-kubernetes-map-type: atomic
                       pkcs12:
                         description: |-
-                          PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the target.
+                          pkcs12 requests a PKCS12-formatted binary trust bundle to be written to the target.
 
                           The bundle is by default created without a password.
                           For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
                         properties:
                           key:
-                            description: Key is the key of the entry in the object's
+                            description: key is the key of the entry in the object's
                               `data` field to be used.
                             minLength: 1
                             type: string
                           password:
                             default: ""
-                            description: Password for PKCS12 trust store
+                            description: password for PKCS12 trust store
                             maxLength: 128
                             type: string
                           profile:
                             description: |-
-                              Profile specifies the certificate encryption algorithms and the HMAC algorithm
+                              profile specifies the certificate encryption algorithms and the HMAC algorithm
                               used to create the PKCS12 trust store.
 
                               If provided, allowed values are:
@@ -301,28 +301,28 @@ spec:
                     type: object
                   configMap:
                     description: |-
-                      ConfigMap is the target ConfigMap in Namespaces that all Bundle source
+                      configMap is the target ConfigMap in Namespaces that all Bundle source
                       data will be synced to.
                     properties:
                       key:
-                        description: Key is the key of the entry in the object's `data`
+                        description: key is the key of the entry in the object's `data`
                           field to be used.
                         minLength: 1
                         type: string
                       metadata:
-                        description: Metadata is an optional set of labels and annotations
+                        description: metadata is an optional set of labels and annotations
                           to be copied to the target.
                         properties:
                           annotations:
                             additionalProperties:
                               type: string
-                            description: Annotations is a key value map to be copied
+                            description: annotations is a key value map to be copied
                               to the target.
                             type: object
                           labels:
                             additionalProperties:
                               type: string
-                            description: Labels is a key value map to be copied to
+                            description: labels is a key value map to be copied to
                               the target.
                             type: object
                         type: object
@@ -331,7 +331,7 @@ spec:
                     type: object
                   namespaceSelector:
                     description: |-
-                      NamespaceSelector will, if set, only sync the target resource in
+                      namespaceSelector will, if set, only sync the target resource in
                       Namespaces which match the selector.
                     properties:
                       matchExpressions:
@@ -379,29 +379,29 @@ spec:
                     x-kubernetes-map-type: atomic
                   secret:
                     description: |-
-                      Secret is the target Secret that all Bundle source data will be synced to.
+                      secret is the target Secret that all Bundle source data will be synced to.
                       Using Secrets as targets is only supported if enabled at trust-manager startup.
                       By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.
                     properties:
                       key:
-                        description: Key is the key of the entry in the object's `data`
+                        description: key is the key of the entry in the object's `data`
                           field to be used.
                         minLength: 1
                         type: string
                       metadata:
-                        description: Metadata is an optional set of labels and annotations
+                        description: metadata is an optional set of labels and annotations
                           to be copied to the target.
                         properties:
                           annotations:
                             additionalProperties:
                               type: string
-                            description: Annotations is a key value map to be copied
+                            description: annotations is a key value map to be copied
                               to the target.
                             type: object
                           labels:
                             additionalProperties:
                               type: string
-                            description: Labels is a key value map to be copied to
+                            description: labels is a key value map to be copied to
                               the target.
                             type: object
                         type: object
@@ -413,12 +413,11 @@ spec:
             - sources
             type: object
           status:
-            description: Status of the Bundle. This is set and managed automatically.
+            description: status of the Bundle. This is set and managed automatically.
             properties:
               conditions:
-                description: |-
-                  List of status conditions to indicate the status of the Bundle.
-                  Known condition types are `Bundle`.
+                description: conditions represent the latest available observations
+                  of the Bundle's current state.
                 items:
                   description: Condition contains details for one aspect of the current
                     state of this API Resource.
@@ -479,10 +478,11 @@ spec:
                 x-kubernetes-list-type: map
               defaultCAVersion:
                 description: |-
-                  DefaultCAPackageVersion, if set and non-empty, indicates the version information
-                  which was retrieved when the set of default CAs was requested in the bundle
-                  source. This should only be set if useDefaultCAs was set to "true" on a source,
-                  and will be the same for the same version of a bundle with identical certificates.
+                  defaultCAVersion is the version of the default CA package used when resolving
+                  the default CA source(s) for this Bundle (for example, when any source has
+                  useDefaultCAs set to true), if applicable.
+                  Bundles resolved from identical sets of default CA certificates will report
+                  the same defaultCAVersion value.
                 type: string
             type: object
         required:

--- a/pkg/apis/trust/v1alpha1/types_bundle.go
+++ b/pkg/apis/trust/v1alpha1/types_bundle.go
@@ -38,14 +38,17 @@ var BundleHashAnnotationKey = "trust.cert-manager.io/hash"
 
 type Bundle struct {
 	metav1.TypeMeta `json:",inline"`
+
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	// +optional
 	metav1.ObjectMeta `json:"metadata"`
 
-	// Desired state of the Bundle resource.
+	// spec represents the desired state of the Bundle resource.
 	// +required
 	Spec BundleSpec `json:"spec"`
 
-	// Status of the Bundle. This is set and managed automatically.
+	// status of the Bundle. This is set and managed automatically.
 	// +optional
 	Status BundleStatus `json:"status,omitzero"`
 }
@@ -60,14 +63,14 @@ type BundleList struct {
 
 // BundleSpec defines the desired state of a Bundle.
 type BundleSpec struct {
-	// Sources is a set of references to data whose data will sync to the target.
+	// sources is a set of references to data whose data will sync to the target.
 	// +required
 	// +listType=atomic
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=100
 	Sources []BundleSource `json:"sources"`
 
-	// Target is the target location in all namespaces to sync source data to.
+	// target is the target location in all namespaces to sync source data to.
 	// +optional
 	Target BundleTarget `json:"target,omitzero"`
 }
@@ -76,28 +79,28 @@ type BundleSpec struct {
 // the BundleTarget in all Namespaces.
 // +structType=atomic
 type BundleSource struct {
-	// ConfigMap is a reference (by name) to a ConfigMap's `data` key(s), or to a
-	// list of ConfigMap's `data` key(s) using label selector, in the trust Namespace.
+	// configMap is a reference (by name) to a ConfigMap's `data` key(s), or to a
+	// list of ConfigMap's `data` key(s) using label selector, in the trust namespace.
 	// +optional
 	ConfigMap *SourceObjectKeySelector `json:"configMap,omitempty"`
 
-	// Secret is a reference (by name) to a Secret's `data` key(s), or to a
-	// list of Secret's `data` key(s) using label selector, in the trust Namespace.
+	// secret is a reference (by name) to a Secret's `data` key(s), or to a
+	// list of Secret's `data` key(s) using label selector, in the trust namespace.
 	// +optional
 	Secret *SourceObjectKeySelector `json:"secret,omitempty"`
 
-	// InLine is a simple string to append as the source data.
+	// inLine is a simple string to append as the source data.
 	// +optional
 	InLine *string `json:"inLine,omitempty"`
 
-	// UseDefaultCAs, when true, requests the default CA bundle to be used as a source.
-	// Default CAs are available if trust-manager was installed via Helm
-	// or was otherwise set up to include a package-injecting init container by using the
-	// "--default-package-location" flag when starting the trust-manager controller.
-	// If default CAs were not configured at start-up, any request to use the default
-	// CAs will fail.
-	// The version of the default CA package which is used for a Bundle is stored in the
-	// defaultCAPackageVersion field of the Bundle's status field.
+	// useDefaultCAs indicates whether the default CA bundle should be used as a source.
+	// The default CA bundle is available only if trust-manager was installed with
+	// default CA support enabled, either via the Helm chart or by starting the
+	// trust-manager controller with the "--default-package-location" flag.
+	// If default CA support was not enabled at startup, setting this field to true
+	// will result in reconciliation failure.
+	// The version of the default CA package used for this Bundle is reported in
+	// status.defaultCAVersion.
 	// +optional
 	UseDefaultCAs *bool `json:"useDefaultCAs,omitempty"`
 }
@@ -105,22 +108,22 @@ type BundleSource struct {
 // BundleTarget is the target resource that the Bundle will sync all source
 // data to.
 type BundleTarget struct {
-	// ConfigMap is the target ConfigMap in Namespaces that all Bundle source
+	// configMap is the target ConfigMap in Namespaces that all Bundle source
 	// data will be synced to.
 	// +optional
 	ConfigMap *TargetTemplate `json:"configMap,omitempty"`
 
-	// Secret is the target Secret that all Bundle source data will be synced to.
+	// secret is the target Secret that all Bundle source data will be synced to.
 	// Using Secrets as targets is only supported if enabled at trust-manager startup.
 	// By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.
 	// +optional
 	Secret *TargetTemplate `json:"secret,omitempty"`
 
-	// AdditionalFormats specifies any additional formats to write to the target
+	// additionalFormats specifies any additional formats to write to the target
 	// +optional
 	AdditionalFormats *AdditionalFormats `json:"additionalFormats,omitempty"`
 
-	// NamespaceSelector will, if set, only sync the target resource in
+	// namespaceSelector will, if set, only sync the target resource in
 	// Namespaces which match the selector.
 	// +optional
 	NamespaceSelector *metav1.LabelSelector `json:"namespaceSelector,omitempty"`
@@ -128,14 +131,14 @@ type BundleTarget struct {
 
 // AdditionalFormats specifies any additional formats to write to the target
 type AdditionalFormats struct {
-	// JKS requests a JKS-formatted binary trust bundle to be written to the target.
+	// jks requests a JKS-formatted binary trust bundle to be written to the target.
 	// The bundle has "changeit" as the default password.
 	// For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
 	// Format is deprecated: Writing JKS is subject for removal. Please migrate to PKCS12.
 	// PKCS#12 trust stores created by trust-manager are compatible with Java.
 	// +optional
 	JKS *JKS `json:"jks,omitempty"`
-	// PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the target.
+	// pkcs12 requests a PKCS12-formatted binary trust bundle to be written to the target.
 	//
 	// The bundle is by default created without a password.
 	// For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
@@ -148,7 +151,7 @@ type AdditionalFormats struct {
 type JKS struct {
 	KeySelector `json:",inline"`
 
-	// Password for JKS trust store
+	// password for JKS trust store
 	// +optional
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=128
@@ -161,13 +164,13 @@ type JKS struct {
 type PKCS12 struct {
 	KeySelector `json:",inline"`
 
-	// Password for PKCS12 trust store
+	// password for PKCS12 trust store
 	// +optional
 	// +kubebuilder:validation:MaxLength=128
 	// +kubebuilder:default=""
 	Password *string `json:"password,omitempty"`
 
-	// Profile specifies the certificate encryption algorithms and the HMAC algorithm
+	// profile specifies the certificate encryption algorithms and the HMAC algorithm
 	// used to create the PKCS12 trust store.
 	//
 	// If provided, allowed values are:
@@ -195,39 +198,39 @@ const (
 )
 
 // SourceObjectKeySelector is a reference to a source object and its `data` key(s)
-// in the trust Namespace.
+// in the trust namespace.
 // +structType=atomic
 type SourceObjectKeySelector struct {
-	// Name is the name of the source object in the trust Namespace.
+	// name is the name of the source object in the trust namespace.
 	// This field must be left empty when `selector` is set
 	// +optional
 	// +kubebuilder:validation:MinLength=1
 	Name string `json:"name,omitempty"`
 
-	// Selector is the label selector to use to fetch a list of objects. Must not be set
-	// when `Name` is set.
+	// selector is the label selector to use to fetch a list of objects. Must not be set
+	// when `name` is set.
 	// +optional
 	Selector *metav1.LabelSelector `json:"selector,omitempty"`
 
-	// Key of the entry in the object's `data` field to be used.
+	// key of the entry in the object's `data` field to be used.
 	// +optional
 	// +kubebuilder:validation:MinLength=1
 	Key string `json:"key,omitempty"`
 
-	// IncludeAllKeys is a flag to include all keys in the object's `data` field to be used. False by default.
-	// This field must not be true when `Key` is set.
+	// includeAllKeys is a flag to include all keys in the object's `data` field to be used. False by default.
+	// This field must not be true when `key` is set.
 	// +optional
 	IncludeAllKeys bool `json:"includeAllKeys,omitempty"`
 }
 
 // TargetTemplate defines the form of the Kubernetes Secret or ConfigMap bundle targets.
 type TargetTemplate struct {
-	// Key is the key of the entry in the object's `data` field to be used.
+	// key is the key of the entry in the object's `data` field to be used.
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	Key string `json:"key"`
 
-	// Metadata is an optional set of labels and annotations to be copied to the target.
+	// metadata is an optional set of labels and annotations to be copied to the target.
 	// +optional
 	Metadata *TargetMetadata `json:"metadata,omitempty"`
 }
@@ -250,7 +253,7 @@ func (t *TargetTemplate) GetLabels() map[string]string {
 
 // KeySelector is a reference to a key for some map data object.
 type KeySelector struct {
-	// Key is the key of the entry in the object's `data` field to be used.
+	// key is the key of the entry in the object's `data` field to be used.
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	Key string `json:"key"`
@@ -259,28 +262,28 @@ type KeySelector struct {
 // TargetMetadata defines the default labels and annotations
 // to be copied to the Kubernetes Secret or ConfigMap bundle targets.
 type TargetMetadata struct {
-	// Annotations is a key value map to be copied to the target.
+	// annotations is a key value map to be copied to the target.
 	// +optional
 	Annotations map[string]string `json:"annotations,omitempty"`
 
-	// Labels is a key value map to be copied to the target.
+	// labels is a key value map to be copied to the target.
 	// +optional
 	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // BundleStatus defines the observed state of the Bundle.
 type BundleStatus struct {
-	// List of status conditions to indicate the status of the Bundle.
-	// Known condition types are `Bundle`.
+	// conditions represent the latest available observations of the Bundle's current state.
 	// +listType=map
 	// +listMapKey=type
 	// +optional
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
-	// DefaultCAPackageVersion, if set and non-empty, indicates the version information
-	// which was retrieved when the set of default CAs was requested in the bundle
-	// source. This should only be set if useDefaultCAs was set to "true" on a source,
-	// and will be the same for the same version of a bundle with identical certificates.
+	// defaultCAVersion is the version of the default CA package used when resolving
+	// the default CA source(s) for this Bundle (for example, when any source has
+	// useDefaultCAs set to true), if applicable.
+	// Bundles resolved from identical sets of default CA certificates will report
+	// the same defaultCAVersion value.
 	// +optional
 	DefaultCAPackageVersion *string `json:"defaultCAVersion,omitempty"`
 }

--- a/pkg/applyconfigurations/trust/v1alpha1/additionalformats.go
+++ b/pkg/applyconfigurations/trust/v1alpha1/additionalformats.go
@@ -22,13 +22,13 @@ package v1alpha1
 //
 // AdditionalFormats specifies any additional formats to write to the target
 type AdditionalFormatsApplyConfiguration struct {
-	// JKS requests a JKS-formatted binary trust bundle to be written to the target.
+	// jks requests a JKS-formatted binary trust bundle to be written to the target.
 	// The bundle has "changeit" as the default password.
 	// For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
 	// Format is deprecated: Writing JKS is subject for removal. Please migrate to PKCS12.
 	// PKCS#12 trust stores created by trust-manager are compatible with Java.
 	JKS *JKSApplyConfiguration `json:"jks,omitempty"`
-	// PKCS12 requests a PKCS12-formatted binary trust bundle to be written to the target.
+	// pkcs12 requests a PKCS12-formatted binary trust bundle to be written to the target.
 	//
 	// The bundle is by default created without a password.
 	// For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords

--- a/pkg/applyconfigurations/trust/v1alpha1/bundle.go
+++ b/pkg/applyconfigurations/trust/v1alpha1/bundle.go
@@ -26,11 +26,13 @@ import (
 // BundleApplyConfiguration represents a declarative configuration of the Bundle type for use
 // with apply.
 type BundleApplyConfiguration struct {
-	v1.TypeMetaApplyConfiguration    `json:",inline"`
+	v1.TypeMetaApplyConfiguration `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	// Desired state of the Bundle resource.
+	// spec represents the desired state of the Bundle resource.
 	Spec *BundleSpecApplyConfiguration `json:"spec,omitempty"`
-	// Status of the Bundle. This is set and managed automatically.
+	// status of the Bundle. This is set and managed automatically.
 	Status *BundleStatusApplyConfiguration `json:"status,omitempty"`
 }
 

--- a/pkg/applyconfigurations/trust/v1alpha1/bundlesource.go
+++ b/pkg/applyconfigurations/trust/v1alpha1/bundlesource.go
@@ -23,22 +23,22 @@ package v1alpha1
 // BundleSource is the set of sources whose data will be appended and synced to
 // the BundleTarget in all Namespaces.
 type BundleSourceApplyConfiguration struct {
-	// ConfigMap is a reference (by name) to a ConfigMap's `data` key(s), or to a
-	// list of ConfigMap's `data` key(s) using label selector, in the trust Namespace.
+	// configMap is a reference (by name) to a ConfigMap's `data` key(s), or to a
+	// list of ConfigMap's `data` key(s) using label selector, in the trust namespace.
 	ConfigMap *SourceObjectKeySelectorApplyConfiguration `json:"configMap,omitempty"`
-	// Secret is a reference (by name) to a Secret's `data` key(s), or to a
-	// list of Secret's `data` key(s) using label selector, in the trust Namespace.
+	// secret is a reference (by name) to a Secret's `data` key(s), or to a
+	// list of Secret's `data` key(s) using label selector, in the trust namespace.
 	Secret *SourceObjectKeySelectorApplyConfiguration `json:"secret,omitempty"`
-	// InLine is a simple string to append as the source data.
+	// inLine is a simple string to append as the source data.
 	InLine *string `json:"inLine,omitempty"`
-	// UseDefaultCAs, when true, requests the default CA bundle to be used as a source.
-	// Default CAs are available if trust-manager was installed via Helm
-	// or was otherwise set up to include a package-injecting init container by using the
-	// "--default-package-location" flag when starting the trust-manager controller.
-	// If default CAs were not configured at start-up, any request to use the default
-	// CAs will fail.
-	// The version of the default CA package which is used for a Bundle is stored in the
-	// defaultCAPackageVersion field of the Bundle's status field.
+	// useDefaultCAs indicates whether the default CA bundle should be used as a source.
+	// The default CA bundle is available only if trust-manager was installed with
+	// default CA support enabled, either via the Helm chart or by starting the
+	// trust-manager controller with the "--default-package-location" flag.
+	// If default CA support was not enabled at startup, setting this field to true
+	// will result in reconciliation failure.
+	// The version of the default CA package used for this Bundle is reported in
+	// status.defaultCAVersion.
 	UseDefaultCAs *bool `json:"useDefaultCAs,omitempty"`
 }
 

--- a/pkg/applyconfigurations/trust/v1alpha1/bundlespec.go
+++ b/pkg/applyconfigurations/trust/v1alpha1/bundlespec.go
@@ -22,9 +22,9 @@ package v1alpha1
 //
 // BundleSpec defines the desired state of a Bundle.
 type BundleSpecApplyConfiguration struct {
-	// Sources is a set of references to data whose data will sync to the target.
+	// sources is a set of references to data whose data will sync to the target.
 	Sources []BundleSourceApplyConfiguration `json:"sources,omitempty"`
-	// Target is the target location in all namespaces to sync source data to.
+	// target is the target location in all namespaces to sync source data to.
 	Target *BundleTargetApplyConfiguration `json:"target,omitempty"`
 }
 

--- a/pkg/applyconfigurations/trust/v1alpha1/bundlestatus.go
+++ b/pkg/applyconfigurations/trust/v1alpha1/bundlestatus.go
@@ -26,13 +26,13 @@ import (
 //
 // BundleStatus defines the observed state of the Bundle.
 type BundleStatusApplyConfiguration struct {
-	// List of status conditions to indicate the status of the Bundle.
-	// Known condition types are `Bundle`.
+	// conditions represent the latest available observations of the Bundle's current state.
 	Conditions []v1.ConditionApplyConfiguration `json:"conditions,omitempty"`
-	// DefaultCAPackageVersion, if set and non-empty, indicates the version information
-	// which was retrieved when the set of default CAs was requested in the bundle
-	// source. This should only be set if useDefaultCAs was set to "true" on a source,
-	// and will be the same for the same version of a bundle with identical certificates.
+	// defaultCAVersion is the version of the default CA package used when resolving
+	// the default CA source(s) for this Bundle (for example, when any source has
+	// useDefaultCAs set to true), if applicable.
+	// Bundles resolved from identical sets of default CA certificates will report
+	// the same defaultCAVersion value.
 	DefaultCAPackageVersion *string `json:"defaultCAVersion,omitempty"`
 }
 

--- a/pkg/applyconfigurations/trust/v1alpha1/bundletarget.go
+++ b/pkg/applyconfigurations/trust/v1alpha1/bundletarget.go
@@ -27,16 +27,16 @@ import (
 // BundleTarget is the target resource that the Bundle will sync all source
 // data to.
 type BundleTargetApplyConfiguration struct {
-	// ConfigMap is the target ConfigMap in Namespaces that all Bundle source
+	// configMap is the target ConfigMap in Namespaces that all Bundle source
 	// data will be synced to.
 	ConfigMap *TargetTemplateApplyConfiguration `json:"configMap,omitempty"`
-	// Secret is the target Secret that all Bundle source data will be synced to.
+	// secret is the target Secret that all Bundle source data will be synced to.
 	// Using Secrets as targets is only supported if enabled at trust-manager startup.
 	// By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.
 	Secret *TargetTemplateApplyConfiguration `json:"secret,omitempty"`
-	// AdditionalFormats specifies any additional formats to write to the target
+	// additionalFormats specifies any additional formats to write to the target
 	AdditionalFormats *AdditionalFormatsApplyConfiguration `json:"additionalFormats,omitempty"`
-	// NamespaceSelector will, if set, only sync the target resource in
+	// namespaceSelector will, if set, only sync the target resource in
 	// Namespaces which match the selector.
 	NamespaceSelector *v1.LabelSelectorApplyConfiguration `json:"namespaceSelector,omitempty"`
 }

--- a/pkg/applyconfigurations/trust/v1alpha1/jks.go
+++ b/pkg/applyconfigurations/trust/v1alpha1/jks.go
@@ -23,7 +23,7 @@ package v1alpha1
 // JKS specifies additional target JKS files
 type JKSApplyConfiguration struct {
 	KeySelectorApplyConfiguration `json:",inline"`
-	// Password for JKS trust store
+	// password for JKS trust store
 	Password *string `json:"password,omitempty"`
 }
 

--- a/pkg/applyconfigurations/trust/v1alpha1/keyselector.go
+++ b/pkg/applyconfigurations/trust/v1alpha1/keyselector.go
@@ -22,7 +22,7 @@ package v1alpha1
 //
 // KeySelector is a reference to a key for some map data object.
 type KeySelectorApplyConfiguration struct {
-	// Key is the key of the entry in the object's `data` field to be used.
+	// key is the key of the entry in the object's `data` field to be used.
 	Key *string `json:"key,omitempty"`
 }
 

--- a/pkg/applyconfigurations/trust/v1alpha1/pkcs12.go
+++ b/pkg/applyconfigurations/trust/v1alpha1/pkcs12.go
@@ -27,9 +27,9 @@ import (
 // PKCS12 specifies additional target PKCS#12 files
 type PKCS12ApplyConfiguration struct {
 	KeySelectorApplyConfiguration `json:",inline"`
-	// Password for PKCS12 trust store
+	// password for PKCS12 trust store
 	Password *string `json:"password,omitempty"`
-	// Profile specifies the certificate encryption algorithms and the HMAC algorithm
+	// profile specifies the certificate encryption algorithms and the HMAC algorithm
 	// used to create the PKCS12 trust store.
 	//
 	// If provided, allowed values are:

--- a/pkg/applyconfigurations/trust/v1alpha1/sourceobjectkeyselector.go
+++ b/pkg/applyconfigurations/trust/v1alpha1/sourceobjectkeyselector.go
@@ -25,18 +25,18 @@ import (
 // with apply.
 //
 // SourceObjectKeySelector is a reference to a source object and its `data` key(s)
-// in the trust Namespace.
+// in the trust namespace.
 type SourceObjectKeySelectorApplyConfiguration struct {
-	// Name is the name of the source object in the trust Namespace.
+	// name is the name of the source object in the trust namespace.
 	// This field must be left empty when `selector` is set
 	Name *string `json:"name,omitempty"`
-	// Selector is the label selector to use to fetch a list of objects. Must not be set
-	// when `Name` is set.
+	// selector is the label selector to use to fetch a list of objects. Must not be set
+	// when `name` is set.
 	Selector *v1.LabelSelectorApplyConfiguration `json:"selector,omitempty"`
-	// Key of the entry in the object's `data` field to be used.
+	// key of the entry in the object's `data` field to be used.
 	Key *string `json:"key,omitempty"`
-	// IncludeAllKeys is a flag to include all keys in the object's `data` field to be used. False by default.
-	// This field must not be true when `Key` is set.
+	// includeAllKeys is a flag to include all keys in the object's `data` field to be used. False by default.
+	// This field must not be true when `key` is set.
 	IncludeAllKeys *bool `json:"includeAllKeys,omitempty"`
 }
 

--- a/pkg/applyconfigurations/trust/v1alpha1/targetmetadata.go
+++ b/pkg/applyconfigurations/trust/v1alpha1/targetmetadata.go
@@ -23,9 +23,9 @@ package v1alpha1
 // TargetMetadata defines the default labels and annotations
 // to be copied to the Kubernetes Secret or ConfigMap bundle targets.
 type TargetMetadataApplyConfiguration struct {
-	// Annotations is a key value map to be copied to the target.
+	// annotations is a key value map to be copied to the target.
 	Annotations map[string]string `json:"annotations,omitempty"`
-	// Labels is a key value map to be copied to the target.
+	// labels is a key value map to be copied to the target.
 	Labels map[string]string `json:"labels,omitempty"`
 }
 

--- a/pkg/applyconfigurations/trust/v1alpha1/targettemplate.go
+++ b/pkg/applyconfigurations/trust/v1alpha1/targettemplate.go
@@ -22,9 +22,9 @@ package v1alpha1
 //
 // TargetTemplate defines the form of the Kubernetes Secret or ConfigMap bundle targets.
 type TargetTemplateApplyConfiguration struct {
-	// Key is the key of the entry in the object's `data` field to be used.
+	// key is the key of the entry in the object's `data` field to be used.
 	Key *string `json:"key,omitempty"`
-	// Metadata is an optional set of labels and annotations to be copied to the target.
+	// metadata is an optional set of labels and annotations to be copied to the target.
 	Metadata *TargetMetadataApplyConfiguration `json:"metadata,omitempty"`
 }
 

--- a/pkg/applyconfigurations/trustmanager/v1alpha2/bundlesourceref.go
+++ b/pkg/applyconfigurations/trustmanager/v1alpha2/bundlesourceref.go
@@ -28,9 +28,9 @@ import (
 // the bundle target resources.
 type BundleSourceRefApplyConfiguration struct {
 	SourceReferenceApplyConfiguration `json:",inline"`
-	// Key(s) of the entry in the object's `data` field to be used.
-	// Wildcards "*" in Key matches any sequence characters.
-	// A Key containing only "*" will match all data fields.
+	// key specifies one or more keys in the object's data field to be used.
+	// The "*" wildcard matches any sequence of characters within a key.
+	// A value of "*" matches all entries in the data field.
 	Key *string `json:"key,omitempty"`
 }
 

--- a/pkg/applyconfigurations/trustmanager/v1alpha2/bundlespec.go
+++ b/pkg/applyconfigurations/trustmanager/v1alpha2/bundlespec.go
@@ -22,21 +22,21 @@ package v1alpha2
 //
 // BundleSpec defines the desired state of a Bundle.
 type BundleSpecApplyConfiguration struct {
-	// SourceRefs is a list of references to resources whose data will be appended and synced into
+	// sourceRefs is a list of references to resources whose data will be appended and synced into
 	// the bundle target resources.
 	SourceRefs []BundleSourceRefApplyConfiguration `json:"sourceRefs,omitempty"`
-	// IncludeDefaultCAs, when true, requests the default CA bundle to be used as a source.
-	// Default CAs are available if trust-manager was installed via Helm
-	// or was otherwise set up to include a package-injecting init container by using the
-	// "--default-package-location" flag when starting the trust-manager controller.
-	// If default CAs were not configured at start-up, any request to use the default
-	// CAs will fail.
-	// The version of the default CA package which is used for a Bundle is stored in the
-	// defaultCAPackageVersion field of the Bundle's status field.
+	// includeDefaultCAs indicates whether the default CA bundle should be used as a source.
+	// The default CA bundle is available only if trust-manager was installed with
+	// default CA support enabled, either via the Helm chart or by starting the
+	// trust-manager controller with the "--default-package-location" flag.
+	// If default CA support was not enabled at startup, setting this field to true
+	// will result in reconciliation failure.
+	// The version of the default CA package used for this Bundle is reported in
+	// status.defaultCAVersion.
 	IncludeDefaultCAs *bool `json:"includeDefaultCAs,omitempty"`
-	// InLine is a simple string to append as the source data.
+	// inLineCAs is a simple string to append as the source data.
 	InLineCAs *string `json:"inLineCAs,omitempty"`
-	// Target is the target location in all namespaces to sync source data to.
+	// target is the target location in all namespaces to sync source data to.
 	Target *BundleTargetApplyConfiguration `json:"target,omitempty"`
 }
 

--- a/pkg/applyconfigurations/trustmanager/v1alpha2/bundlestatus.go
+++ b/pkg/applyconfigurations/trustmanager/v1alpha2/bundlestatus.go
@@ -26,13 +26,13 @@ import (
 //
 // BundleStatus defines the observed state of the Bundle.
 type BundleStatusApplyConfiguration struct {
-	// List of status conditions to indicate the status of the Bundle.
-	// Known condition types are `Bundle`.
+	// conditions represent the latest available observations of the ClusterBundle's current state.
 	Conditions []v1.ConditionApplyConfiguration `json:"conditions,omitempty"`
-	// DefaultCAPackageVersion, if set and non-empty, indicates the version information
-	// which was retrieved when the set of default CAs was requested in the bundle
-	// source. This should only be set if useDefaultCAs was set to "true" on a source,
-	// and will be the same for the same version of a bundle with identical certificates.
+	// defaultCAVersion is the version of the default CA package used for this ClusterBundle
+	// when resolving default CAs, if applicable.
+	// This field is populated only when spec.includeDefaultCAs is set to true.
+	// ClusterBundles resolved from identical sets of default CA certificates will report
+	// the same defaultCAVersion value.
 	DefaultCAPackageVersion *string `json:"defaultCAVersion,omitempty"`
 }
 

--- a/pkg/applyconfigurations/trustmanager/v1alpha2/bundletarget.go
+++ b/pkg/applyconfigurations/trustmanager/v1alpha2/bundletarget.go
@@ -27,13 +27,13 @@ import (
 // BundleTarget is the target resource that the Bundle will sync all source
 // data to.
 type BundleTargetApplyConfiguration struct {
-	// ConfigMap is the target ConfigMap in Namespaces that all Bundle source data will be synced to.
+	// configMap is the target ConfigMap in Namespaces that all Bundle source data will be synced to.
 	ConfigMap *KeyValueTargetApplyConfiguration `json:"configMap,omitempty"`
-	// Secret is the target Secret in Namespaces that all Bundle source data will be synced to.
+	// secret is the target Secret in Namespaces that all Bundle source data will be synced to.
 	// Using Secrets as targets is only supported if enabled at trust-manager startup.
 	// By default, trust-manager has no permissions for writing to secrets and can only read secrets in the trust namespace.
 	Secret *KeyValueTargetApplyConfiguration `json:"secret,omitempty"`
-	// NamespaceSelector specifies the namespaces where target resources will be synced.
+	// namespaceSelector specifies the namespaces where target resources will be synced.
 	NamespaceSelector *v1.LabelSelectorApplyConfiguration `json:"namespaceSelector,omitempty"`
 }
 

--- a/pkg/applyconfigurations/trustmanager/v1alpha2/clusterbundle.go
+++ b/pkg/applyconfigurations/trustmanager/v1alpha2/clusterbundle.go
@@ -26,11 +26,13 @@ import (
 // ClusterBundleApplyConfiguration represents a declarative configuration of the ClusterBundle type for use
 // with apply.
 type ClusterBundleApplyConfiguration struct {
-	v1.TypeMetaApplyConfiguration    `json:",inline"`
+	v1.TypeMetaApplyConfiguration `json:",inline"`
+	// metadata is the standard object's metadata.
+	// More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#metadata
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	// Desired state of the Bundle resource.
+	// spec represents the desired state of the ClusterBundle resource.
 	Spec *BundleSpecApplyConfiguration `json:"spec,omitempty"`
-	// Status of the Bundle. This is set and managed automatically.
+	// status of the ClusterBundle. This is set and managed automatically.
 	Status *BundleStatusApplyConfiguration `json:"status,omitempty"`
 }
 

--- a/pkg/applyconfigurations/trustmanager/v1alpha2/keyvaluetarget.go
+++ b/pkg/applyconfigurations/trustmanager/v1alpha2/keyvaluetarget.go
@@ -22,9 +22,9 @@ package v1alpha2
 //
 // KeyValueTarget is the specification of key value target resources as ConfigMaps and Secrets.
 type KeyValueTargetApplyConfiguration struct {
-	// Data is the specification of the object's `data` field.
+	// data is the specification of the object's `data` field.
 	Data []TargetKeyValueApplyConfiguration `json:"data,omitempty"`
-	// Metadata is an optional set of labels and annotations to be copied to the target.
+	// metadata is an optional set of labels and annotations to be copied to the target.
 	Metadata *TargetMetadataApplyConfiguration `json:"metadata,omitempty"`
 }
 

--- a/pkg/applyconfigurations/trustmanager/v1alpha2/pkcs12.go
+++ b/pkg/applyconfigurations/trustmanager/v1alpha2/pkcs12.go
@@ -26,10 +26,10 @@ import (
 //
 // PKCS12 specifies configs for target PKCS#12 files.
 type PKCS12ApplyConfiguration struct {
-	// Password for PKCS12 trust store.
+	// password for PKCS12 trust store.
 	// By default, no password is used (password-less PKCS#12).
 	Password *string `json:"password,omitempty"`
-	// Profile specifies the certificate encryption algorithms and the HMAC algorithm
+	// profile specifies the certificate encryption algorithms and the HMAC algorithm
 	// used to create the PKCS12 trust store.
 	//
 	// If provided, allowed values are:

--- a/pkg/applyconfigurations/trustmanager/v1alpha2/sourcereference.go
+++ b/pkg/applyconfigurations/trustmanager/v1alpha2/sourcereference.go
@@ -26,13 +26,13 @@ import (
 //
 // SourceReference is a reference to a source object.
 type SourceReferenceApplyConfiguration struct {
-	// Kind is the kind of the source object.
+	// kind is the kind of the source object.
 	Kind *string `json:"kind,omitempty"`
-	// Name is the name of the source object in the trust Namespace.
+	// name is the name of the source object in the trust namespace.
 	// This field must be left empty when `selector` is set
 	Name *string `json:"name,omitempty"`
-	// Selector is the label selector to use to fetch a list of objects. Must not be set
-	// when `Name` is set.
+	// selector is the label selector to use to fetch a list of objects. Must not be set
+	// when `name` is set.
 	Selector *v1.LabelSelectorApplyConfiguration `json:"selector,omitempty"`
 }
 

--- a/pkg/applyconfigurations/trustmanager/v1alpha2/targetkeyvalue.go
+++ b/pkg/applyconfigurations/trustmanager/v1alpha2/targetkeyvalue.go
@@ -26,9 +26,9 @@ import (
 //
 // TargetKeyValue is the specification of a key with value in a key-value target resource.
 type TargetKeyValueApplyConfiguration struct {
-	// Key is the key of the entry in the object's `data` field to be used.
+	// key is the key of the entry in the object's `data` field to be used.
 	Key *string `json:"key,omitempty"`
-	// Format defines the format of the target value.
+	// format defines the format of the target value.
 	// The default format is PEM.
 	Format *trustmanagerv1alpha2.BundleFormat `json:"format,omitempty"`
 	// PKCS12 specifies configs for PKCS#12 files.

--- a/pkg/applyconfigurations/trustmanager/v1alpha2/targetmetadata.go
+++ b/pkg/applyconfigurations/trustmanager/v1alpha2/targetmetadata.go
@@ -23,9 +23,9 @@ package v1alpha2
 // TargetMetadata defines the default labels and annotations
 // to be copied to the Kubernetes Secret or ConfigMap bundle targets.
 type TargetMetadataApplyConfiguration struct {
-	// Annotations is a key value map to be copied to the target.
+	// annotations is a key value map to be copied to the target.
 	Annotations map[string]string `json:"annotations,omitempty"`
-	// Labels is a key value map to be copied to the target.
+	// labels is a key value map to be copied to the target.
 	Labels map[string]string `json:"labels,omitempty"`
 }
 


### PR DESCRIPTION
This is a follow-up PR after https://github.com/cert-manager/trust-manager/pull/850, that enables the [CommentStart](https://github.com/kubernetes-sigs/kube-api-linter/blob/main/docs/linters.md#commentstart) check and fixes current violations. As this only affects the documentation of fields, the change is non-breaking.

The initial/simple fixes were automatically done by KAL by running `make fix-kube-api-lint` locally. But it didn't manage to fix more complex constructs, so please review the updated field docs.