### PR TITLE
Introduce KAL minlength/maxlength checks

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -11,11 +11,11 @@ linters:
         settings:
           linters:
             enable:
+              - maxlength # Checks for maximum length constraints on strings and arrays
+              - minlength # Checks for minimum length constraints on strings, arrays, maps and structs
               - statusoptional # Ensures status fields are marked as optional
               - statussubresource # Validates status subresource configuration
             # Linters that are not enabled by default, but recommended
-            #  - maxlength # Checks for maximum length constraints on strings and arrays
-            #  - minlength # Checks for minium length constraints on strings, arrays, maps and structs
             #  - nobools # Prevents usage of boolean types
             disable:
               - arrayofstruct # Ensures arrays of structs have at least one required field

--- a/deploy/charts/trust-manager/templates/crd-trust.cert-manager.io_bundles.yaml
+++ b/deploy/charts/trust-manager/templates/crd-trust.cert-manager.io_bundles.yaml
@@ -82,12 +82,14 @@ spec:
                             type: boolean
                           key:
                             description: key of the entry in the object's `data` field to be used.
+                            maxLength: 253
                             minLength: 1
                             type: string
                           name:
                             description: |-
                               name is the name of the source object in the trust namespace.
                               This field must be left empty when `selector` is set
+                            maxLength: 253
                             minLength: 1
                             type: string
                           selector:
@@ -138,8 +140,13 @@ spec:
                             x-kubernetes-map-type: atomic
                         type: object
                         x-kubernetes-map-type: atomic
+                        x-kubernetes-validations:
+                          - message: exactly one of the fields in [name selector] must be set
+                            rule: '[has(self.name),has(self.selector)].filter(x,x==true).size() == 1'
                       inLine:
                         description: inLine is a simple string to append as the source data.
+                        maxLength: 1048576
+                        minLength: 1
                         type: string
                       secret:
                         description: |-
@@ -153,12 +160,14 @@ spec:
                             type: boolean
                           key:
                             description: key of the entry in the object's `data` field to be used.
+                            maxLength: 253
                             minLength: 1
                             type: string
                           name:
                             description: |-
                               name is the name of the source object in the trust namespace.
                               This field must be left empty when `selector` is set
+                            maxLength: 253
                             minLength: 1
                             type: string
                           selector:
@@ -209,6 +218,9 @@ spec:
                             x-kubernetes-map-type: atomic
                         type: object
                         x-kubernetes-map-type: atomic
+                        x-kubernetes-validations:
+                          - message: exactly one of the fields in [name selector] must be set
+                            rule: '[has(self.name),has(self.selector)].filter(x,x==true).size() == 1'
                       useDefaultCAs:
                         description: |-
                           useDefaultCAs indicates whether the default CA bundle should be used as a source.
@@ -222,6 +234,9 @@ spec:
                         type: boolean
                     type: object
                     x-kubernetes-map-type: atomic
+                    x-kubernetes-validations:
+                      - message: exactly one of the fields in [configMap secret inLine useDefaultCAs] must be set
+                        rule: '[has(self.configMap),has(self.secret),has(self.inLine),has(self.useDefaultCAs)].filter(x,x==true).size() == 1'
                   maxItems: 100
                   minItems: 1
                   type: array
@@ -239,9 +254,11 @@ spec:
                             For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
                             Format is deprecated: Writing JKS is subject for removal. Please migrate to PKCS12.
                             PKCS#12 trust stores created by trust-manager are compatible with Java.
+                          minProperties: 1
                           properties:
                             key:
                               description: key is the key of the entry in the object's `data` field to be used.
+                              maxLength: 253
                               minLength: 1
                               type: string
                             password:
@@ -260,15 +277,18 @@ spec:
 
                             The bundle is by default created without a password.
                             For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
+                          minProperties: 1
                           properties:
                             key:
                               description: key is the key of the entry in the object's `data` field to be used.
+                              maxLength: 253
                               minLength: 1
                               type: string
                             password:
                               default: ""
                               description: password for PKCS12 trust store
                               maxLength: 128
