### PR TITLE
add bundle metrics

### DIFF
--- a/cmd/trust-manager/app/app.go
+++ b/cmd/trust-manager/app/app.go
@@ -28,12 +28,16 @@ import (
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	ctrlwebhook "sigs.k8s.io/controller-runtime/pkg/webhook"
 
 	"github.com/cert-manager/trust-manager/cmd/trust-manager/app/options"
 	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
 	"github.com/cert-manager/trust-manager/pkg/bundle"
+	bundleMetrics "github.com/cert-manager/trust-manager/pkg/bundle/metrics"
+	"github.com/cert-manager/trust-manager/pkg/fspkg"
+	pkgMetrics "github.com/cert-manager/trust-manager/pkg/metrics"
 	"github.com/cert-manager/trust-manager/pkg/webhook"
 )
 
@@ -95,6 +99,23 @@ func NewCommand() *cobra.Command {
 				return fmt.Errorf("failed to create manager: %w", err)
 			}
 
+			var pkg *fspkg.Package
+			if opts.Bundle.DefaultPackageLocation != "" {
+				data, err := fspkg.LoadPackageFromFile(opts.Bundle.DefaultPackageLocation)
+				if err != nil {
+					return fmt.Errorf("must load default package successfully when default package location is set: %w", err)
+				}
+				pkg = &data
+				log.Info("successfully loaded default package from filesystem", "id", pkg.StringID(), "path", opts.Bundle.DefaultPackageLocation)
+			}
+
+			m := pkgMetrics.NewRegistrator(metrics.Registry)
+			m.Add(bundleMetrics.NewBundleCollector(log, opts.Bundle, mgr.GetClient(), pkg))
+
+			if err := mgr.Add(m); err != nil {
+				return fmt.Errorf("failed to add metrics: %w", err)
+			}
+
 			if err := mgr.AddReadyzCheck("webhook", mgr.GetWebhookServer().StartedChecker()); err != nil {
 				return fmt.Errorf("failed to add webhook ready check: %v", err)
 			}
