### PR TITLE
Replace another illegal image tag character in trust image

### DIFF
--- a/make/00_mod.mk
+++ b/make/00_mod.mk
@@ -37,7 +37,8 @@ go_package_debian_bullseye_mod_dir := ./trust-packages/debian
 go_package_debian_bullseye_ldflags :=
 oci_package_debian_bullseye_base_image_flavor := static
 oci_package_debian_bullseye_image_name := quay.io/jetstack/cert-manager-package-debian
-oci_package_debian_bullseye_image_tag := $(shell echo $(DEBIAN_BULLSEYE_BUNDLE_VERSION) | tr '+' '-')
+# '+' and '~' characters are not valid in docker image tags. Transform them to '-' for image tags.
+oci_package_debian_bullseye_image_tag := $(shell echo $(DEBIAN_BULLSEYE_BUNDLE_VERSION) | tr '+~' '-')
 oci_package_debian_bullseye_image_name_development := cert-manager.local/trust-pkg-debian-bullseye
 debian_bullseye_package_layer := $(bin_dir)/scratch/debian-bullseye-trust-package
 oci_package_debian_bullseye_additional_layers += $(debian_bullseye_package_layer)
@@ -47,8 +48,8 @@ go_package_debian_bookworm_mod_dir := ./trust-packages/debian
 go_package_debian_bookworm_ldflags :=
 oci_package_debian_bookworm_base_image_flavor := static
 oci_package_debian_bookworm_image_name := quay.io/jetstack/trust-pkg-debian-bookworm
-# '+' characters are not valid in docker image names. Transform it to a '.' for images
-oci_package_debian_bookworm_image_tag := $(shell echo $(DEBIAN_BOOKWORM_BUNDLE_VERSION) | tr '+' '-')
+# '+' and '~' characters are not valid in docker image tags. Transform them to '-' for image tags.
+oci_package_debian_bookworm_image_tag := $(shell echo $(DEBIAN_BOOKWORM_BUNDLE_VERSION) | tr '+~' '-')
 oci_package_debian_bookworm_image_name_development := cert-manager.local/trust-pkg-debian-bookworm
 debian_bookworm_package_layer := $(bin_dir)/scratch/debian-bookworm-trust-package
 oci_package_debian_bookworm_additional_layers += $(debian_bookworm_package_layer)


### PR DESCRIPTION
To mend https://github.com/cert-manager/trust-manager/pull/890.

````
$ echo '20230311+deb12u1~deb11u1.0' | tr '+~' '-'
20230311-deb12u1-deb11u1.0
````