+                              minLength: 0
                               type: string
                             profile:
                               description: |-
@@ -291,6 +311,9 @@ spec:
                           type: object
                           x-kubernetes-map-type: atomic
                       type: object
+                      x-kubernetes-validations:
+                        - message: at least one of the fields in [jks pkcs12] must be set
+                          rule: '[has(self.jks),has(self.pkcs12)].filter(x,x==true).size() >= 1'
                     configMap:
                       description: |-
                         configMap is the target ConfigMap in Namespaces that all Bundle source
@@ -298,20 +321,24 @@ spec:
                       properties:
                         key:
                           description: key is the key of the entry in the object's `data` field to be used.
+                          maxLength: 253
                           minLength: 1
                           type: string
                         metadata:
                           description: metadata is an optional set of labels and annotations to be copied to the target.
+                          minProperties: 1
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
                               description: annotations is a key value map to be copied to the target.
+                              minProperties: 1
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
                               description: labels is a key value map to be copied to the target.
+                              minProperties: 1
                               type: object
                           type: object
                       required:
@@ -371,31 +398,39 @@ spec:
                       properties:
                         key:
                           description: key is the key of the entry in the object's `data` field to be used.
+                          maxLength: 253
                           minLength: 1
                           type: string
                         metadata:
                           description: metadata is an optional set of labels and annotations to be copied to the target.
+                          minProperties: 1
                           properties:
                             annotations:
                               additionalProperties:
                                 type: string
                               description: annotations is a key value map to be copied to the target.
+                              minProperties: 1
                               type: object
                             labels:
                               additionalProperties:
                                 type: string
                               description: labels is a key value map to be copied to the target.
+                              minProperties: 1
                               type: object
                           type: object
                       required:
                         - key
                       type: object
                   type: object
+                  x-kubernetes-validations:
+                    - message: at least one of the fields in [configMap secret] must be set
+                      rule: '[has(self.configMap),has(self.secret)].filter(x,x==true).size() >= 1'
               required:
                 - sources
               type: object
             status:
               description: status of the Bundle. This is set and managed automatically.
+              minProperties: 1
               properties:
                 conditions:
                   description: conditions represent the latest available observations of the Bundle's current state.
@@ -452,6 +487,8 @@ spec:
                       - status
                       - type
                     type: object
+                  maxItems: 10
+                  minItems: 0
                   type: array
                   x-kubernetes-list-map-keys:
                     - type
@@ -463,6 +500,8 @@ spec:
                     useDefaultCAs set to true), if applicable.
                     Bundles resolved from identical sets of default CA certificates will report
                     the same defaultCAVersion value.
+                  maxLength: 253
+                  minLength: 1
                   type: string
               type: object
           required:

--- a/deploy/crds/trust-manager.io_clusterbundles.yaml
+++ b/deploy/crds/trust-manager.io_clusterbundles.yaml
@@ -58,6 +58,7 @@ spec:
             type: object
           spec:
             description: spec represents the desired state of the ClusterBundle resource.
+            minProperties: 1
             properties:
               defaultCAs:
                 description: defaultCAs configures the use of a default CA bundle
@@ -85,6 +86,8 @@ spec:
               inLineCAs:
                 description: inLineCAs is a simple string to append as the source
                   data.
+                maxLength: 1048576
+                minLength: 1
                 type: string
               sourceRefs:
                 description: |-
@@ -100,6 +103,7 @@ spec:
                         key specifies one or more keys in the object's data field to be used.
                         The "*" wildcard matches any sequence of characters within a key.
                         A value of "*" matches all entries in the data field.
+                      maxLength: 253
                       minLength: 1
                       pattern: ^[0-9A-Za-z_.\-*]+$
                       type: string
@@ -170,9 +174,10 @@ spec:
                   type: object
                   x-kubernetes-map-type: atomic
                   x-kubernetes-validations:
