### PR TITLE
Improve webhook validation test error list assert

### DIFF
--- a/pkg/webhook/validation_test.go
+++ b/pkg/webhook/validation_test.go
@@ -32,16 +32,16 @@ import (
 func Test_validate(t *testing.T) {
 	tests := map[string]struct {
 		bundle      *trustapi.Bundle
-		expErr      *string
+		expErr      field.ErrorList
 		expWarnings admission.Warnings
 	}{
 		"no sources, no target": {
 			bundle: &trustapi.Bundle{
 				Spec: trustapi.BundleSpec{},
 			},
-			expErr: ptr.To(field.ErrorList{
+			expErr: field.ErrorList{
 				field.Forbidden(field.NewPath("spec", "sources"), "must define at least one source"),
-			}.ToAggregate().Error()),
+			},
 		},
 		"sources with multiple types defined in items": {
 			bundle: &trustapi.Bundle{
@@ -60,10 +60,10 @@ func Test_validate(t *testing.T) {
 					Target: trustapi.BundleTarget{ConfigMap: &trustapi.TargetTemplate{Key: "test"}},
 				},
 			},
-			expErr: ptr.To(field.ErrorList{
+			expErr: field.ErrorList{
 				field.Forbidden(field.NewPath("spec", "sources").Index(0), "must define exactly one source type for each item but found 2 defined types"),
 				field.Forbidden(field.NewPath("spec", "sources").Index(2), "must define exactly one source type for each item but found 2 defined types"),
-			}.ToAggregate().Error()),
+			},
 		},
 		"empty source with no defined types": {
 			bundle: &trustapi.Bundle{
@@ -74,10 +74,10 @@ func Test_validate(t *testing.T) {
 					Target: trustapi.BundleTarget{ConfigMap: &trustapi.TargetTemplate{Key: "test"}},
 				},
 			},
-			expErr: ptr.To(field.ErrorList{
+			expErr: field.ErrorList{
 				field.Forbidden(field.NewPath("spec", "sources").Index(0), "must define exactly one source type for each item but found 0 defined types"),
 				field.Forbidden(field.NewPath("spec", "sources"), "must define at least one source"),
-			}.ToAggregate().Error()),
+			},
 		},
 		"useDefaultCAs false, with no other defined sources": {
 			bundle: &trustapi.Bundle{
@@ -90,9 +90,9 @@ func Test_validate(t *testing.T) {
 					Target: trustapi.BundleTarget{ConfigMap: &trustapi.TargetTemplate{Key: "test"}},
 				},
 			},
-			expErr: ptr.To(field.ErrorList{
+			expErr: field.ErrorList{
 				field.Forbidden(field.NewPath("spec", "sources"), "must define at least one source"),
-			}.ToAggregate().Error()),
+			},
 		},
 		"useDefaultCAs requested twice": {
 			bundle: &trustapi.Bundle{
@@ -108,9 +108,9 @@ func Test_validate(t *testing.T) {
 					Target: trustapi.BundleTarget{ConfigMap: &trustapi.TargetTemplate{Key: "test"}},
 				},
 			},
-			expErr: ptr.To(field.ErrorList{
+			expErr: field.ErrorList{
 				field.Forbidden(field.NewPath("spec", "sources"), "must request default CAs either once or not at all but got 2 requests"),
-			}.ToAggregate().Error()),
+			},
 		},
 		"useDefaultCAs requested three times": {
 			bundle: &trustapi.Bundle{
@@ -129,9 +129,9 @@ func Test_validate(t *testing.T) {
 					Target: trustapi.BundleTarget{ConfigMap: &trustapi.TargetTemplate{Key: "test"}},
 				},
 			},
-			expErr: ptr.To(field.ErrorList{
+			expErr: field.ErrorList{
 				field.Forbidden(field.NewPath("spec", "sources"), "must request default CAs either once or not at all but got 3 requests"),
-			}.ToAggregate().Error()),
+			},
 		},
 		"sources names, selectors and keys are empty": {
 			bundle: &trustapi.Bundle{
@@ -144,12 +144,12 @@ func Test_validate(t *testing.T) {
 					Target: trustapi.BundleTarget{ConfigMap: &trustapi.TargetTemplate{Key: "test"}},
 				},
 			},
-			expErr: ptr.To(field.ErrorList{
+			expErr: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "sources").Index(0).Child("configMap"), "name: ' ', selector: nil", "must validate one and only one schema (oneOf): [name, selector]. Found none valid"),
 				field.Invalid(field.NewPath("spec", "sources").Index(0).Child("configMap"), "key: ' ', includeAllKeys: false", "source configMap key must be defined when includeAllKeys is false"),
 				field.Invalid(field.NewPath("spec", "sources").Index(2).Child("secret"), "name: ' ', selector: nil", "must validate one and only one schema (oneOf): [name, selector]. Found none valid"),
 				field.Invalid(field.NewPath("spec", "sources").Index(2).Child("secret"), "key: ' ', includeAllKeys: false", "source secret key must be defined when includeAllKeys is false"),
-			}.ToAggregate().Error()),
+			},
 		},
 		"sources names and selectors are both set": {
 			bundle: &trustapi.Bundle{
@@ -162,10 +162,10 @@ func Test_validate(t *testing.T) {
 					Target: trustapi.BundleTarget{ConfigMap: &trustapi.TargetTemplate{Key: "test"}},
 				},
 			},
-			expErr: ptr.To(field.ErrorList{
+			expErr: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "sources").Index(0).Child("configMap"), "name: some-config-map, selector: {}", "must validate one and only one schema (oneOf): [name, selector]. Found both set"),
 				field.Invalid(field.NewPath("spec", "sources").Index(2).Child("secret"), "name: some-secret, selector: {}", "must validate one and only one schema (oneOf): [name, selector]. Found both set"),
-			}.ToAggregate().Error()),
+			},
 		},
 		"sources key is set and includeAllKeys is true": {
 			bundle: &trustapi.Bundle{
@@ -178,10 +178,10 @@ func Test_validate(t *testing.T) {
 					Target: trustapi.BundleTarget{ConfigMap: &trustapi.TargetTemplate{Key: "test"}},
 				},
 			},
-			expErr: ptr.To(field.ErrorList{
+			expErr: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "sources").Index(0).Child("configMap"), "key: test, includeAllKeys: true", "source configMap key cannot be defined when includeAllKeys is true"),
 				field.Invalid(field.NewPath("spec", "sources").Index(2).Child("secret"), "key: test, includeAllKeys: true", "source secret key cannot be defined when includeAllKeys is true"),
-			}.ToAggregate().Error()),
+			},
 		},
 		"sources defines the same configMap target": {
 			bundle: &trustapi.Bundle{
@@ -194,9 +194,9 @@ func Test_validate(t *testing.T) {
 					Target: trustapi.BundleTarget{ConfigMap: &trustapi.TargetTemplate{Key: "test"}},
 				},
 			},
-			expErr: ptr.To(field.ErrorList{
+			expErr: field.ErrorList{
 				field.Forbidden(field.NewPath("spec", "sources").Index(1).Child("configMap", "test-bundle", "test"), "cannot define the same source as target"),
-			}.ToAggregate().Error()),
+			},
 		},
 		"sources defines the same secret target": {
 			bundle: &trustapi.Bundle{
@@ -209,9 +209,9 @@ func Test_validate(t *testing.T) {
 					Target: trustapi.BundleTarget{Secret: &trustapi.TargetTemplate{Key: "test"}},
 				},
 			},
-			expErr: ptr.To(field.ErrorList{
+			expErr: field.ErrorList{
 				field.Forbidden(field.NewPath("spec", "sources").Index(1).Child("secret", "test-bundle", "test"), "cannot define the same source as target"),
-			}.ToAggregate().Error()),
+			},
 		},
 		"invalid namespace selector": {
 			bundle: &trustapi.Bundle{
@@ -236,9 +236,9 @@ func Test_validate(t *testing.T) {
 					},
 				},
 			},