@@ -106,7 +127,7 @@ func NewCommand() *cobra.Command {
 			logf.IntoContext(ctx, log)
 
 			// Add Bundle controller to manager.
-			if err := bundle.SetupWithManager(ctx, mgr, opts.Bundle); err != nil {
+			if err := bundle.SetupWithManager(ctx, mgr, opts.Bundle, pkg); err != nil {
 				return fmt.Errorf("failed to register Bundle controller: %w", err)
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/onsi/ginkgo/v2 v2.32.0
 	github.com/onsi/gomega v1.42.1
 	github.com/pavlo-v-chernykh/keystore-go/v4 v4.5.0
+	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
 	github.com/stretchr/testify v1.11.1
@@ -67,8 +69,6 @@ require (
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
 	github.com/peterbourgon/diskv v2.0.1+incompatible // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.23.2 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.67.5 // indirect
 	github.com/prometheus/procfs v0.19.2 // indirect
 	github.com/x448/float16 v0.8.4 // indirect

--- a/pkg/bundle/controller.go
+++ b/pkg/bundle/controller.go
@@ -79,6 +79,7 @@ func SetupWithManager(
 	ctx context.Context,
 	mgr ctrl.Manager,
 	opts controller.Options,
+	pkg *fspkg.Package,
 ) error {
 	targetRequirement, err := labels.NewRequirement(trustapi.BundleLabelKey, selection.Exists, nil)
 	if err != nil {
@@ -110,7 +111,7 @@ func SetupWithManager(
 	}
 
 	// Add Bundle controller to manager.
-	if err := addBundleController(ctx, mgr, opts, targetCache); err != nil {
+	if err := addBundleController(ctx, mgr, opts, targetCache, pkg); err != nil {
 		return fmt.Errorf("failed to register Bundle controller: %w", err)
 	}
 
@@ -127,6 +128,7 @@ func addBundleController(
 	mgr manager.Manager,
 	opts controller.Options,
 	targetCache cache.Cache,
+	pkg *fspkg.Package,
 ) error {
 	b := &bundle{
 		client:   mgr.GetClient(),
@@ -134,8 +136,9 @@ func addBundleController(
 		clock:    clock.RealClock{},
 		Options:  opts,
 		bundleBuilder: &source.BundleBuilder{
-			Reader:  mgr.GetClient(),
-			Options: opts,
+			Reader:         mgr.GetClient(),
+			Options:        opts,
+			DefaultPackage: pkg,
 		},
 		targetReconciler: &target.Reconciler{
 			Client: mgr.GetClient(),
@@ -146,17 +149,6 @@ func addBundleController(
 	if len(b.Options.TargetNamespaces) > 0 {
 		logf.FromContext(ctx).Info("reconciler will skip namespaces outside targetlist",
 			"target-namespaces", b.Options.TargetNamespaces)
-	}
-
-	if b.Options.DefaultPackageLocation != "" {
-		pkg, err := fspkg.LoadPackageFromFile(b.Options.DefaultPackageLocation)
-		if err != nil {
-			return fmt.Errorf("must load default package successfully when default package location is set: %w", err)
-		}
-
-		b.bundleBuilder.DefaultPackage = &pkg
-
-		logf.FromContext(ctx).Info("successfully loaded default package from filesystem", "id", pkg.StringID(), "path", b.Options.DefaultPackageLocation)
 	}
 
 	// Only reconcile config maps that match the well known name

--- a/pkg/bundle/internal/source/source.go
+++ b/pkg/bundle/internal/source/source.go
@@ -18,6 +18,8 @@ package source
 
 import (
 	"context"
+	"crypto/sha256"
+	"crypto/x509"
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
@@ -38,6 +40,20 @@ type NotFoundError struct{ error }
 type InvalidPEMError struct{ error }
 
 type InvalidSecretError struct{ error }
+type Kind string
+
+const (
+	ConfigMapKind Kind = "ConfigMap"
+	SecretKind    Kind = "Secret"
+	InlineKind    Kind = "InLine"
+	DefaultCAKind Kind = "DefaultCAs"
+)
+
+type CertMetadata struct {
+	Kind Kind
+	Name string
+	Key  string
+}
 
 // BundleData holds the result of a call to BuildBundle. It contains the resulting PEM-encoded
 // certificate data from concatenating all the sources together, binary data for any additional formats and
@@ -46,6 +62,41 @@ type BundleData struct {
 	CertPool *util.CertPool
 
 	DefaultCAPackageStringID string
+
+	meta map[[32]byte]CertMetadata
+}
+
+func NewBundleData(pool *util.CertPool) BundleData {
+	return BundleData{
+		CertPool: pool,
+		meta:     make(map[[32]byte]CertMetadata),
+	}
+}
+
+func (b *BundleData) AddFromPem(pemData []byte, kind Kind, name, key string) error {
+	err := b.CertPool.ParsePemData(pemData, func(cert *x509.Certificate) {
+		if b.CertPool.AddCert(cert) {
+			hash := sha256.Sum256(cert.Raw)
+			if kind == DefaultCAKind || kind == InlineKind {
+				name = fmt.Sprintf("%x", hash)
+			}
+			b.meta[hash] = CertMetadata{
+				Kind: kind,
+				Name: name,
+				Key:  key,
+			}
+		}
+	})
+	return err
+}
+
+func (b *BundleData) GetMetadata(cert *x509.Certificate) (CertMetadata, error) {
+	hash := sha256.Sum256(cert.Raw)
+	meta, ok := b.meta[hash]
+	if !ok {
+		return CertMetadata{}, fmt.Errorf("no metadata found for certificate with hash %x", hash[:])
+	}
+	return meta, nil
 }
 
 type BundleBuilder struct {
@@ -61,12 +112,12 @@ type BundleBuilder struct {
 // BuildBundle retrieves and concatenates all source bundle data for this Bundle object.
 // Each source data is validated and pruned to ensure that all certificates within are valid.
 func (b *BundleBuilder) BuildBundle(ctx context.Context, sources []trustapi.BundleSource) (BundleData, error) {
-	var resolvedBundle BundleData
-	resolvedBundle.CertPool = util.NewCertPool(
+	certPool := util.NewCertPool(
 		util.WithFilteredExpiredCerts(b.FilterExpiredCerts),
 		util.WithFilteredNonCaCerts(b.FilterNonCACerts),
 		util.WithLogger(logf.FromContext(ctx).WithName("cert-pool")),
 	)
+	resolvedBundle := NewBundleData(certPool)
 
 	for _, source := range sources {
 		var certSource bundleSource
@@ -94,7 +145,7 @@ func (b *BundleBuilder) BuildBundle(ctx context.Context, sources []trustapi.Bund
 			panic(fmt.Sprintf("don't know how to process source: %+v", source))
 		}
 
-		if err := certSource.addToCertPool(ctx, resolvedBundle.CertPool); err != nil {
+		if err := certSource.addToBundle(ctx, &resolvedBundle); err != nil {
 			return BundleData{}, err
 		}
 	}
@@ -108,15 +159,15 @@ func (b *BundleBuilder) BuildBundle(ctx context.Context, sources []trustapi.Bund
 }
 
 type bundleSource interface {
-	addToCertPool(context.Context, *util.CertPool) error
+	addToBundle(context.Context, *BundleData) error
 }
 
 type inlineBundleSource struct {
 	pemData string
 }
 
-func (s inlineBundleSource) addToCertPool(_ context.Context, pool *util.CertPool) error {
-	if err := pool.AddCertsFromPEM([]byte(s.pemData)); err != nil {
+func (s inlineBundleSource) addToBundle(_ context.Context, bundle *BundleData) error {
+	if err := bundle.AddFromPem([]byte(s.pemData), InlineKind, "", ""); err != nil {
 		return InvalidPEMError{fmt.Errorf("inline source contains invalid PEM data: %w", err)}
 	}
 	return nil
@@ -126,8 +177,8 @@ type defaultCAsBundleSource struct {
 	pemData string
 }
 
-func (s defaultCAsBundleSource) addToCertPool(_ context.Context, pool *util.CertPool) error {
-	if err := pool.AddCertsFromPEM([]byte(s.pemData)); err != nil {
+func (s defaultCAsBundleSource) addToBundle(_ context.Context, bundle *BundleData) error {
+	if err := bundle.AddFromPem([]byte(s.pemData), DefaultCAKind, "", ""); err != nil {
 		return InvalidPEMError{fmt.Errorf("default package contains invalid PEM data: %w", err)}
 	}
 	return nil
@@ -139,7 +190,7 @@ type configMapBundleSource struct {
 	ref       *trustapi.SourceObjectKeySelector
 }
 
-func (b configMapBundleSource) addToCertPool(ctx context.Context, pool *util.CertPool) error {
+func (b configMapBundleSource) addToBundle(ctx context.Context, bundle *BundleData) error {
 	// this slice will contain a single ConfigMap if we fetch by name
 	// or potentially multiple ConfigMaps if we fetch by label selector
 	var configMaps []corev1.ConfigMap
@@ -185,11 +236,11 @@ func (b configMapBundleSource) addToCertPool(ctx context.Context, pool *util.Cer
 			binaryData, binaryOk := cm.BinaryData[b.ref.Key]
 			switch {
 			case ok:
-				if err := pool.AddCertsFromPEM([]byte(data)); err != nil {
+				if err := bundle.AddFromPem([]byte(data), ConfigMapKind, cm.Name, b.ref.Key); err != nil {
 					return InvalidPEMError{fmt.Errorf("invalid PEM data in ConfigMap %s/%s at key %q: %w", cm.Namespace, cm.Name, b.ref.Key, err)}
 				}
 			case binaryOk:
-				if err := pool.AddCertsFromPEM(binaryData); err != nil {
+				if err := bundle.AddFromPem(binaryData, ConfigMapKind, cm.Name, b.ref.Key); err != nil {
 					return InvalidPEMError{fmt.Errorf("invalid PEM data in ConfigMap %s/%s at key %q: %w", cm.Namespace, cm.Name, b.ref.Key, err)}
 				}
 			default:
@@ -197,12 +248,12 @@ func (b configMapBundleSource) addToCertPool(ctx context.Context, pool *util.Cer
 			}
 		} else if ptr.Deref(b.ref.IncludeAllKeys, false) {
 			for key, data := range cm.Data {
-				if err := pool.AddCertsFromPEM([]byte(data)); err != nil {
+				if err := bundle.AddFromPem([]byte(data), ConfigMapKind, cm.Name, key); err != nil {
 					return InvalidPEMError{fmt.Errorf("invalid PEM data in ConfigMap %s/%s at key %q: %w", cm.Namespace, cm.Name, key, err)}
 				}
 			}
 			for key, data := range cm.BinaryData {
-				if err := pool.AddCertsFromPEM(data); err != nil {
+				if err := bundle.AddFromPem(data, ConfigMapKind, cm.Name, key); err != nil {
 					return InvalidPEMError{fmt.Errorf("invalid PEM data in ConfigMap %s/%s at key %q: %w", cm.Namespace, cm.Name, key, err)}
 				}
 			}
@@ -217,7 +268,7 @@ type secretBundleSource struct {
 	ref       *trustapi.SourceObjectKeySelector
 }
 
-func (b secretBundleSource) addToCertPool(ctx context.Context, pool *util.CertPool) error {
+func (b secretBundleSource) addToBundle(ctx context.Context, bundle *BundleData) error {
 	// this slice will contain a single Secret if we fetch by name
 	// or potentially multiple Secrets if we fetch by label selector
 	var secrets []corev1.Secret
@@ -260,7 +311,7 @@ func (b secretBundleSource) addToCertPool(ctx context.Context, pool *util.CertPo
 			if !ok {
 				return NotFoundError{fmt.Errorf("no data found in Secret %s/%s at key %q", secret.Namespace, secret.Name, b.ref.Key)}
 			}
-			if err := pool.AddCertsFromPEM(data); err != nil {
+			if err := bundle.AddFromPem(data, SecretKind, secret.Name, b.ref.Key); err != nil {
 				return InvalidPEMError{fmt.Errorf("invalid PEM data in Secret %s/%s at key %q: %w", secret.Namespace, secret.Name, b.ref.Key, err)}
 			}
 		} else if ptr.Deref(b.ref.IncludeAllKeys, false) {
@@ -270,7 +321,7 @@ func (b secretBundleSource) addToCertPool(ctx context.Context, pool *util.CertPo
 			}
 
 			for key, data := range secret.Data {
-				if err := pool.AddCertsFromPEM(data); err != nil {
+				if err := bundle.AddFromPem(data, SecretKind, secret.Name, key); err != nil {
 					return InvalidPEMError{fmt.Errorf("invalid PEM data in Secret %s/%s at key %q: %w", secret.Namespace, secret.Name, key, err)}
 				}
 			}

--- a/pkg/bundle/internal/target/target_test.go
+++ b/pkg/bundle/internal/target/target_test.go
@@ -477,7 +477,7 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 					AdditionalFormats: &trustapi.AdditionalFormats{},
 				},
 			}
-			resolvedBundle := source.BundleData{CertPool: certPool}
+			resolvedBundle := source.NewBundleData(certPool)
 			if tt.withJKS {
 				spec.Target.AdditionalFormats.JKS = &trustapi.JKS{
 					KeySelector: trustapi.KeySelector{
@@ -923,7 +923,7 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 					AdditionalFormats: &trustapi.AdditionalFormats{},
 				},
 			}
-			resolvedBundle := source.BundleData{CertPool: certPool}
+			resolvedBundle := source.NewBundleData(certPool)
 			if tt.withJKS {
 				spec.Target.AdditionalFormats.JKS = &trustapi.JKS{
 					KeySelector: trustapi.KeySelector{

--- a/pkg/bundle/metrics/bundlecollector.go
+++ b/pkg/bundle/metrics/bundlecollector.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+	"crypto/x509"
+	"time"
+
+	"github.com/go-logr/logr"
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
+	"github.com/cert-manager/trust-manager/pkg/bundle/controller"
+	"github.com/cert-manager/trust-manager/pkg/bundle/internal/source"
+	"github.com/cert-manager/trust-manager/pkg/fspkg"
+)
+
+var (
+	caSSLNotBefore = prometheus.NewDesc("certmanager_ssl_ca_not_before", "A Unix timestamp of the date when the CA validity begins", []string{"serial_number", "subject_common_name", "bundle_name", "kind", "name", "key"}, nil)
+	caSSLNotAfter  = prometheus.NewDesc("certmanager_ssl_ca_not_after", "A Unix timestamp of the date when the CA validity ends", []string{"serial_number", "subject_common_name", "bundle_name", "kind", "name", "key"}, nil)
+)
+
+type BundleCollector struct {
+	logger               logr.Logger
+	opts                 controller.Options
+	client               client.Client
+	pkg                  *fspkg.Package
+	caSSLNotBeforeMetric *prometheus.Desc
+	caSSLNotAfterMetric  *prometheus.Desc
+}
+
+func NewBundleCollector(log logr.Logger, opts controller.Options, client client.Client, pkg *fspkg.Package) prometheus.Collector {
+	return &BundleCollector{
+		logger:               log.WithName("Metrics"),
+		opts:                 opts,
+		client:               client,
+		pkg:                  pkg,
+		caSSLNotBeforeMetric: caSSLNotBefore,
+		caSSLNotAfterMetric:  caSSLNotAfter,
+	}
+}
+
+func (bc BundleCollector) Describe(desc chan<- *prometheus.Desc) {
+	desc <- bc.caSSLNotBeforeMetric
+	desc <- bc.caSSLNotAfterMetric
+}
+
+func (bc BundleCollector) Collect(ch chan<- prometheus.Metric) {
+	bundles := v1alpha1.BundleList{}
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	err := bc.client.List(ctx, &bundles)
+	if err != nil {
+		bc.logger.V(5).Error(err, "failed to list bundles")
+		return
+	}
+
+	bc.reportBundleMetrics(ctx, ch, bundles)
+}
+
+func (bc BundleCollector) reportBundleMetrics(ctx context.Context, ch chan<- prometheus.Metric, bundles v1alpha1.BundleList) {
+	for i := range bundles.Items {
+		bundle := bundles.Items[i]
+		builder := source.BundleBuilder{
+			Reader:         bc.client,
+			Options:        bc.opts,
+			DefaultPackage: bc.pkg,
+		}
+		bundleData, err := builder.BuildBundle(ctx, bundle.Spec.Sources)
+		if err != nil {
+			bc.logger.V(5).Error(err, "failed to build bundle")
+			continue
+		}
+
+		certificates := bundleData.CertPool.Certificates()
+		metrics := make([]prometheus.Metric, 0, len(certificates)*2)
+
+		for j := range certificates {
+			s := certificates[j]
+			meta, err := bundleData.GetMetadata(s)
+			if err != nil {
+				bc.logger.Error(err, "failed to get metadata")
+				continue
+			}
+			metrics = append(metrics, buildMetric(s, bundle.Name, string(meta.Kind), meta.Name, meta.Key)...)
+		}
+
+		for _, metric := range metrics {
+			ch <- metric
+		}
+	}
+}
+
+func buildMetric(cert *x509.Certificate, bundleName string, sourceKind string, sourceName, sourceKey string) []prometheus.Metric {
+	metrics := make([]prometheus.Metric, 0, 2)
+	notAfter := prometheus.MustNewConstMetric(
+		caSSLNotAfter,
+		prometheus.GaugeValue,
+		float64(cert.NotAfter.Unix()),
+		cert.SerialNumber.String(),
+		cert.Subject.CommonName,
+		bundleName,
+		sourceKind,
+		sourceName,
+		sourceKey,
+	)
+	metrics = append(metrics, notAfter)
+	notBefore := prometheus.MustNewConstMetric(
+		caSSLNotBefore,
+		prometheus.GaugeValue,
+		float64(cert.NotBefore.Unix()),
+		cert.SerialNumber.String(),
+		cert.Subject.CommonName,
+		bundleName,
+		sourceKind,
+		sourceName,
+		sourceKey,
+	)
+	metrics = append(metrics, notBefore)
+	return metrics
+}

--- a/pkg/bundle/metrics/bundlecollector_test.go
+++ b/pkg/bundle/metrics/bundlecollector_test.go
@@ -1,0 +1,392 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/go-logr/logr/funcr"
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
+	"github.com/cert-manager/trust-manager/pkg/bundle/controller"
+	"github.com/cert-manager/trust-manager/pkg/fspkg"
+	"github.com/cert-manager/trust-manager/test/dummy"
+)
+
+func newTestLogger(t *testing.T) logr.Logger {
+	return funcr.New(func(prefix, args string) {
+		t.Logf("%s: %s", prefix, args)
+	}, funcr.Options{
+		Verbosity: 10,
+	})
+}
+
+func getDescName(desc *prometheus.Desc) string {
+	descStr := desc.String()
+	parts := strings.Split(descStr, "\"")
+	if len(parts) >= 2 {
+		return strings.TrimSuffix(parts[1], "\"")
+	}
+	return ""
+}
+
+func getMetricValue(m prometheus.Metric) float64 {
+	dtoMetric := &dto.Metric{}
+	err := m.Write(dtoMetric)
+	if err != nil {
+		return 0
+	}
+	if dtoMetric.GetGauge() != nil {
+		return dtoMetric.GetGauge().GetValue()
+	}
+	return 0
+}
+
+func parseTestCertificate(t *testing.T, certPEM string) *x509.Certificate {
+	t.Helper()
+	block, _ := pem.Decode([]byte(certPEM))
+	require.NotNil(t, block, "should be able to decode PEM block")
+	cert, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err, "should be able to parse certificate")
+	return cert
+}
+
+func Test_BundleCollector_Describe(t *testing.T) {
+	tests := map[string]struct {
+		expectedDescNames []string
+	}{
+		"should describe both not_before and not_after metrics": {
+			expectedDescNames: []string{
+				"certmanager_ssl_ca_not_before",
+				"certmanager_ssl_ca_not_after",
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			logger := newTestLogger(t)
+			scheme := runtime.NewScheme()
+			require.NoError(t, trustapi.AddToScheme(scheme))
+			require.NoError(t, corev1.AddToScheme(scheme))
+
+			client := fake.NewClientBuilder().
+				WithScheme(scheme).
+				Build()
+
+			collector := NewBundleCollector(logger, controller.Options{Namespace: "test"}, client, nil)
+
+			descCh := make(chan *prometheus.Desc, 10)
+			collector.Describe(descCh)
+			close(descCh)
+
+			var descs []*prometheus.Desc
+			for desc := range descCh {
+				descs = append(descs, desc)
+			}
+
+			require.Len(t, descs, len(tt.expectedDescNames))
+			for i, expectedName := range tt.expectedDescNames {
+				assert.Equal(t, expectedName, getDescName(descs[i]))
+			}
+		})
+	}
+}
+
+func Test_BundleCollector_Collect(t *testing.T) {
+	tests := map[string]struct {
+		bundle         *trustapi.Bundle
+		extraObjects   []client.Object
+		namespace      string
+		expectedLen    int
+		defaultPackage *fspkg.Package
+	}{
+		"inLine source should collect metrics": {
+			bundle: &trustapi.Bundle{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-bundle",
+					Namespace: "test-namespace",
+				},
+				Spec: trustapi.BundleSpec{
+					Sources: []trustapi.BundleSource{
+						{InLine: dummy.TestCertificate1},
+					},
+				},
+			},
+			extraObjects: nil,
+			namespace:    "test-namespace",
+			expectedLen:  2,
+		},
+		"secret with key should collect metrics": {
+			bundle: &trustapi.Bundle{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-bundle",
+					Namespace: "test-namespace",
+				},
+				Spec: trustapi.BundleSpec{
+					Sources: []trustapi.BundleSource{
+						{Secret: &trustapi.SourceObjectKeySelector{
+							Name: "my-secret",
+							Key:  "ca.crt",
+						}},
+					},
+				},
+			},
+			extraObjects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-secret",
+						Namespace: "test-namespace",
+					},
+					Data: map[string][]byte{
+						"ca.crt": []byte(dummy.TestCertificate1),
+					},
+				},
+			},
+			namespace:   "test-namespace",
+			expectedLen: 2,
+		},
+		"secret with includeAllKeys should collect metrics for all keys": {
+			bundle: &trustapi.Bundle{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-bundle",
+					Namespace: "test-namespace",
+				},
+				Spec: trustapi.BundleSpec{
+					Sources: []trustapi.BundleSource{
+						{Secret: &trustapi.SourceObjectKeySelector{
+							Name:           "my-secret",
+							IncludeAllKeys: new(true),
+						}},
+					},
+				},
+			},
+			extraObjects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-secret",
+						Namespace: "test-namespace",
+					},
+					Data: map[string][]byte{
+						"ca.crt":  []byte(dummy.TestCertificate1),
+						"ca2.crt": []byte(dummy.TestCertificate3),
+					},
+				},
+			},
+			namespace:   "test-namespace",
+			expectedLen: 4,
+		},
+		"configMap with key should collect metrics": {
+			bundle: &trustapi.Bundle{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-bundle",
+					Namespace: "test-namespace",
+				},
+				Spec: trustapi.BundleSpec{
+					Sources: []trustapi.BundleSource{
+						{ConfigMap: &trustapi.SourceObjectKeySelector{
+							Name: "my-configmap",
+							Key:  "ca.crt",
+						}},
+					},
+				},
+			},
+			extraObjects: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-configmap",
+						Namespace: "test-namespace",
+					},
+					Data: map[string]string{
+						"ca.crt": dummy.TestCertificate1,
+					},
+				},
+			},
+			namespace:   "test-namespace",
+			expectedLen: 2,
+		},
+		"configMap with includeAllKeys should collect metrics for all keys": {
+			bundle: &trustapi.Bundle{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-bundle",
+					Namespace: "test-namespace",
+				},
+				Spec: trustapi.BundleSpec{
+					Sources: []trustapi.BundleSource{
+						{ConfigMap: &trustapi.SourceObjectKeySelector{
+							Name:           "my-configmap",
+							IncludeAllKeys: new(true),
+						}},
+					},
+				},
+			},
+			extraObjects: []client.Object{
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-configmap",
+						Namespace: "test-namespace",
+					},
+					Data: map[string]string{
+						"ca.crt":  dummy.TestCertificate1,
+						"ca2.crt": dummy.TestCertificate3,
+					},
+				},
+			},
+			namespace:   "test-namespace",
+			expectedLen: 4,
+		},
+		"all source types combined in a single bundle should collect metrics": {
+			bundle: &trustapi.Bundle{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-bundle",
+					Namespace: "test-namespace",
+				},
+				Spec: trustapi.BundleSpec{
+					Sources: []trustapi.BundleSource{
+						{InLine: dummy.TestCertificate1},
+						{Secret: &trustapi.SourceObjectKeySelector{
+							Name: "my-secret",
+							Key:  "ca.crt",
+						}},
+						{ConfigMap: &trustapi.SourceObjectKeySelector{
+							Name: "my-configmap",
+							Key:  "ca.crt",
+						}},
+						{UseDefaultCAs: new(true)},
+					},
+				},
+			},
+			extraObjects: []client.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-secret",
+						Namespace: "test-namespace",
+					},
+					Data: map[string][]byte{
+						"ca.crt": []byte(dummy.TestCertificate3),
+					},
+				},
+				&corev1.ConfigMap{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "my-configmap",
+						Namespace: "test-namespace",
+					},
+					Data: map[string]string{
+						"ca.crt": dummy.TestCertificate4,
+					},
+				},
+			},
+			namespace:   "test-namespace",
+			expectedLen: 8,
+			defaultPackage: &fspkg.Package{
+				Name:    "testpkg",
+				Version: "123",
+				Bundle:  dummy.TestCertificate5,
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			logger := newTestLogger(t)
+			scheme := runtime.NewScheme()
+			require.NoError(t, trustapi.AddToScheme(scheme))
+			require.NoError(t, corev1.AddToScheme(scheme))
+
+			objects := []client.Object{tt.bundle}
+			objects = append(objects, tt.extraObjects...)
+
+			client := fake.NewClientBuilder().
+				WithScheme(scheme).
+				WithObjects(objects...).
+				Build()
+
+			collector := NewBundleCollector(logger, controller.Options{Namespace: tt.namespace}, client, tt.defaultPackage)
+
+			metricCh := make(chan prometheus.Metric, 100)
+			collector.Collect(metricCh)
+			close(metricCh)
+
+			var metrics []prometheus.Metric
+			for metric := range metricCh {
+				metrics = append(metrics, metric)
+			}
+
+			require.Len(t, metrics, tt.expectedLen)
+		})
+	}
+}
+
+func Test_buildMetric(t *testing.T) {
+	tests := map[string]struct {
+		cert                   string
+		bundleName             string
+		kind                   string
+		name                   string
+		key                    string
+		expectedNotAfterFirst  string
+		expectedNotBeforeFirst string
+	}{
+		"TestCertificate1": {
+			cert:                   dummy.TestCertificate1,
+			bundleName:             "test-bundle",
+			kind:                   "ConfigMap",
+			name:                   "test-configmap",
+			key:                    "cert",
+			expectedNotAfterFirst:  "certmanager_ssl_ca_not_after",
+			expectedNotBeforeFirst: "certmanager_ssl_ca_not_before",
+		},
+		"TestCertificate3": {
+			cert:                   dummy.TestCertificate3,
+			bundleName:             "my-bundle",
+			kind:                   "Secret",
+			name:                   "my-secret",
+			key:                    "ca.crt",
+			expectedNotAfterFirst:  "certmanager_ssl_ca_not_after",
+			expectedNotBeforeFirst: "certmanager_ssl_ca_not_before",
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			cert := parseTestCertificate(t, tt.cert)
+
+			metrics := buildMetric(cert, tt.bundleName, tt.kind, tt.name, tt.key)
+
+			require.Len(t, metrics, 2)
+
+			assert.Equal(t, tt.expectedNotAfterFirst, getDescName(metrics[0].Desc()))
+			assert.Equal(t, tt.expectedNotBeforeFirst, getDescName(metrics[1].Desc()))
+
+			assert.Equal(t, float64(cert.NotAfter.Unix()), getMetricValue(metrics[0]))
+			assert.Equal(t, float64(cert.NotBefore.Unix()), getMetricValue(metrics[1]))
+		})
+	}
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package metrics
+
+import (
+	"context"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+)
+
+type MetricRegistrator struct {
+	registry   metrics.RegistererGatherer
+	collectors []prometheus.Collector
+}
+
+func NewRegistrator(registry metrics.RegistererGatherer) *MetricRegistrator {
+	return &MetricRegistrator{
+		registry:   registry,
+		collectors: make([]prometheus.Collector, 0),
+	}
+}
+
+func (m *MetricRegistrator) Add(collector prometheus.Collector) {
+	m.collectors = append(m.collectors, collector)
+}
+
+func (m *MetricRegistrator) Start(ctx context.Context) error {
+	for i := range m.collectors {
+		err := m.registry.Register(m.collectors[i])
+		if err != nil {
+			return err
+		}
+	}
+	<-ctx.Done()
+
+	for i := range m.collectors {
+		m.registry.Unregister(m.collectors[i])
+	}
+
+	return nil
+}
+
+func (m *MetricRegistrator) NeedLeaderElection() bool {
+	return true
+}

--- a/pkg/util/cert_pool.go
+++ b/pkg/util/cert_pool.go
@@ -117,6 +117,12 @@ func NewCertPool(options ...Option) *CertPool {
 //
 // Additionally, if the input PEM bundle contains no non-expired certificates, an error is returned.
 func (cp *CertPool) AddCertsFromPEM(pemData []byte) error {
+	return cp.ParsePemData(pemData, func(cert *x509.Certificate) {
+		cp.AddCert(cert)
+	})
+}
+
+func (cp *CertPool) ParsePemData(pemData []byte, processCert func(cert *x509.Certificate)) error {
 	if pemData == nil {
 		return fmt.Errorf("certificate data can't be nil")
 	}
@@ -156,7 +162,7 @@ func (cp *CertPool) AddCertsFromPEM(pemData []byte) error {
 			return fmt.Errorf("failed appending a certificate: certificate is nil")
 		}
 
-		cp.AddCert(certificate)
+		processCert(certificate)
 	}
 
 	return nil
@@ -171,6 +177,7 @@ func (cp *CertPool) AddCert(certificate *x509.Certificate) bool {
 
 	hash := sha256.Sum256(certificate.Raw)
 	cp.certificates[hash] = certificate
+
 	return true
 }
 

--- a/test/integration/bundle/env.go
+++ b/test/integration/bundle/env.go
@@ -101,6 +101,9 @@ var _ = BeforeSuite(func() {
 	tmpFileName, err = writeDefaultPackage()
 	Expect(err).NotTo(HaveOccurred())
 
+	pkg, err := fspkg.LoadPackageFromFile(tmpFileName)
+	Expect(err).NotTo(HaveOccurred())
+
 	cl, err = client.New(env.Config, client.Options{
 		Scheme: test.Scheme,
 	})
@@ -119,7 +122,7 @@ var _ = BeforeSuite(func() {
 		Namespace:              namespace.Name,
 		DefaultPackageLocation: tmpFileName,
 	}
-	Expect(bundle.SetupWithManager(ctx, mgr, opts)).NotTo(HaveOccurred())
+	Expect(bundle.SetupWithManager(ctx, mgr, opts, &pkg)).NotTo(HaveOccurred())
 
 	go func() {
 		defer GinkgoRecover()


### PR DESCRIPTION
Fixes: https://github.com/cert-manager/trust-manager/issues/588

### Changes
- New metrics: certmanager_ssl_ca_not_before and certmanager_ssl_ca_not_after expose certificate validity dates as Unix timestamps
- Source tracking: Certificates are now tracked with their source (ConfigMap, Secret, inline, or default CA package) for better observability
- Prometheus integration: Metrics are automatically scraped when the trust-manager is deployed with Prometheus