-                  - message: 'exactly one of the following fields must be provided:
-                      [name, selector]'
-                    rule: '[has(self.name), has(self.selector)].exists_one(x,x)'
+                  - message: exactly one of the fields in [name selector] must be
+                      set
+                    rule: '[has(self.name),has(self.selector)].filter(x,x==true).size()
+                      == 1'
                 maxItems: 100
                 minItems: 0
                 type: array
@@ -191,6 +196,7 @@ spec:
                         items:
                           description: TargetKeyValue is the specification of a key
                             with value in a key-value target resource.
+                          minProperties: 0
                           properties:
                             format:
                               description: |-
@@ -203,6 +209,7 @@ spec:
                             key:
                               description: key is the key of the entry in the object's
                                 `data` field to be used.
+                              maxLength: 253
                               minLength: 1
                               pattern: ^[0-9A-Za-z_.\-]+$
                               type: string
@@ -211,6 +218,7 @@ spec:
                                 password for PKCS12 trust store.
                                 By default, no password is used (password-less PKCS#12).
                               maxLength: 128
+                              minLength: 0
                               type: string
                             profile:
                               description: |-
@@ -252,12 +260,14 @@ spec:
                       metadata:
                         description: metadata is an optional set of labels and annotations
                           to be copied to the target.
+                        minProperties: 1
                         properties:
                           annotations:
                             additionalProperties:
                               type: string
                             description: annotations is a key value map to be copied
                               to the target.
+                            minProperties: 1
                             type: object
                             x-kubernetes-validations:
                             - message: must not use forbidden domains as prefixes
@@ -269,6 +279,7 @@ spec:
                               type: string
                             description: labels is a key value map to be copied to
                               the target.
+                            minProperties: 1
                             type: object
                             x-kubernetes-validations:
                             - message: must not use forbidden domains as prefixes
@@ -338,6 +349,7 @@ spec:
                         items:
                           description: TargetKeyValue is the specification of a key
                             with value in a key-value target resource.
+                          minProperties: 0
                           properties:
                             format:
                               description: |-
@@ -350,6 +362,7 @@ spec:
                             key:
                               description: key is the key of the entry in the object's
                                 `data` field to be used.
+                              maxLength: 253
                               minLength: 1
                               pattern: ^[0-9A-Za-z_.\-]+$
                               type: string
@@ -358,6 +371,7 @@ spec:
                                 password for PKCS12 trust store.
                                 By default, no password is used (password-less PKCS#12).
                               maxLength: 128
+                              minLength: 0
                               type: string
                             profile:
                               description: |-
@@ -399,12 +413,14 @@ spec:
                       metadata:
                         description: metadata is an optional set of labels and annotations
                           to be copied to the target.
+                        minProperties: 1
                         properties:
                           annotations:
                             additionalProperties:
                               type: string
                             description: annotations is a key value map to be copied
                               to the target.
+                            minProperties: 1
                             type: object
                             x-kubernetes-validations:
                             - message: must not use forbidden domains as prefixes
@@ -416,6 +432,7 @@ spec:
                               type: string
                             description: labels is a key value map to be copied to
                               the target.
+                            minProperties: 1
                             type: object
                             x-kubernetes-validations:
                             - message: must not use forbidden domains as prefixes
@@ -430,12 +447,14 @@ spec:
                 - namespaceSelector
                 type: object
                 x-kubernetes-validations:
-                - message: 'any of the following fields must be provided: [configMap,
-                    secret]'
-                  rule: '[has(self.configMap), has(self.secret)].exists(x,x)'
+                - message: at least one of the fields in [configMap secret] must be
+                    set
+                  rule: '[has(self.configMap),has(self.secret)].filter(x,x==true).size()
+                    >= 1'
             type: object
           status:
             description: status of the ClusterBundle. This is set and managed automatically.
+            minProperties: 1
             properties:
               conditions:
                 description: conditions represent the latest available observations
@@ -494,6 +513,8 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 10
+                minItems: 0
                 type: array
                 x-kubernetes-list-map-keys:
                 - type
@@ -505,6 +526,8 @@ spec:
                   This field is populated only when spec.includeDefaultCAs is set to true.
                   ClusterBundles resolved from identical sets of default CA certificates will report
                   the same defaultCAVersion value.
+                maxLength: 253
+                minLength: 1
                 type: string
             type: object
         type: object

--- a/deploy/crds/trust.cert-manager.io_bundles.yaml
+++ b/deploy/crds/trust.cert-manager.io_bundles.yaml
@@ -80,12 +80,14 @@ spec:
                         key:
                           description: key of the entry in the object's `data` field
                             to be used.
+                          maxLength: 253
                           minLength: 1
                           type: string
                         name:
                           description: |-
                             name is the name of the source object in the trust namespace.
                             This field must be left empty when `selector` is set
+                          maxLength: 253
                           minLength: 1
                           type: string
                         selector:
@@ -138,9 +140,16 @@ spec:
                           x-kubernetes-map-type: atomic
                       type: object
                       x-kubernetes-map-type: atomic
+                      x-kubernetes-validations:
+                      - message: exactly one of the fields in [name selector] must
+                          be set
+                        rule: '[has(self.name),has(self.selector)].filter(x,x==true).size()
+                          == 1'
                     inLine:
                       description: inLine is a simple string to append as the source
                         data.
+                      maxLength: 1048576
+                      minLength: 1
                       type: string
                     secret:
                       description: |-
@@ -155,12 +164,14 @@ spec:
                         key:
                           description: key of the entry in the object's `data` field
                             to be used.
+                          maxLength: 253
                           minLength: 1
                           type: string
                         name:
                           description: |-
                             name is the name of the source object in the trust namespace.
                             This field must be left empty when `selector` is set
+                          maxLength: 253
                           minLength: 1
                           type: string
                         selector:
@@ -213,6 +224,11 @@ spec:
                           x-kubernetes-map-type: atomic
                       type: object
                       x-kubernetes-map-type: atomic
+                      x-kubernetes-validations:
+                      - message: exactly one of the fields in [name selector] must
+                          be set
+                        rule: '[has(self.name),has(self.selector)].filter(x,x==true).size()
+                          == 1'
                     useDefaultCAs:
                       description: |-
                         useDefaultCAs indicates whether the default CA bundle should be used as a source.
@@ -226,6 +242,11 @@ spec:
                       type: boolean
                   type: object
                   x-kubernetes-map-type: atomic
+                  x-kubernetes-validations:
+                  - message: exactly one of the fields in [configMap secret inLine
+                      useDefaultCAs] must be set
+                    rule: '[has(self.configMap),has(self.secret),has(self.inLine),has(self.useDefaultCAs)].filter(x,x==true).size()
+                      == 1'
                 maxItems: 100
                 minItems: 1
                 type: array
@@ -245,10 +266,12 @@ spec:
                           For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
                           Format is deprecated: Writing JKS is subject for removal. Please migrate to PKCS12.
                           PKCS#12 trust stores created by trust-manager are compatible with Java.
+                        minProperties: 1
                         properties:
                           key:
                             description: key is the key of the entry in the object's
                               `data` field to be used.
+                            maxLength: 253
                             minLength: 1
                             type: string
                           password:
@@ -267,16 +290,19 @@ spec:
 
                           The bundle is by default created without a password.
                           For more information refer to this link https://cert-manager.io/docs/faq/#keystore-passwords
+                        minProperties: 1
                         properties:
                           key:
                             description: key is the key of the entry in the object's
                               `data` field to be used.
+                            maxLength: 253
                             minLength: 1
                             type: string
                           password:
                             default: ""
                             description: password for PKCS12 trust store
                             maxLength: 128
+                            minLength: 0
                             type: string
                           profile:
                             description: |-
@@ -299,6 +325,11 @@ spec:
                         type: object
                         x-kubernetes-map-type: atomic
                     type: object
+                    x-kubernetes-validations:
+                    - message: at least one of the fields in [jks pkcs12] must be
+                        set
+                      rule: '[has(self.jks),has(self.pkcs12)].filter(x,x==true).size()
+                        >= 1'
                   configMap:
                     description: |-
                       configMap is the target ConfigMap in Namespaces that all Bundle source
@@ -307,23 +338,27 @@ spec:
                       key:
                         description: key is the key of the entry in the object's `data`
                           field to be used.
+                        maxLength: 253
                         minLength: 1
                         type: string
                       metadata:
                         description: metadata is an optional set of labels and annotations
                           to be copied to the target.
+                        minProperties: 1
                         properties:
                           annotations:
                             additionalProperties:
                               type: string
                             description: annotations is a key value map to be copied
                               to the target.
+                            minProperties: 1
                             type: object
                           labels:
                             additionalProperties:
                               type: string
                             description: labels is a key value map to be copied to
                               the target.
+                            minProperties: 1
                             type: object
                         type: object
                     required:
@@ -386,34 +421,44 @@ spec:
                       key:
                         description: key is the key of the entry in the object's `data`
                           field to be used.
+                        maxLength: 253
                         minLength: 1
                         type: string
                       metadata:
                         description: metadata is an optional set of labels and annotations
                           to be copied to the target.
+                        minProperties: 1
                         properties:
                           annotations:
                             additionalProperties:
                               type: string
                             description: annotations is a key value map to be copied
                               to the target.
+                            minProperties: 1
                             type: object
                           labels:
                             additionalProperties:
                               type: string
                             description: labels is a key value map to be copied to
                               the target.
+                            minProperties: 1
                             type: object
                         type: object
                     required:
                     - key
                     type: object
                 type: object
+                x-kubernetes-validations:
+                - message: at least one of the fields in [configMap secret] must be
+                    set
+                  rule: '[has(self.configMap),has(self.secret)].filter(x,x==true).size()
+                    >= 1'
             required:
             - sources
             type: object
           status:
             description: status of the Bundle. This is set and managed automatically.
+            minProperties: 1
             properties:
               conditions:
                 description: conditions represent the latest available observations
@@ -472,6 +517,8 @@ spec:
                   - status
                   - type
                   type: object
+                maxItems: 10
+                minItems: 0
                 type: array
                 x-kubernetes-list-map-keys:
                 - type
@@ -483,6 +530,8 @@ spec:
                   useDefaultCAs set to true), if applicable.
                   Bundles resolved from identical sets of default CA certificates will report
                   the same defaultCAVersion value.