-			expErr: ptr.To(field.ErrorList{
-				field.Invalid(field.NewPath("spec", "target", "namespaceSelector", "matchLabels"), "@@@@", `name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')`),
-			}.ToAggregate().Error()),
+			expErr: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "target", "namespaceSelector", "matchLabels"), "@@@@", `name part must consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyName',  or 'my.name',  or '123-abc', regex used for validation is '([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]')`).WithOrigin("format=k8s-label-key"),
+			},
 		},
 		"a Bundle with a duplicate target JKS key should fail validation and return a denied response": {
 			bundle: &trustapi.Bundle{
@@ -264,7 +264,9 @@ func Test_validate(t *testing.T) {
 					},
 				},
 			},
-			expErr: ptr.To("spec.target.additionalFormats.jks.key: Invalid value: \"bar\": key must be unique in target configMap"),
+			expErr: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "target", "additionalFormats", "jks", "key"), "bar", "key must be unique in target configMap"),
+			},
 		},
 		"a Bundle with a duplicate target PKCS12 key should fail validation and return a denied response": {
 			bundle: &trustapi.Bundle{
@@ -290,7 +292,9 @@ func Test_validate(t *testing.T) {
 					},
 				},
 			},
-			expErr: ptr.To("spec.target.additionalFormats.pkcs12.key: Invalid value: \"bar\": key must be unique in target configMap"),
+			expErr: field.ErrorList{
+				field.Invalid(field.NewPath("spec", "target", "additionalFormats", "pkcs12", "key"), "bar", "key must be unique in target configMap"),
+			},
 		},
 		"valid Bundle": {
 			bundle: &trustapi.Bundle{
@@ -397,10 +401,10 @@ func Test_validate(t *testing.T) {
 					},
 				},
 			},
-			expErr: ptr.To(field.ErrorList{
+			expErr: field.ErrorList{
 				field.Invalid(field.NewPath("spec", "target", "configMap", "metadata", "annotations"), "trust-manager.io/hash", "trust-manager.io/* annotations are not allowed"),
 				field.Invalid(field.NewPath("spec", "target", "configMap", "metadata", "labels"), "trust.cert-manager.io/bundle", "trust.cert-manager.io/* labels are not allowed"),
-			}.ToAggregate().Error()),
+			},
 		},
 		"valid Bundle with JKS": {
 			bundle: &trustapi.Bundle{
@@ -479,11 +483,7 @@ func Test_validate(t *testing.T) {
 			_, ctx := ktesting.NewTestContext(t)
 			v := &validator{}
 			gotWarnings, gotErr := v.validate(ctx, test.bundle)
-			if test.expErr == nil && gotErr != nil {
-				t.Errorf("got an unexpected error: %v", gotErr)
-			} else if test.expErr != nil && (gotErr == nil || *test.expErr != gotErr.Error()) {
-				t.Errorf("wants error: %v got: %v", *test.expErr, gotErr)
-			}
+			assert.Equal(t, test.expErr.ToAggregate(), gotErr)
 			assert.Equal(t, test.expWarnings, gotWarnings)
 
 		})


### PR DESCRIPTION
While working on debugging this test in another PR, it was almost impossible to see/understand the difference between the actual and the expected error list. This can probably be further improved, but now it should be easier to see what's wrong if anything breaks.