### PR TITLE
Add imageRegistry/imageNamespace to Helm chart image settings

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -93,23 +93,61 @@ This is helpful when installing trust-manager as a chart dependency (sub chart).
 > ```
 
 For Private docker registries, authentication is needed. Registry secrets are applied to the service account.
+#### **imageRegistry** ~ `string`
+> Default value:
+> ```yaml
+> quay.io
+> ```
+
+The container registry used for trust-manager images by default. This can include path prefixes (e.g. "artifactory.example.com/docker").
+
+#### **imageNamespace** ~ `string`
+> Default value:
+> ```yaml
+> jetstack
+> ```
+
+The repository namespace used for trust-manager images by default.  
+Examples:  
+- jetstack  
+- cert-manager
+
 #### **image.registry** ~ `string`
 
 Target image registry. This value is prepended to the target image repository, if set.  
 For example:
 
 ```yaml
-registry: quay.io
-repository: jetstack/trust-manager
+registry: legacy.example.io
 ```
+
+Deprecated: per-component registry prefix.  
+  
+If set, this value is *prepended* to the image repository that the chart would otherwise render. This applies both when `image.repository` is set and when the repository is computed from  
+`imageRegistry` + `imageNamespace` + `image.name`.  
+  
+This can produce "double registry" style references such as  
+`legacy.example.io/quay.io/jetstack/...`. Prefer using the global  
+`imageRegistry`/`imageNamespace` values.
 
 #### **image.repository** ~ `string`
 > Default value:
 > ```yaml
-> quay.io/jetstack/trust-manager
+> ""
 > ```
 
-Target image repository.
+Full repository override (takes precedence over `imageRegistry`, `imageNamespace`, and `image.name`).  
+Example: quay.io/jetstack/trust-manager
+
+#### **image.name** ~ `string`
+> Default value:
+> ```yaml
+> trust-manager
+> ```
+
+The image name for trust-manager.  
+This is used (together with `imageRegistry` and `imageNamespace`) to construct the full image reference.
+
 #### **image.tag** ~ `string`
 
 Override the image tag to deploy by setting this variable. If no value is set, the chart's appVersion is used.
@@ -166,13 +204,33 @@ registry: quay.io
 repository: jetstack/cert-manager-package-debian
 ```
 
+Deprecated: per-component registry prefix.  
+  
+If set, this value is *prepended* to the image repository that the chart would otherwise render. This applies both when `image.repository` is set and when the repository is computed from  
+`imageRegistry` + `imageNamespace` + `image.name`.  
+  
+This can produce "double registry" style references such as  
+`legacy.example.io/quay.io/jetstack/...`. Prefer using the global  
+`imageRegistry`/`imageNamespace` values.
+
 #### **defaultPackageImage.repository** ~ `string`
 > Default value:
 > ```yaml
-> quay.io/jetstack/trust-pkg-debian-bookworm
+> ""
 > ```
 
-The repository for the default package image. This image enables the 'useDefaultCAs' source on Bundles.
+Full repository override (takes precedence over `imageRegistry`, `imageNamespace`, and `image.name`).  
+Example: quay.io/jetstack/trust-manager
+
+#### **defaultPackageImage.name** ~ `string`
+> Default value:
+> ```yaml
+> trust-pkg-debian-bookworm
+> ```
+
+The image name for trust-manager.  
+This is used (together with `imageRegistry` and `imageNamespace`) to construct the full image reference.
+
 #### **defaultPackageImage.tag** ~ `string`
 
 Override the image tag of the default package image. Is set at chart build time to the version specified in ./make/00_debian_bookworm_version.mk.

--- a/deploy/charts/trust-manager/templates/_helpers.tpl
+++ b/deploy/charts/trust-manager/templates/_helpers.tpl
@@ -31,16 +31,70 @@ app.kubernetes.io/managed-by: {{ .Release.Service }}
 
 {{/*
 Util function for generating the image URL based on the provided options.
-IMPORTANT: This function is standarized across all charts in the cert-manager GH organization.
+IMPORTANT: This function is standardized across all charts in the cert-manager GH organization.
 Any changes to this function should also be made in cert-manager, trust-manager, approver-policy, ...
 See https://github.com/cert-manager/cert-manager/issues/6329 for a list of linked PRs.
 */}}
 {{- define "image" -}}