+                maxLength: 253
+                minLength: 1
                 type: string
             type: object
         required:

--- a/pkg/apis/trust/v1alpha1/types_bundle.go
+++ b/pkg/apis/trust/v1alpha1/types_bundle.go
@@ -78,6 +78,7 @@ type BundleSpec struct {
 // BundleSource is the set of sources whose data will be appended and synced to
 // the BundleTarget in all Namespaces.
 // +structType=atomic
+// +kubebuilder:validation:ExactlyOneOf=configMap;secret;inLine;useDefaultCAs
 type BundleSource struct {
 	// configMap is a reference (by name) to a ConfigMap's `data` key(s), or to a
 	// list of ConfigMap's `data` key(s) using label selector, in the trust namespace.
@@ -91,6 +92,8 @@ type BundleSource struct {
 
 	// inLine is a simple string to append as the source data.
 	// +optional
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=1048576
 	InLine *string `json:"inLine,omitempty"`
 
 	// useDefaultCAs indicates whether the default CA bundle should be used as a source.
@@ -107,6 +110,7 @@ type BundleSource struct {
 
 // BundleTarget is the target resource that the Bundle will sync all source
 // data to.
+// +kubebuilder:validation:AtLeastOneOf=configMap;secret
 type BundleTarget struct {
 	// configMap is the target ConfigMap in Namespaces that all Bundle source
 	// data will be synced to.
@@ -130,6 +134,7 @@ type BundleTarget struct {
 }
 
 // AdditionalFormats specifies any additional formats to write to the target
+// +kubebuilder:validation:AtLeastOneOf=jks;pkcs12
 type AdditionalFormats struct {
 	// jks requests a JKS-formatted binary trust bundle to be written to the target.
 	// The bundle has "changeit" as the default password.
@@ -148,6 +153,7 @@ type AdditionalFormats struct {
 
 // JKS specifies additional target JKS files
 // +structType=atomic
+// +kubebuilder:validation:MinProperties=1
 type JKS struct {
 	KeySelector `json:",inline"`
 
@@ -161,11 +167,13 @@ type JKS struct {
 
 // PKCS12 specifies additional target PKCS#12 files
 // +structType=atomic
+// +kubebuilder:validation:MinProperties=1
 type PKCS12 struct {
 	KeySelector `json:",inline"`
 
 	// password for PKCS12 trust store
 	// +optional
+	// +kubebuilder:validation:MinLength=0
 	// +kubebuilder:validation:MaxLength=128
 	// +kubebuilder:default=""
 	Password *string `json:"password,omitempty"`
@@ -200,11 +208,13 @@ const (
 // SourceObjectKeySelector is a reference to a source object and its `data` key(s)
 // in the trust namespace.
 // +structType=atomic
+// +kubebuilder:validation:ExactlyOneOf=name;selector
 type SourceObjectKeySelector struct {
 	// name is the name of the source object in the trust namespace.
 	// This field must be left empty when `selector` is set
 	// +optional
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
 	Name string `json:"name,omitempty"`
 
 	// selector is the label selector to use to fetch a list of objects. Must not be set
@@ -215,6 +225,7 @@ type SourceObjectKeySelector struct {
 	// key of the entry in the object's `data` field to be used.
 	// +optional
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
 	Key string `json:"key,omitempty"`
 
 	// includeAllKeys is a flag to include all keys in the object's `data` field to be used. False by default.
@@ -228,6 +239,7 @@ type TargetTemplate struct {
 	// key is the key of the entry in the object's `data` field to be used.
 	// +required
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
 	Key string `json:"key"`
 
 	// metadata is an optional set of labels and annotations to be copied to the target.
@@ -256,27 +268,34 @@ type KeySelector struct {
 	// key is the key of the entry in the object's `data` field to be used.
 	// +required
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
 	Key string `json:"key"`
 }
 
 // TargetMetadata defines the default labels and annotations
 // to be copied to the Kubernetes Secret or ConfigMap bundle targets.
+// +kubebuilder:validation:MinProperties=1
 type TargetMetadata struct {
 	// annotations is a key value map to be copied to the target.
 	// +optional
+	// +kubebuilder:validation:MinProperties=1
 	Annotations map[string]string `json:"annotations,omitempty"`
 
 	// labels is a key value map to be copied to the target.
 	// +optional
+	// +kubebuilder:validation:MinProperties=1
 	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // BundleStatus defines the observed state of the Bundle.
+// +kubebuilder:validation:MinProperties=1
 type BundleStatus struct {
 	// conditions represent the latest available observations of the Bundle's current state.
 	// +listType=map
 	// +listMapKey=type
 	// +optional
+	// +kubebuilder:validation:MinItems=0
+	// +kubebuilder:validation:MaxItems=10
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// defaultCAVersion is the version of the default CA package used when resolving
@@ -285,6 +304,8 @@ type BundleStatus struct {
 	// Bundles resolved from identical sets of default CA certificates will report
 	// the same defaultCAVersion value.
 	// +optional
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
 	DefaultCAPackageVersion *string `json:"defaultCAVersion,omitempty"`
 }
 

--- a/pkg/apis/trustmanager/v1alpha2/types_cluster_bundle.go
+++ b/pkg/apis/trustmanager/v1alpha2/types_cluster_bundle.go
@@ -62,6 +62,7 @@ type ClusterBundleList struct {
 }
 
 // BundleSpec defines the desired state of a Bundle.
+// +kubebuilder:validation:MinProperties=1
 type BundleSpec struct {
 	// sourceRefs is a list of references to resources whose data will be appended and synced into
 	// the bundle target resources.
@@ -77,6 +78,8 @@ type BundleSpec struct {
 
 	// inLineCAs is a simple string to append as the source data.
 	// +optional
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=1048576
 	InLineCAs *string `json:"inLineCAs,omitempty"`
 
 	// target is the target location in all namespaces to sync source data to.
@@ -95,6 +98,7 @@ type BundleSourceRef struct {
 	// A value of "*" matches all entries in the data field.
 	// +required
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern=`^[0-9A-Za-z_.\-*]+$`
 	Key string `json:"key"`
 }
@@ -122,7 +126,7 @@ type DefaultCAsSource struct {
 
 // BundleTarget is the target resource that the Bundle will sync all source
 // data to.
-// +kubebuilder:validation:XValidation:rule="[has(self.configMap), has(self.secret)].exists(x,x)", message="any of the following fields must be provided: [configMap, secret]"
+// +kubebuilder:validation:AtLeastOneOf=configMap;secret
 type BundleTarget struct {
 	// configMap is the target ConfigMap in Namespaces that all Bundle source data will be synced to.
 	// +optional
@@ -141,10 +145,12 @@ type BundleTarget struct {
 
 // PKCS12 specifies configs for target PKCS#12 files.
 // +structType=atomic
+// +kubebuilder:validation:MinProperties=0
 type PKCS12 struct {
 	// password for PKCS12 trust store.
 	// By default, no password is used (password-less PKCS#12).
 	// +optional
+	// +kubebuilder:validation:MinLength=0
 	// +kubebuilder:validation:MaxLength=128
 	Password *string `json:"password,omitempty"`
 
@@ -184,7 +190,7 @@ const (
 
 // SourceReference is a reference to a source object.
 // +structType=atomic
-// +kubebuilder:validation:XValidation:rule="[has(self.name), has(self.selector)].exists_one(x,x)", message="exactly one of the following fields must be provided: [name, selector]"
+// +kubebuilder:validation:ExactlyOneOf=name;selector
 type SourceReference struct {
 	// kind is the kind of the source object.
 	// +required
@@ -243,6 +249,7 @@ type TargetKeyValue struct {
 	// key is the key of the entry in the object's `data` field to be used.
 	// +required
 	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern=`^[0-9A-Za-z_.\-]+$`
 	Key string `json:"key"`
 
@@ -269,24 +276,30 @@ const (
 
 // TargetMetadata defines the default labels and annotations
 // to be copied to the Kubernetes Secret or ConfigMap bundle targets.
+// +kubebuilder:validation:MinProperties=1
 type TargetMetadata struct {
 	// annotations is a key value map to be copied to the target.
 	// +optional
+	// +kubebuilder:validation:MinProperties=1
 	// +kubebuilder:validation:XValidation:rule="self.all(k, !k.startsWith('trust-manager.io/'))", reason=FieldValueForbidden, message="must not use forbidden domains as prefixes (e.g., trust-manager.io)"
 	Annotations map[string]string `json:"annotations,omitempty"`
 
 	// labels is a key value map to be copied to the target.
 	// +optional
+	// +kubebuilder:validation:MinProperties=1
 	// +kubebuilder:validation:XValidation:rule="self.all(k, !k.startsWith('trust-manager.io/'))", reason=FieldValueForbidden, message="must not use forbidden domains as prefixes (e.g., trust-manager.io)"
 	Labels map[string]string `json:"labels,omitempty"`
 }
 
 // BundleStatus defines the observed state of the Bundle.
+// +kubebuilder:validation:MinProperties=1
 type BundleStatus struct {
 	// conditions represent the latest available observations of the ClusterBundle's current state.
 	// +listType=map
 	// +listMapKey=type
 	// +optional
+	// +kubebuilder:validation:MinItems=0
+	// +kubebuilder:validation:MaxItems=10
 	Conditions []metav1.Condition `json:"conditions,omitempty"`
 
 	// defaultCAVersion is the version of the default CA package used for this ClusterBundle
@@ -295,6 +308,8 @@ type BundleStatus struct {
 	// ClusterBundles resolved from identical sets of default CA certificates will report
 	// the same defaultCAVersion value.
 	// +optional
+	// +kubebuilder:validation:MinLength=1
+	// +kubebuilder:validation:MaxLength=253
 	DefaultCAPackageVersion *string `json:"defaultCAVersion,omitempty"`
 }
 

--- a/test/integration/clusterbundle/validation_test.go
+++ b/test/integration/clusterbundle/validation_test.go
@@ -90,11 +90,11 @@ var _ = Describe("ClusterBundle Validation", func() {
 			Entry("when kind ConfigMap", trustmanagerapi.SourceReference{Kind: trustmanagerapi.ConfigMapKind, Name: "ca"}, ""),
 			Entry("when kind Secret", trustmanagerapi.SourceReference{Kind: trustmanagerapi.SecretKind, Name: "ca"}, ""),
 			Entry("when kind unknown", trustmanagerapi.SourceReference{Kind: "OtherKind", Name: "ca"}, "spec.sourceRefs[0].kind: Unsupported value: \"OtherKind\": supported values: \"ConfigMap\", \"Secret\""),
-			Entry("when no name nor selector set", trustmanagerapi.SourceReference{Kind: trustmanagerapi.ConfigMapKind}, "spec.sourceRefs[0]: Invalid value: exactly one of the following fields must be provided: [name, selector"),
+			Entry("when no name nor selector set", trustmanagerapi.SourceReference{Kind: trustmanagerapi.ConfigMapKind}, "spec.sourceRefs[0]: Invalid value: exactly one of the fields in [name selector] must be set"),
 			Entry("when name set", trustmanagerapi.SourceReference{Name: "ca", Kind: trustmanagerapi.ConfigMapKind}, ""),
 			Entry("when selector set", trustmanagerapi.SourceReference{Kind: trustmanagerapi.ConfigMapKind, Selector: &metav1.LabelSelector{}}, ""),
 			Entry("when invalid selector set", trustmanagerapi.SourceReference{Kind: trustmanagerapi.ConfigMapKind, Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"@@@@": "test"}}}, "spec.sourceRefs[0].selector.matchLabels: Invalid value: \"@@@@\": name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')"),
-			Entry("when name and selector set", trustmanagerapi.SourceReference{Kind: trustmanagerapi.ConfigMapKind, Name: "ca", Selector: &metav1.LabelSelector{}}, "spec.sourceRefs[0]: Invalid value: exactly one of the following fields must be provided: [name, selector"),
+			Entry("when name and selector set", trustmanagerapi.SourceReference{Kind: trustmanagerapi.ConfigMapKind, Name: "ca", Selector: &metav1.LabelSelector{}}, "spec.sourceRefs[0]: Invalid value: exactly one of the fields in [name selector] must be set"),
 		)
 	})
 
@@ -131,7 +131,7 @@ var _ = Describe("ClusterBundle Validation", func() {
 		)
 
 		It("should require a target if namespace selector set", func() {
-			expectedErr := "spec.target: Invalid value: any of the following fields must be provided: [configMap, secret]"
+			expectedErr := "spec.target: Invalid value: at least one of the fields in [configMap secret] must be set"
 			Expect(cl.Create(ctx, bundle)).Should(MatchError(ContainSubstring(expectedErr)))
 		})
 


### PR DESCRIPTION
This PR enables two more KAL linters: minLength and maxLength. By enabling these checks, we will get better suggestions when enabling the required and optional fields checks in a follow-up PR.

As part of this work, I discovered some nice new markers supported by controller-gen, which I have started using in this PR. This slightly modifies some validation errors without changing the meaning. **Some changes in this PR are technically breaking, but I would consider them as bugfixes - hopefully not bothering anyone. But please review carefully!**

Adding these new CEL-based validations could allow us to delete most of the Bundle validating webhook code, but I suggest leaving it as is, as cleaning the code would also require cleaning the tests. Please let me know what you think!