### PR TITLE
Introduce KAL required fields checks

### DIFF
--- a/.golangci-kal.yml
+++ b/.golangci-kal.yml
@@ -21,7 +21,6 @@ linters:
               - arrayofstruct # Ensures arrays of structs have at least one required field
               - nonpointerstructs # Ensures non-pointer structs are marked correctly with required/optional markers
               - optionalfields # Validates optional field conventions
-              - requiredfields # Validates required field conventions
           lintersConfig:
             conditions:
               useProtobuf: Forbid

--- a/pkg/apis/trust/v1alpha1/types_bundle.go
+++ b/pkg/apis/trust/v1alpha1/types_bundle.go
@@ -46,7 +46,7 @@ type Bundle struct {
 
 	// spec represents the desired state of the Bundle resource.
 	// +required
-	Spec BundleSpec `json:"spec"`
+	Spec BundleSpec `json:"spec,omitzero"`
 
 	// status of the Bundle. This is set and managed automatically.
 	// +optional
@@ -68,7 +68,7 @@ type BundleSpec struct {
 	// +listType=atomic
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=100
-	Sources []BundleSource `json:"sources"`
+	Sources []BundleSource `json:"sources,omitempty"`
 
 	// target is the target location in all namespaces to sync source data to.
 	// +optional
@@ -240,7 +240,7 @@ type TargetTemplate struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
-	Key string `json:"key"`
+	Key string `json:"key,omitempty"`
 
 	// metadata is an optional set of labels and annotations to be copied to the target.
 	// +optional
@@ -269,7 +269,7 @@ type KeySelector struct {
 	// +required
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
-	Key string `json:"key"`
+	Key string `json:"key,omitempty"`
 }
 
 // TargetMetadata defines the default labels and annotations

--- a/pkg/apis/trustmanager/v1alpha2/types_cluster_bundle.go
+++ b/pkg/apis/trustmanager/v1alpha2/types_cluster_bundle.go
@@ -100,7 +100,7 @@ type BundleSourceRef struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern=`^[0-9A-Za-z_.\-*]+$`
-	Key string `json:"key"`
+	Key string `json:"key,omitempty"`
 }
 
 // DefaultCAsSource configures the use of a default CA bundle as a trust source.
@@ -121,7 +121,7 @@ type DefaultCAsSource struct {
 	// - Disabled: No default CAs are used as sources.
 	// +required
 	// +kubebuilder:validation:Enum=System;Disabled
-	Provider string `json:"provider"`
+	Provider string `json:"provider,omitempty"`
 }
 
 // BundleTarget is the target resource that the Bundle will sync all source
@@ -140,7 +140,7 @@ type BundleTarget struct {
 
 	// namespaceSelector specifies the namespaces where target resources will be synced.
 	// +required
-	NamespaceSelector *metav1.LabelSelector `json:"namespaceSelector"`
+	NamespaceSelector *metav1.LabelSelector `json:"namespaceSelector,omitempty"`
 }
 
 // PKCS12 specifies configs for target PKCS#12 files.
@@ -195,7 +195,7 @@ type SourceReference struct {
 	// kind is the kind of the source object.
 	// +required
 	// +kubebuilder:validation:Enum=ConfigMap;Secret
-	Kind string `json:"kind"`
+	Kind string `json:"kind,omitempty"`
 
 	// name is the name of the source object in the trust namespace.
 	// This field must be left empty when `selector` is set
@@ -218,7 +218,7 @@ type KeyValueTarget struct {
 	// +listMapKey=key
 	// +kubebuilder:validation:MinItems=1
 	// +kubebuilder:validation:MaxItems=10
-	Data []TargetKeyValue `json:"data"`
+	Data []TargetKeyValue `json:"data,omitempty"`
 
 	// metadata is an optional set of labels and annotations to be copied to the target.
 	// +optional
@@ -251,7 +251,7 @@ type TargetKeyValue struct {
 	// +kubebuilder:validation:MinLength=1
 	// +kubebuilder:validation:MaxLength=253
 	// +kubebuilder:validation:Pattern=`^[0-9A-Za-z_.\-]+$`
-	Key string `json:"key"`
+	Key string `json:"key,omitempty"`
 
 	// format defines the format of the target value.
 	// The default format is PEM.

--- a/test/integration/bundle/validation_test.go
+++ b/test/integration/bundle/validation_test.go
@@ -55,10 +55,10 @@ var _ = Describe("Bundle Validation", func() {
 	})
 
 	Context("Sources", func() {
-		It("should require at least one source", func() {
-			bundle.Spec.Sources = make([]trustapi.BundleSource, 0)
+		It("should require sources", func() {
+			bundle.Spec.Sources = nil
 
-			expectedErr := "spec.sources: Invalid value: 0: spec.sources in body should have at least 1 items"
+			expectedErr := "spec.sources: Required value"
 			Expect(cl.Create(ctx, bundle)).Should(MatchError(ContainSubstring(expectedErr)))
 		})
 
@@ -202,24 +202,6 @@ var _ = Describe("Bundle Validation", func() {
 				ConfigMap: &trustapi.TargetTemplate{Key: "ca-bundle.crt", Metadata: &trustapi.TargetMetadata{Labels: map[string]string{"not-trust-manager.io/bundle": "bundle"}}}}, false),
 		)
 
-		DescribeTable("should require target key",
-			func(target trustapi.BundleTarget, wantErr bool) {
-				bundle.Spec.Target = target
-				if wantErr {
-					Expect(cl.Create(ctx, bundle)).Should(MatchError(
-						SatisfyAny(
-							ContainSubstring("spec.target.configMap.key: Invalid value: \"\": spec.target.configMap.key in body should be at least 1 chars long"),
-							ContainSubstring("spec.target.secret.key: Invalid value: \"\": spec.target.secret.key in body should be at least 1 chars long"),
-						),
-					))
-				} else {
-					Expect(cl.Create(ctx, bundle)).To(Succeed())
-				}
-			},
-			Entry("for configmap", trustapi.BundleTarget{ConfigMap: &trustapi.TargetTemplate{Key: ""}}, true),
-			Entry("for secret", trustapi.BundleTarget{Secret: &trustapi.TargetTemplate{Key: ""}}, true),
-		)
-
 		type TargetKeySpec struct {
 			ConfigMapKey string
 			SecretKey    string
@@ -296,8 +278,8 @@ var _ = Describe("Bundle Validation", func() {
 			It("should require target key", func() {
 				bundle.Spec.Target = trustapi.BundleTarget{}
 				selectorAccessor(&trustapi.TargetTemplate{})
-				expectedErr := "spec.target.%s.key: Invalid value: \"\": spec.target.%s.key in body should be at least 1 chars long"
-				Expect(cl.Create(ctx, bundle)).Should(MatchError(ContainSubstring(expectedErr, field, field)))
+				expectedErr := "spec.target.%s.key: Required value"
+				Expect(cl.Create(ctx, bundle)).Should(MatchError(ContainSubstring(expectedErr, field)))
 			})
 		}
 

--- a/test/integration/clusterbundle/validation_test.go
+++ b/test/integration/clusterbundle/validation_test.go
@@ -67,7 +67,7 @@ var _ = Describe("ClusterBundle Validation", func() {
 					Expect(cl.Create(ctx, bundle)).To(Succeed())
 				}
 			},
-			Entry("when unset", "", "spec.sourceRefs[0].key: Invalid value: \"\": spec.sourceRefs[0].key in body should be at least 1 chars long"),
+			Entry("when unset", "", "spec.sourceRefs[0].key: Required value"),
 			Entry("when given", "ca.crt", ""),
 			Entry("when using simple wildcard to include some keys", "*.crt", ""),
 			Entry("when using simple wildcard to include all keys", "*", ""),
@@ -86,7 +86,7 @@ var _ = Describe("ClusterBundle Validation", func() {
 					Expect(cl.Create(ctx, bundle)).To(Succeed())
 				}
 			},
-			Entry("when kind unset", trustmanagerapi.SourceReference{Name: "ca"}, "spec.sourceRefs[0].kind: Unsupported value: \"\": supported values: \"ConfigMap\", \"Secret\""),
+			Entry("when kind unset", trustmanagerapi.SourceReference{Name: "ca"}, "spec.sourceRefs[0].kind: Required value"),
 			Entry("when kind ConfigMap", trustmanagerapi.SourceReference{Kind: trustmanagerapi.ConfigMapKind, Name: "ca"}, ""),
 			Entry("when kind Secret", trustmanagerapi.SourceReference{Kind: trustmanagerapi.SecretKind, Name: "ca"}, ""),
 			Entry("when kind unknown", trustmanagerapi.SourceReference{Kind: "OtherKind", Name: "ca"}, "spec.sourceRefs[0].kind: Unsupported value: \"OtherKind\": supported values: \"ConfigMap\", \"Secret\""),
@@ -158,14 +158,14 @@ var _ = Describe("ClusterBundle Validation", func() {
 						}},
 					})
 					if matchErr != "" {
-						Expect(cl.Create(ctx, bundle)).Should(MatchError(ContainSubstring(matchErr, targetField, targetField)))
+						Expect(cl.Create(ctx, bundle)).Should(MatchError(ContainSubstring(matchErr, targetField)))
 					} else {
 						Expect(cl.Create(ctx, bundle)).To(Succeed())
 					}
 				},
-				Entry("when unset", "", "spec.target.%s.data[0].key: Invalid value: \"\": spec.target.%s.data[0].key in body should be at least 1 chars long"),
+				Entry("when unset", "", "spec.target.%s.data[0].key: Required value"),
 				Entry("when given", "ca.crt", ""),
-				Entry("when using wildcard", "*.crt", "spec.target.%s.data[0].key: Invalid value: \"*.crt\": spec.target.%s.data[0].key in body should match '^[0-9A-Za-z_.\\-]+$"),
+				Entry("when using wildcard", "*.crt", "spec.target.%[1]s.data[0].key: Invalid value: \"*.crt\": spec.target.%[1]s.data[0].key in body should match '^[0-9A-Za-z_.\\-]+$"),
 			)
 
 			It("should require unique keys", func() {


### PR DESCRIPTION
This PR introduces some new KAL checks for required fields.

I prepared this PR by changing the KAL configuration, and then running `make fix-kube-api-lint` and fixing the tests. I found a duplicated test that is also deleted.