### PR TITLE
Fix events RBAC (new API group)

### DIFF
--- a/deploy/charts/trust-manager/templates/_helpers.tpl
+++ b/deploy/charts/trust-manager/templates/_helpers.tpl
@@ -77,7 +77,7 @@ Namespaced resources rules
   verbs: ["get","list","create","patch","watch","delete"]
 
 - apiGroups:
-  - ""
+  - "events.k8s.io"
   resources:
   - "events"
   verbs: ["create","patch"]


### PR DESCRIPTION
This PR fixes an oversight in https://github.com/cert-manager/trust-manager/pull/863. When migrating to the new events API group, we also need to update RBAC. This is listed as a breaking change in the controller-runtime release notes: https://github.com/kubernetes-sigs/controller-runtime/releases/tag/v0.23.0