### PR TITLE
Grant additional RBAC to events old API group

### DIFF
--- a/deploy/charts/trust-manager/templates/_helpers.tpl
+++ b/deploy/charts/trust-manager/templates/_helpers.tpl
@@ -77,6 +77,7 @@ Namespaced resources rules
   verbs: ["get","list","create","patch","watch","delete"]
 
 - apiGroups:
+  - "" {{/* TODO(erikgb): Remove; MIGRATION to new events API group. */}}
   - "events.k8s.io"
   resources:
   - "events"


### PR DESCRIPTION
It seems we still need to grant RBAC to the old group due to the leader election. See https://github.com/cert-manager/trust-manager/pull/865#discussion_r2834195935

I did observe errors like this in one of our own clusters:

````
{"time":"2026-02-20T09:54:10.139437317Z","level":"ERROR","msg":"Server rejected event (will not retry!)","err":"events is forbidden: User \"system:serviceaccount:cert-manager:trust-manager\" cannot create resource \"events\" in API group \"\" in the namespace \"cert-manager\"","event":{"metadata":{"name":"trust-manager-leader-election.1895ebc2c12eb3df","namespace":"cert-manager"},"involvedObject":{"kind":"Lease","namespace":"cert-manager","name":"trust-manager-leader-election","uid":"53a28b95-8cf7-49dc-bebc-43c1c26ef441","apiVersion":"coordination.k8s.io/v1","resourceVersion":"863871874"},"reason":"LeaderElection","message":"trust-manager-798bc4794b-pl25w_b1b2d517-bbcd-492b-8ecb-3698ac246e20 became leader","source":{"component":"trust-manager-798bc4794b-pl25w_b1b2d517-bbcd-492b-8ecb-3698ac246e20"},"firstTimestamp":"2026-02-20T09:54:10Z","lastTimestamp":"2026-02-20T09:54:10Z","count":1,"type":"Normal","eventTime":null,"reportingComponent":"trust-manager-798bc4794b-pl25w_b1b2d517-bbcd-492b-8ecb-3698ac246e20"...
````