### PR TITLE
chart: add startupapicheck to ensure trust-manager is ready after install

### DIFF
--- a/cmd/trust-manager/app/app.go
+++ b/cmd/trust-manager/app/app.go
@@ -121,6 +121,8 @@ func NewCommand() *cobra.Command {
 		},
 	}
 
+	cmd.AddCommand(NewStartupAPICheckCommand())
+
 	opts = opts.Prepare(cmd)
 
 	return cmd

--- a/cmd/trust-manager/app/startupapicheck.go
+++ b/cmd/trust-manager/app/startupapicheck.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2021 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/cli-runtime/pkg/genericclioptions"
+	"k8s.io/client-go/dynamic"
+
+	_ "k8s.io/client-go/plugin/pkg/client/auth"
+)
+
+func NewStartupAPICheckCommand() *cobra.Command {
+	var (
+		timeout  time.Duration
+		interval time.Duration
+
+		kubeConfigFlags = genericclioptions.NewConfigFlags(true)
+	)
+
+	cmd := &cobra.Command{
+		Use:   "startupapicheck",
+		Short: "Wait for trust-manager to be ready to accept Bundle resources (CRD + webhook ready)",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			restCfg, err := kubeConfigFlags.ToRESTConfig()
+			if err != nil {
+				return fmt.Errorf("failed to build kubernetes rest config: %w", err)
+			}
+
+			dc, err := dynamic.NewForConfig(restCfg)
+			if err != nil {
+				return fmt.Errorf("failed to create dynamic client: %w", err)
+			}
+
+			// Bundles are cluster-scoped.
+			gvr := schema.GroupVersionResource{
+				Group:    "trust.cert-manager.io",
+				Version:  "v1alpha1",
+				Resource: "bundles",
+			}
+
+			// Use DryRun so we don't persist anything, but still exercise admission.
+			name := "startupapicheck-" + utilrand.String(8)
+
+			bundle := &unstructured.Unstructured{
+				Object: map[string]any{
+					"apiVersion": "trust.cert-manager.io/v1alpha1",
+					"kind":       "Bundle",
+					"metadata": map[string]any{
+						"name": name,
+					},
+					"spec": map[string]any{
+						"sources": []any{
+							map[string]any{
+								// Simple non-empty string; avoids requiring default packages etc.
+								"inLine": "startupapicheck",
+							},
+						},
+						"target": map[string]any{
+							"configMap": map[string]any{
+								"key": "bundle.pem",
+							},
+						},
+					},
+				},
+			}
+
+			ctx, cancel := context.WithTimeout(cmd.Context(), timeout)
+			defer cancel()
+
+			lastLog := time.Time{}
+
+			return wait.PollUntilContextCancel(ctx, interval, true, func(ctx context.Context) (bool, error) {
+				_, err := dc.Resource(gvr).Create(ctx, bundle, metav1.CreateOptions{
+					DryRun: []string{"All"},
+				})
+				if err != nil {
+					// Don't spam logs every poll; log ~every 10s.
+					if time.Since(lastLog) > 10*time.Second {
+						fmt.Fprintf(cmd.ErrOrStderr(), "startupapicheck: waiting for API to accept Bundle (CRD+webhook): %v\n", err)
+						lastLog = time.Now()
+					}
+					return false, nil
+				}
+
+				fmt.Fprintln(cmd.OutOrStdout(), "startupapicheck: success")
+				return true, nil
+			})
+		},
+	}
+
+	cmd.Flags().DurationVar(&timeout, "timeout", time.Minute, "Timeout to wait for the API to be ready")
+	cmd.Flags().DurationVar(&interval, "interval", 2*time.Second, "Polling interval between attempts")
+
+	// Support running locally too.
+	kubeConfigFlags.AddFlags(cmd.Flags())
+
+	return cmd
+}

