### PR TITLE
Bump trust packages to force rebuild with go 1.26.2

### DIFF
--- a/make/00_debian_bookworm_version.mk
+++ b/make/00_debian_bookworm_version.mk
@@ -17,5 +17,5 @@
 # This file is used to store the latest version of the debian trust package and the DEBIAN_BOOKWORM_BUNDLE_VERSION
 # variable is automatically updated by the `upgrade-debian-bookworm-trust-package-version` target and cron GH action.
 
-DEBIAN_BOOKWORM_BUNDLE_VERSION := 20230311+deb12u1.5
+DEBIAN_BOOKWORM_BUNDLE_VERSION := 20230311+deb12u1.6
 DEBIAN_BOOKWORM_BUNDLE_SOURCE_IMAGE=docker.io/library/debian:12-slim

--- a/make/00_debian_bullseye_version.mk
+++ b/make/00_debian_bullseye_version.mk
@@ -17,5 +17,5 @@
 # This file is used to store the latest version of the debian trust package and the DEBIAN_BULLSEYE_BUNDLE_VERSION
 # variable is automatically updated by the `upgrade-debian-bullseye-trust-package-version` target and cron GH action.
 
-DEBIAN_BULLSEYE_BUNDLE_VERSION := 20230311+deb12u1~deb11u1.1
+DEBIAN_BULLSEYE_BUNDLE_VERSION := 20230311+deb12u1~deb11u1.2
 DEBIAN_BULLSEYE_BUNDLE_SOURCE_IMAGE=docker.io/library/debian:11-slim


### PR DESCRIPTION
Similar to https://github.com/cert-manager/trust-manager/pull/907. Scanners are reporting vulnerabilities in the trust images, and we are preparing a new release of trist-manager now.