### PR TITLE
Helm Chart: Add support for setting relabelling on the ServiceMonitor

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -614,6 +614,27 @@ The timeout for a metrics scrape.
 > ```
 
 Additional labels to add to the ServiceMonitor.
+#### **app.metrics.service.servicemonitor.endpointAdditionalProperties** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+EndpointAdditionalProperties allows setting additional properties on the endpoint such as relabelings, metricRelabelings etc.  
+  
+For example:
+
+```yaml
+endpointAdditionalProperties:
+ relabelings:
+ - action: replace
+   sourceLabels:
+   - __meta_kubernetes_pod_node_name
+   targetLabel: instance
+```
+
+
+
 #### **podDisruptionBudget.enabled** ~ `bool`
 > Default value:
 > ```yaml

--- a/deploy/charts/trust-manager/templates/metrics-servicemonitor.yaml
+++ b/deploy/charts/trust-manager/templates/metrics-servicemonitor.yaml
@@ -28,4 +28,7 @@ spec:
     path: "/metrics"
     interval: {{ .Values.app.metrics.service.servicemonitor.interval }}
     scrapeTimeout: {{ .Values.app.metrics.service.servicemonitor.scrapeTimeout }}
+    {{- with .Values.app.metrics.service.servicemonitor.endpointAdditionalProperties }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
 {{- end }}

--- a/deploy/charts/trust-manager/values.schema.json
+++ b/deploy/charts/trust-manager/values.schema.json
@@ -248,6 +248,9 @@
         "enabled": {
           "$ref": "#/$defs/helm-values.app.metrics.service.servicemonitor.enabled"
         },
+        "endpointAdditionalProperties": {
+          "$ref": "#/$defs/helm-values.app.metrics.service.servicemonitor.endpointAdditionalProperties"
+        },
         "interval": {
           "$ref": "#/$defs/helm-values.app.metrics.service.servicemonitor.interval"
         },
@@ -267,6 +270,11 @@
       "default": false,
       "description": "Create a Prometheus ServiceMonitor for trust-manager.",
       "type": "boolean"
+    },
+    "helm-values.app.metrics.service.servicemonitor.endpointAdditionalProperties": {
+      "default": {},
+      "description": "EndpointAdditionalProperties allows setting additional properties on the endpoint such as relabelings, metricRelabelings etc.\n\nFor example:\nendpointAdditionalProperties:\n relabelings:\n - action: replace\n   sourceLabels:\n   - __meta_kubernetes_pod_node_name\n   targetLabel: instance",
+      "type": "object"
     },
     "helm-values.app.metrics.service.servicemonitor.interval": {
       "default": "10s",

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -344,6 +344,20 @@ app:
         scrapeTimeout: 5s
         # Additional labels to add to the ServiceMonitor.
         labels: {}
+        # EndpointAdditionalProperties allows setting additional properties on the
+        # endpoint such as relabelings, metricRelabelings etc.
+        #
+        # For example:
+        #  endpointAdditionalProperties:
+        #   relabelings:
+        #   - action: replace
+        #     sourceLabels:
+        #     - __meta_kubernetes_pod_node_name
+        #     targetLabel: instance
+        #
+        # +docs:property
+        endpointAdditionalProperties: {}
+
 
 podDisruptionBudget:
   # Enable or disable the PodDisruptionBudget resource.


### PR DESCRIPTION
As discussed [here](https://kubernetes.slack.com/archives/C4NV3DWUC/p1770300885888059), it's convenient to be able to configure metrics relabelling on the deployed ServiceMonitor, similarly like with [cert-manager](https://github.com/cert-manager/cert-manager/blob/26d38b0bc40c9d9a6d01298b500dd972372f35a7/deploy/charts/cert-manager/values.yaml#L670-L682).

This adds the same property in the `values.yaml` as in the helm chart of cert-manager, and wires it up appropriately, and updates the schema, and documentation. I've tried to keep it as close to cert-manager as possible.

If there is anything I've missed, let me know, and I'll update the PR.