### PR TITLE
Fix flaky integration test

### DIFF
--- a/pkg/webhook/validation_test.go
+++ b/pkg/webhook/validation_test.go
@@ -265,7 +265,7 @@ func Test_validate(t *testing.T) {
 				},
 			},
 			expErr: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "target", "additionalFormats", "jks", "key"), "bar", "key must be unique in target configMap"),
+				field.Invalid(field.NewPath("spec", "target", "additionalFormats", "jks", "key"), "bar", "key must be unique across all target output keys"),
 			},
 		},
 		"a Bundle with a duplicate target PKCS12 key should fail validation and return a denied response": {
@@ -293,7 +293,7 @@ func Test_validate(t *testing.T) {
 				},
 			},
 			expErr: field.ErrorList{
-				field.Invalid(field.NewPath("spec", "target", "additionalFormats", "pkcs12", "key"), "bar", "key must be unique in target configMap"),
+				field.Invalid(field.NewPath("spec", "target", "additionalFormats", "pkcs12", "key"), "bar", "key must be unique across all target output keys"),
 			},
 		},
 		"valid Bundle": {

--- a/test/integration/bundle/validation_test.go
+++ b/test/integration/bundle/validation_test.go
@@ -242,7 +242,7 @@ var _ = Describe("Bundle Validation", func() {
 				bundle.Spec.Target = target
 
 				if wantErr {
-					expectedErr := "key must be unique in target"
+					expectedErr := "key must be unique across all target output keys"
 					Expect(cl.Create(ctx, bundle)).Should(MatchError(ContainSubstring(expectedErr)))
 				} else {
 					Expect(cl.Create(ctx, bundle)).To(Succeed())
@@ -271,7 +271,7 @@ var _ = Describe("Bundle Validation", func() {
 			func(formats *trustapi.AdditionalFormats, wantErr bool) {
 				bundle.Spec.Target.AdditionalFormats = formats
 				if wantErr {
-					expectedErr := "spec.target.additionalFormats.pkcs12.key: Invalid value: \"cacerts\": key must be unique in target configMap"
+					expectedErr := "spec.target.additionalFormats.pkcs12.key: Invalid value: \"cacerts\": key must be unique across all target output keys"
 					Expect(cl.Create(ctx, bundle)).Should(MatchError(ContainSubstring(expectedErr)))
 				} else {
 					Expect(cl.Create(ctx, bundle)).To(Succeed())


### PR DESCRIPTION
This PR should fix a flaky test I've been observing quite frequently, last seen in https://github.com/cert-manager/trust-manager/pull/878: https://prow.infra.cert-manager.io/view/gs/cert-manager-prow-artifacts/pr-logs/pull/cert-manager_trust-manager/878/pull-trust-manager-integration/2020299342467829760.

Maps in Go do not have a consistent behavior, which has surprised me many times. 😅 

Also, fixing a misleading validation error Copilot suggested.