--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -753,5 +753,139 @@ extraObjects:
        - toEntities:
            - kube-apiserver
 ```
+### Startup API Check
+
+
+Helm post-install/post-upgrade hook Job that waits until the API server can successfully admit a Bundle (CRD served + validating webhook reachable + CA bundle ready).
+#### **startupapicheck.enabled** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+#### **startupapicheck.timeout** ~ `string`
+> Default value:
+> ```yaml
+> 1m
+> ```
+#### **startupapicheck.backoffLimit** ~ `number`
+> Default value:
+> ```yaml
+> 4
+> ```
+#### **startupapicheck.jobAnnotations** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+Extra annotations for the Job. (Helm hook annotations are applied in the template.)
+#### **startupapicheck.podAnnotations** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+#### **startupapicheck.podLabels** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+#### **startupapicheck.securityContext.runAsNonRoot** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+#### **startupapicheck.securityContext.seccompProfile.type** ~ `string`
+> Default value:
+> ```yaml
+> RuntimeDefault
+> ```
+#### **startupapicheck.containerSecurityContext.allowPrivilegeEscalation** ~ `bool`
+> Default value:
+> ```yaml
+> false
+> ```
+#### **startupapicheck.containerSecurityContext.capabilities.drop[0]** ~ `string`
+> Default value:
+> ```yaml
+> ALL
+> ```
+#### **startupapicheck.containerSecurityContext.readOnlyRootFilesystem** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+#### **startupapicheck.resources** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+#### **startupapicheck.nodeSelector** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+
+Keep empty by default to avoid schema pointer issues with "/" keys.  
+Template defaults to kubernetes.io/os=linux.
+#### **startupapicheck.affinity** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+#### **startupapicheck.tolerations** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+#### **startupapicheck.volumes** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+#### **startupapicheck.volumeMounts** ~ `array`
+> Default value:
+> ```yaml
+> []
+> ```
+#### **startupapicheck.rbac.annotations** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+#### **startupapicheck.serviceAccount.create** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+#### **startupapicheck.serviceAccount.name** ~ `string`
+> Default value:
+> ```yaml
+> ""
+> ```
+#### **startupapicheck.serviceAccount.annotations** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+#### **startupapicheck.serviceAccount.labels** ~ `object`
+> Default value:
+> ```yaml
+> {}
+> ```
+#### **startupapicheck.serviceAccount.automountServiceAccountToken** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+#### **startupapicheck.automountServiceAccountToken** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+#### **startupapicheck.enableServiceLinks** ~ `bool`
+> Default value:
+> ```yaml
+> false
+> ```
 
 <!-- /AUTO-GENERATED -->

--- a/deploy/charts/trust-manager/templates/_helpers.tpl
+++ b/deploy/charts/trust-manager/templates/_helpers.tpl
@@ -160,3 +160,16 @@ Namespaced resources rules
   {{- end }}
 {{- end }}
 {{- end -}}
+
+{{/* Startup API check helpers */}}
+{{- define "trust-manager.startupapicheck.name" -}}
+{{- printf "%s-startupapicheck" (include "trust-manager.name" .) -}}
+{{- end -}}
+
+{{- define "trust-manager.startupapicheck.serviceAccountName" -}}
+{{- if .Values.startupapicheck.serviceAccount.create -}}
+{{- default (include "trust-manager.startupapicheck.name" .) .Values.startupapicheck.serviceAccount.name -}}
+{{- else -}}
+{{- default "default" .Values.startupapicheck.serviceAccount.name -}}
+{{- end -}}
+{{- end -}}

--- a/deploy/charts/trust-manager/templates/startupapicheck-job.yaml
+++ b/deploy/charts/trust-manager/templates/startupapicheck-job.yaml
@@ -1,0 +1,82 @@
+{{- if .Values.startupapicheck.enabled -}}
+{{- $ann := dict "helm.sh/hook" "post-install,post-upgrade" "helm.sh/hook-weight" "1" "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded" -}}
+{{- with .Values.startupapicheck.jobAnnotations -}}
+{{- $ann = merge $ann . -}}
+{{- end -}}
+
+{{- $nodeSelector := dict "kubernetes.io/os" "linux" -}}
+{{- with .Values.startupapicheck.nodeSelector -}}
+{{- $nodeSelector = merge $nodeSelector . -}}
+{{- end -}}
+
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "trust-manager.startupapicheck.name" . }}
+  namespace: {{ include "trust-manager.namespace" . }}
+  labels:
+    app: {{ include "trust-manager.startupapicheck.name" . }}
+{{- include "trust-manager.labels" . | nindent 4 }}
+  annotations:
+{{- toYaml $ann | nindent 4 }}
+spec:
+  backoffLimit: {{ .Values.startupapicheck.backoffLimit }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "trust-manager.startupapicheck.name" . }}
+{{- include "trust-manager.labels" . | nindent 8 }}
+{{- with .Values.startupapicheck.podLabels }}
+{{- toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.startupapicheck.podAnnotations }}
+      annotations:
+{{- toYaml . | nindent 8 }}
+{{- end }}
+    spec:
+      restartPolicy: OnFailure
+      serviceAccountName: {{ include "trust-manager.startupapicheck.serviceAccountName" . }}
+      automountServiceAccountToken: {{ .Values.startupapicheck.automountServiceAccountToken }}
+      enableServiceLinks: {{ .Values.startupapicheck.enableServiceLinks }}
+{{- with .Values.startupapicheck.securityContext }}
+      securityContext:
+{{- toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{- toYaml . | nindent 8 }}
+{{- end }}
+      containers:
+        - name: trust-manager-startupapicheck
+          image: "{{ template "image" (tuple .Values.image .Values.imageRegistry .Values.imageNamespace (printf ":%s" $.Chart.AppVersion)) }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          args:
+            - startupapicheck
+            - --timeout={{ .Values.startupapicheck.timeout }}
+{{- with .Values.startupapicheck.containerSecurityContext }}
+          securityContext:
+{{- toYaml . | nindent 12 }}
+{{- end }}
+{{- with .Values.startupapicheck.resources }}
+          resources:
+{{- toYaml . | nindent 12 }}
+{{- end }}
+{{- with .Values.startupapicheck.volumeMounts }}
+          volumeMounts:
+{{- toYaml . | nindent 12 }}
+{{- end }}
+      nodeSelector:
+{{- toYaml $nodeSelector | nindent 8 }}
+{{- with .Values.startupapicheck.affinity }}
+      affinity:
+{{- toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.startupapicheck.tolerations }}
+      tolerations:
+{{- toYaml . | nindent 8 }}
+{{- end }}
+{{- with .Values.startupapicheck.volumes }}
+      volumes:
+{{- toYaml . | nindent 8 }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/trust-manager/templates/startupapicheck-rbac.yaml
+++ b/deploy/charts/trust-manager/templates/startupapicheck-rbac.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.startupapicheck.enabled -}}
+{{- if .Values.global.rbac.create -}}
+{{- $ann := dict "helm.sh/hook" "post-install,post-upgrade" "helm.sh/hook-weight" "-5" "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded" -}}
+{{- with .Values.startupapicheck.rbac.annotations -}}
+{{- $ann = merge $ann . -}}
+{{- end -}}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "trust-manager.startupapicheck.name" . }}
+  labels:
+    app: {{ include "trust-manager.startupapicheck.name" . }}
+{{- include "trust-manager.labels" . | nindent 4 }}
+  annotations:
+{{- toYaml $ann | nindent 4 }}
+rules:
+  - apiGroups: ["trust.cert-manager.io"]
+    resources: ["bundles"]
+    verbs: ["create"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ include "trust-manager.startupapicheck.name" . }}
+  labels:
+    app: {{ include "trust-manager.startupapicheck.name" . }}
+{{- include "trust-manager.labels" . | nindent 4 }}
+  annotations:
+{{- toYaml $ann | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "trust-manager.startupapicheck.name" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ include "trust-manager.startupapicheck.serviceAccountName" . }}
+    namespace: {{ include "trust-manager.namespace" . }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/trust-manager/templates/startupapicheck-serviceaccount.yaml
+++ b/deploy/charts/trust-manager/templates/startupapicheck-serviceaccount.yaml
@@ -1,0 +1,26 @@
+{{- if .Values.startupapicheck.enabled -}}
+{{- if .Values.startupapicheck.serviceAccount.create -}}
+{{- $ann := dict "helm.sh/hook" "post-install,post-upgrade" "helm.sh/hook-weight" "-5" "helm.sh/hook-delete-policy" "before-hook-creation,hook-succeeded" -}}
+{{- with .Values.startupapicheck.serviceAccount.annotations -}}
+{{- $ann = merge $ann . -}}
+{{- end -}}
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: {{ .Values.startupapicheck.serviceAccount.automountServiceAccountToken }}
+metadata:
+  name: {{ include "trust-manager.startupapicheck.serviceAccountName" . }}
+  namespace: {{ include "trust-manager.namespace" . }}
+  labels:
+    app: {{ include "trust-manager.startupapicheck.name" . }}
+{{- include "trust-manager.labels" . | nindent 4 }}
+{{- with .Values.startupapicheck.serviceAccount.labels }}
+{{- toYaml . | nindent 4 }}
+{{- end }}
+  annotations:
+{{- toYaml $ann | nindent 4 }}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+{{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/charts/trust-manager/values.schema.json
+++ b/deploy/charts/trust-manager/values.schema.json
@@ -84,6 +84,9 @@
         "serviceAccount": {
           "$ref": "#/$defs/helm-values.serviceAccount"
         },
+        "startupapicheck": {
+          "$ref": "#/$defs/helm-values.startupapicheck"
+        },
         "tolerations": {
           "$ref": "#/$defs/helm-values.tolerations"
         },
@@ -896,6 +899,252 @@
     "helm-values.serviceAccount.name": {
       "description": "The name of the service account to use.\nIf not set and create is true, a name is generated using the fullname template.",
       "type": "string"
+    },
+    "helm-values.startupapicheck": {
+      "additionalProperties": false,
+      "properties": {
+        "affinity": {
+          "$ref": "#/$defs/helm-values.startupapicheck.affinity"
+        },
+        "automountServiceAccountToken": {
+          "$ref": "#/$defs/helm-values.startupapicheck.automountServiceAccountToken"
+        },
+        "backoffLimit": {
+          "$ref": "#/$defs/helm-values.startupapicheck.backoffLimit"
+        },
+        "containerSecurityContext": {
+          "$ref": "#/$defs/helm-values.startupapicheck.containerSecurityContext"
+        },
+        "enableServiceLinks": {
+          "$ref": "#/$defs/helm-values.startupapicheck.enableServiceLinks"
+        },
+        "enabled": {
+          "$ref": "#/$defs/helm-values.startupapicheck.enabled"
+        },
+        "jobAnnotations": {
+          "$ref": "#/$defs/helm-values.startupapicheck.jobAnnotations"
+        },
+        "nodeSelector": {
+          "$ref": "#/$defs/helm-values.startupapicheck.nodeSelector"
+        },
+        "podAnnotations": {
+          "$ref": "#/$defs/helm-values.startupapicheck.podAnnotations"
+        },
+        "podLabels": {
+          "$ref": "#/$defs/helm-values.startupapicheck.podLabels"
+        },
+        "rbac": {
+          "$ref": "#/$defs/helm-values.startupapicheck.rbac"
+        },
+        "resources": {
+          "$ref": "#/$defs/helm-values.startupapicheck.resources"
+        },
+        "securityContext": {
+          "$ref": "#/$defs/helm-values.startupapicheck.securityContext"
+        },
+        "serviceAccount": {
+          "$ref": "#/$defs/helm-values.startupapicheck.serviceAccount"
+        },
+        "timeout": {
+          "$ref": "#/$defs/helm-values.startupapicheck.timeout"
+        },
+        "tolerations": {
+          "$ref": "#/$defs/helm-values.startupapicheck.tolerations"
+        },
+        "volumeMounts": {
+          "$ref": "#/$defs/helm-values.startupapicheck.volumeMounts"
+        },
+        "volumes": {
+          "$ref": "#/$defs/helm-values.startupapicheck.volumes"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.startupapicheck.affinity": {
+      "default": {},
+      "type": "object"
+    },
+    "helm-values.startupapicheck.automountServiceAccountToken": {
+      "default": true,
+      "type": "boolean"
+    },
+    "helm-values.startupapicheck.backoffLimit": {
+      "default": 4,
+      "type": "number"
+    },
+    "helm-values.startupapicheck.containerSecurityContext": {
+      "additionalProperties": false,
+      "properties": {
+        "allowPrivilegeEscalation": {
+          "$ref": "#/$defs/helm-values.startupapicheck.containerSecurityContext.allowPrivilegeEscalation"
+        },
+        "capabilities": {
+          "$ref": "#/$defs/helm-values.startupapicheck.containerSecurityContext.capabilities"
+        },
+        "readOnlyRootFilesystem": {
+          "$ref": "#/$defs/helm-values.startupapicheck.containerSecurityContext.readOnlyRootFilesystem"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.startupapicheck.containerSecurityContext.allowPrivilegeEscalation": {
+      "default": false,
+      "type": "boolean"
+    },
+    "helm-values.startupapicheck.containerSecurityContext.capabilities": {
+      "additionalProperties": false,
+      "properties": {
+        "drop": {
+          "$ref": "#/$defs/helm-values.startupapicheck.containerSecurityContext.capabilities.drop"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.startupapicheck.containerSecurityContext.capabilities.drop": {
+      "items": {
+        "$ref": "#/$defs/helm-values.startupapicheck.containerSecurityContext.capabilities.drop[0]"
+      },
+      "type": "array"
+    },
+    "helm-values.startupapicheck.containerSecurityContext.capabilities.drop[0]": {
+      "default": "ALL",
+      "type": "string"
+    },
+    "helm-values.startupapicheck.containerSecurityContext.readOnlyRootFilesystem": {
+      "default": true,
+      "type": "boolean"
+    },
+    "helm-values.startupapicheck.enableServiceLinks": {
+      "default": false,
+      "type": "boolean"
+    },
+    "helm-values.startupapicheck.enabled": {
+      "default": true,
+      "type": "boolean"
+    },
+    "helm-values.startupapicheck.jobAnnotations": {
+      "default": {},
+      "description": "Extra annotations for the Job. (Helm hook annotations are applied in the template.)",
+      "type": "object"
+    },
+    "helm-values.startupapicheck.nodeSelector": {
+      "default": {},
+      "description": "Keep empty by default to avoid schema pointer issues with \"/\" keys.\nTemplate defaults to kubernetes.io/os=linux.",
+      "type": "object"
+    },
+    "helm-values.startupapicheck.podAnnotations": {
+      "default": {},
+      "type": "object"
+    },
+    "helm-values.startupapicheck.podLabels": {
+      "default": {},
+      "type": "object"
+    },
+    "helm-values.startupapicheck.rbac": {
+      "additionalProperties": false,
+      "properties": {
+        "annotations": {
+          "$ref": "#/$defs/helm-values.startupapicheck.rbac.annotations"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.startupapicheck.rbac.annotations": {
+      "default": {},
+      "type": "object"
+    },
+    "helm-values.startupapicheck.resources": {
+      "default": {},
+      "type": "object"
+    },
+    "helm-values.startupapicheck.securityContext": {
+      "additionalProperties": false,
+      "properties": {
+        "runAsNonRoot": {
+          "$ref": "#/$defs/helm-values.startupapicheck.securityContext.runAsNonRoot"
+        },
+        "seccompProfile": {
+          "$ref": "#/$defs/helm-values.startupapicheck.securityContext.seccompProfile"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.startupapicheck.securityContext.runAsNonRoot": {
+      "default": true,
+      "type": "boolean"
+    },
+    "helm-values.startupapicheck.securityContext.seccompProfile": {
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "$ref": "#/$defs/helm-values.startupapicheck.securityContext.seccompProfile.type"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.startupapicheck.securityContext.seccompProfile.type": {
+      "default": "RuntimeDefault",
+      "type": "string"
+    },
+    "helm-values.startupapicheck.serviceAccount": {
+      "additionalProperties": false,
+      "properties": {
+        "annotations": {
+          "$ref": "#/$defs/helm-values.startupapicheck.serviceAccount.annotations"
+        },
+        "automountServiceAccountToken": {
+          "$ref": "#/$defs/helm-values.startupapicheck.serviceAccount.automountServiceAccountToken"
+        },
+        "create": {
+          "$ref": "#/$defs/helm-values.startupapicheck.serviceAccount.create"
+        },
+        "labels": {
+          "$ref": "#/$defs/helm-values.startupapicheck.serviceAccount.labels"
+        },
+        "name": {
+          "$ref": "#/$defs/helm-values.startupapicheck.serviceAccount.name"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.startupapicheck.serviceAccount.annotations": {
+      "default": {},
+      "type": "object"
+    },
+    "helm-values.startupapicheck.serviceAccount.automountServiceAccountToken": {
+      "default": true,
+      "type": "boolean"
+    },
+    "helm-values.startupapicheck.serviceAccount.create": {
+      "default": true,
+      "type": "boolean"
+    },
+    "helm-values.startupapicheck.serviceAccount.labels": {
+      "default": {},
+      "type": "object"
+    },
+    "helm-values.startupapicheck.serviceAccount.name": {
+      "default": "",
+      "type": "string"
+    },
+    "helm-values.startupapicheck.timeout": {
+      "default": "1m",
+      "type": "string"
+    },
+    "helm-values.startupapicheck.tolerations": {
+      "default": [],
+      "items": {},
+      "type": "array"
+    },
+    "helm-values.startupapicheck.volumeMounts": {
+      "default": [],
+      "items": {},
+      "type": "array"
+    },
+    "helm-values.startupapicheck.volumes": {
+      "default": [],
+      "items": {},
+      "type": "array"
     },
     "helm-values.tolerations": {
       "default": [],

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -462,3 +462,53 @@ extraObjects: []
 # https://helm.sh/docs/chart_best_practices/dependencies/#conditions-and-tags
 # +docs:hidden
 enabled: true
+
+# +docs:section=Startup API Check
+# Helm post-install/post-upgrade hook Job that waits until the API server can successfully admit
+# a Bundle (CRD served + validating webhook reachable + CA bundle ready).
+startupapicheck:
+  enabled: true
+  timeout: 1m
+  backoffLimit: 4
+
+  # Extra annotations for the Job. (Helm hook annotations are applied in the template.)
+  jobAnnotations: {}
+
+  podAnnotations: {}
+  podLabels: {}
+
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+
+  containerSecurityContext:
+    allowPrivilegeEscalation: false
+    capabilities:
+      drop:
+        - ALL
+    readOnlyRootFilesystem: true
+
+  resources: {}
+
+  # Keep empty by default to avoid schema pointer issues with "/" keys.
+  # Template defaults to kubernetes.io/os=linux.
+  nodeSelector: {}
+  affinity: {}
+  tolerations: []
+
+  volumes: []
+  volumeMounts: []
+
+  rbac:
+    annotations: {}
+
+  serviceAccount:
+    create: true
+    name: ""
+    annotations: {}
+    labels: {}
+    automountServiceAccountToken: true
+
+  automountServiceAccountToken: true
+  enableServiceLinks: false


### PR DESCRIPTION
Closes #837

This adds a Helm post-install/post-upgrade startupapicheck Job which waits until the API server can successfully admit a Bundle (dry-run create), ensuring the Bundle CRD is served and the validating webhook is reachable and correctly configured before users apply Bundle resources.

Changes:
- Add `trust-manager startupapicheck` CLI subcommand used by the Job.
- Add Helm hook Job + minimal RBAC/ServiceAccount for the check.
- Add chart values to configure the startupapicheck (timeout/resources/annotations/etc).