-{{- $defaultTag := index . 1 -}}
-{{- with index . 0 -}}
-{{- if .registry -}}{{ printf "%s/%s" .registry .repository }}{{- else -}}{{- .repository -}}{{- end -}}
-{{- if .digest -}}{{ printf "@%s" .digest }}{{- else -}}{{ printf ":%s" (default $defaultTag .tag) }}{{- end -}}
-{{- end }}
+{{- /*
+Calling convention:
+
+- (tuple <imageValues> <imageRegistry> <imageNamespace> <defaultReference>)
+
+We intentionally pass imageRegistry/imageNamespace as explicit arguments rather than reading
+from `.Values` inside this helper, because `helm-tool lint` does not reliably track `.Values.*`
+usage through tuple/variable indirection.
+*/ -}}
+
+{{- if ne (len .) 4 -}}
+    {{- fail (printf "ERROR: template \"image\" expects (tuple <imageValues> <imageRegistry> <imageNamespace> <defaultReference>), got %d arguments" (len .)) -}}
+{{- end -}}
+
+{{- $image := index . 0 -}}
+{{- $imageRegistry := index . 1 | default "" -}}
+{{- $imageNamespace := index . 2 | default "" -}}
+{{- $defaultReference := index . 3 -}}
+
+{{- $repository := "" -}}
+{{- if $image.repository -}}
+    {{- $repository = $image.repository -}}
+
+    {{- /*
+        Backwards compatibility: if image.registry is set, additionally prefix the repository with this registry.
+    */ -}}
+    {{- if $image.registry -}}
+        {{- $repository = printf "%s/%s" $image.registry $repository -}}
+    {{- end -}}
+{{- else -}}
+    {{- $name := required "ERROR: image.name must be set when image.repository is empty" $image.name -}}
+    {{- $repository = $name -}}
+
+    {{- if $imageNamespace -}}
+        {{- $repository = printf "%s/%s" $imageNamespace $repository -}}
+    {{- end -}}
+
+    {{- if $imageRegistry -}}
+        {{- $repository = printf "%s/%s" $imageRegistry $repository -}}
+    {{- end -}}
+
+    {{- /*
+        Backwards compatibility: if image.registry is set, additionally prefix the repository with this registry.
+    */ -}}
+    {{- if $image.registry -}}
+        {{- $repository = printf "%s/%s" $image.registry $repository -}}
+    {{- end -}}
+{{- end -}}
+
+{{- $repository -}}
+{{- if and $image.tag $image.digest -}}
+    {{- printf ":%s@%s" $image.tag $image.digest -}}
+{{- else if $image.tag -}}
+    {{- printf ":%s" $image.tag -}}
+{{- else if $image.digest -}}
+    {{- printf "@%s" $image.digest -}}
+{{- else -}}
+    {{- printf "%s" $defaultReference -}}
+{{- end -}}
 {{- end }}
 
 {{/*

--- a/deploy/charts/trust-manager/templates/deployment.yaml
+++ b/deploy/charts/trust-manager/templates/deployment.yaml
@@ -41,7 +41,7 @@ spec:
       {{- if .Values.defaultPackage.enabled }}
       initContainers:
       - name: cert-manager-package-debian
-        image: "{{ template "image" (tuple .Values.defaultPackageImage "missing") }}"
+        image: "{{ template "image" (tuple .Values.defaultPackageImage .Values.imageRegistry .Values.imageNamespace .Values.defaultPackageImage._defaultReference) }}"
         imagePullPolicy: {{ .Values.defaultPackageImage.pullPolicy }}
         args:
           - "/copyandmaybepause"
@@ -69,7 +69,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ include "trust-manager.name" . }}
-        image: "{{ template "image" (tuple .Values.image $.Chart.AppVersion) }}"
+        image: "{{ template "image" (tuple .Values.image .Values.imageRegistry .Values.imageNamespace (printf ":%s" $.Chart.AppVersion)) }}"
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         ports:
         - containerPort: {{ .Values.app.webhook.port }}

--- a/deploy/charts/trust-manager/values.schema.json
+++ b/deploy/charts/trust-manager/values.schema.json
@@ -45,8 +45,14 @@
         "image": {
           "$ref": "#/$defs/helm-values.image"
         },
+        "imageNamespace": {
+          "$ref": "#/$defs/helm-values.imageNamespace"
+        },
         "imagePullSecrets": {
           "$ref": "#/$defs/helm-values.imagePullSecrets"
+        },
+        "imageRegistry": {
+          "$ref": "#/$defs/helm-values.imageRegistry"
         },
         "nameOverride": {
           "$ref": "#/$defs/helm-values.nameOverride"
@@ -587,8 +593,14 @@
     "helm-values.defaultPackageImage": {
       "additionalProperties": false,
       "properties": {
+        "_defaultReference": {
+          "$ref": "#/$defs/helm-values.defaultPackageImage._defaultReference"
+        },
         "digest": {
           "$ref": "#/$defs/helm-values.defaultPackageImage.digest"
+        },
+        "name": {
+          "$ref": "#/$defs/helm-values.defaultPackageImage.name"
         },
         "pullPolicy": {
           "$ref": "#/$defs/helm-values.defaultPackageImage.pullPolicy"
@@ -605,8 +617,18 @@
       },
       "type": "object"
     },
+    "helm-values.defaultPackageImage._defaultReference": {
+      "default": ":v0.0.0",
+      "description": "WARNING: For internal use only, is overwritten before releasing the chart.",
+      "type": "string"
+    },
     "helm-values.defaultPackageImage.digest": {
       "description": "Target image digest. Override any tag, if set.\nFor example:\ndigest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20",
+      "type": "string"
+    },
+    "helm-values.defaultPackageImage.name": {
+      "default": "trust-pkg-debian-bookworm",
+      "description": "The image name for trust-manager.\nThis is used (together with `imageRegistry` and `imageNamespace`) to construct the full image reference.",
       "type": "string"
     },
     "helm-values.defaultPackageImage.pullPolicy": {
@@ -615,12 +637,12 @@
       "type": "string"
     },
     "helm-values.defaultPackageImage.registry": {
-      "description": "Target image registry. This value is prepended to the target image repository, if set.\nFor example:\nregistry: quay.io\nrepository: jetstack/cert-manager-package-debian",
+      "description": "Target image registry. This value is prepended to the target image repository, if set.\nFor example:\nregistry: quay.io\nrepository: jetstack/cert-manager-package-debian\nDeprecated: per-component registry prefix.\n\nIf set, this value is *prepended* to the image repository that the chart would otherwise render. This applies both when `image.repository` is set and when the repository is computed from\n`imageRegistry` + `imageNamespace` + `image.name`.\n\nThis can produce \"double registry\" style references such as\n`legacy.example.io/quay.io/jetstack/...`. Prefer using the global\n`imageRegistry`/`imageNamespace` values.",
       "type": "string"
     },
     "helm-values.defaultPackageImage.repository": {
-      "default": "quay.io/jetstack/trust-pkg-debian-bookworm",
-      "description": "The repository for the default package image. This image enables the 'useDefaultCAs' source on Bundles.",
+      "default": "",
+      "description": "Full repository override (takes precedence over `imageRegistry`, `imageNamespace`, and `image.name`).\nExample: quay.io/jetstack/trust-manager",
       "type": "string"
     },
     "helm-values.defaultPackageImage.tag": {
@@ -694,6 +716,9 @@
         "digest": {
           "$ref": "#/$defs/helm-values.image.digest"
         },
+        "name": {
+          "$ref": "#/$defs/helm-values.image.name"
+        },
         "pullPolicy": {
           "$ref": "#/$defs/helm-values.image.pullPolicy"
         },
@@ -713,22 +738,32 @@
       "description": "Target image digest. Override any tag, if set.\nFor example:\ndigest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20",
       "type": "string"
     },
+    "helm-values.image.name": {
+      "default": "trust-manager",
+      "description": "The image name for trust-manager.\nThis is used (together with `imageRegistry` and `imageNamespace`) to construct the full image reference.",
+      "type": "string"
+    },
     "helm-values.image.pullPolicy": {
       "default": "IfNotPresent",
       "description": "Kubernetes imagePullPolicy on Deployment.",
       "type": "string"
     },
     "helm-values.image.registry": {
-      "description": "Target image registry. This value is prepended to the target image repository, if set.\nFor example:\nregistry: quay.io\nrepository: jetstack/trust-manager",
+      "description": "Target image registry. This value is prepended to the target image repository, if set.\nFor example:\nregistry: legacy.example.io\nDeprecated: per-component registry prefix.\n\nIf set, this value is *prepended* to the image repository that the chart would otherwise render. This applies both when `image.repository` is set and when the repository is computed from\n`imageRegistry` + `imageNamespace` + `image.name`.\n\nThis can produce \"double registry\" style references such as\n`legacy.example.io/quay.io/jetstack/...`. Prefer using the global\n`imageRegistry`/`imageNamespace` values.",
       "type": "string"
     },
     "helm-values.image.repository": {
-      "default": "quay.io/jetstack/trust-manager",
-      "description": "Target image repository.",
+      "default": "",
+      "description": "Full repository override (takes precedence over `imageRegistry`, `imageNamespace`, and `image.name`).\nExample: quay.io/jetstack/trust-manager",
       "type": "string"
     },
     "helm-values.image.tag": {
       "description": "Override the image tag to deploy by setting this variable. If no value is set, the chart's appVersion is used.",
+      "type": "string"
+    },
+    "helm-values.imageNamespace": {
+      "default": "jetstack",
+      "description": "The repository namespace used for trust-manager images by default.\nExamples:\n- jetstack\n- cert-manager",
       "type": "string"
     },
     "helm-values.imagePullSecrets": {
@@ -736,6 +771,11 @@
       "description": "For Private docker registries, authentication is needed. Registry secrets are applied to the service account.",
       "items": {},
       "type": "array"
+    },
+    "helm-values.imageRegistry": {
+      "default": "quay.io",
+      "description": "The container registry used for trust-manager images by default. This can include path prefixes (e.g. \"artifactory.example.com/docker\").",
+      "type": "string"
     },
     "helm-values.nameOverride": {
       "default": "",

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -50,16 +50,45 @@ namespace: ""
 # For Private docker registries, authentication is needed. Registry secrets are applied to the service account.
 imagePullSecrets: []
 
+# The container registry used for trust-manager images by default.
+# This can include path prefixes (e.g. "artifactory.example.com/docker").
+# +docs:property
+imageRegistry: quay.io
+
+# The repository namespace used for trust-manager images by default.
+# Examples:
+# - jetstack
+# - cert-manager
+# +docs:property
+imageNamespace: jetstack
+
 image:
   # Target image registry. This value is prepended to the target image repository, if set.
   # For example:
-  #   registry: quay.io
-  #   repository: jetstack/trust-manager
+  #   registry: legacy.example.io
+  # Deprecated: per-component registry prefix.
+  #
+  # If set, this value is *prepended* to the image repository that the chart would otherwise render.
+  # This applies both when `image.repository` is set and when the repository is computed from
+  # `imageRegistry` + `imageNamespace` + `image.name`.
+  #
+  # This can produce "double registry" style references such as
+  # `legacy.example.io/quay.io/jetstack/...`. Prefer using the global
+  # `imageRegistry`/`imageNamespace` values.
   # +docs:property
   # registry: quay.io
 
-  # Target image repository.
-  repository: quay.io/jetstack/trust-manager
+  # Full repository override (takes precedence over `imageRegistry`, `imageNamespace`,
+  # and `image.name`).
+  # Example: quay.io/jetstack/trust-manager
+  # +docs:property
+  repository: ""
+
+  # The image name for trust-manager.
+  # This is used (together with `imageRegistry` and `imageNamespace`) to construct the full
+  # image reference.
+  # +docs:property
+  name: trust-manager
 
   # Override the image tag to deploy by setting this variable.
   # If no value is set, the chart's appVersion is used.
@@ -95,11 +124,29 @@ defaultPackageImage:
   # For example:
   #   registry: quay.io
   #   repository: jetstack/cert-manager-package-debian
+  # Deprecated: per-component registry prefix.
+  #
+  # If set, this value is *prepended* to the image repository that the chart would otherwise render.
+  # This applies both when `image.repository` is set and when the repository is computed from
+  # `imageRegistry` + `imageNamespace` + `image.name`.
+  #
+  # This can produce "double registry" style references such as
+  # `legacy.example.io/quay.io/jetstack/...`. Prefer using the global
+  # `imageRegistry`/`imageNamespace` values.
   # +docs:property
   # registry: quay.io
 
-  # The repository for the default package image. This image enables the 'useDefaultCAs' source on Bundles.
-  repository: quay.io/jetstack/trust-pkg-debian-bookworm
+  # Full repository override (takes precedence over `imageRegistry`, `imageNamespace`,
+  # and `image.name`).
+  # Example: quay.io/jetstack/trust-manager
+  # +docs:property
+  repository: ""
+
+  # The image name for trust-manager.
+  # This is used (together with `imageRegistry` and `imageNamespace`) to construct the full
+  # image reference.
+  # +docs:property
+  name: trust-pkg-debian-bookworm
 
   # Override the image tag of the default package image.
   # Is set at chart build time to the version specified in ./make/00_debian_bookworm_version.mk.
@@ -111,6 +158,10 @@ defaultPackageImage:
   #   digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
   # +docs:property
   # digest: sha256:...
+
+  # WARNING: For internal use only, is overwritten before releasing the chart.
+  # +docs:hidden
+  _defaultReference: :v0.0.0
 
   # imagePullPolicy for the default package image.
   pullPolicy: IfNotPresent

--- a/make/00_mod.mk
+++ b/make/00_mod.mk
@@ -69,9 +69,6 @@ golangci_lint_config := .golangci.yaml
 
 define helm_values_mutation_function
 $(YQ) \
-	'( .image.repository = "$(oci_manager_image_name)" ) | \
-	( .image.tag = "$(oci_manager_image_tag)" ) | \
-	( .defaultPackageImage.repository = "$(oci_package_debian_bookworm_image_name)" ) | \
-	( .defaultPackageImage.tag = "$(oci_package_debian_bookworm_image_tag)" )' \
+	'( .defaultPackageImage._defaultReference = ":$(oci_package_debian_bookworm_image_tag)" )' \
 	$1 --inplace
 endef


### PR DESCRIPTION
Adds imageRegistry and imageNamespace values, aligning image configuration with cert-manager charts.

Implements https://github.com/cert-manager/cert-manager/blob/master/design/20260120.images-in-the-helm-chart.md (cert-manager/cert-manager#8425)