### PR TITLE
chore: typo `succesful` -> `successful` in publicbundle design doc

### DIFF
--- a/design/20220722-publicbundle.md
+++ b/design/20220722-publicbundle.md
@@ -149,7 +149,7 @@ spec:
     ```
 
 3. The trust-manager controller starts, this time with a new argument: `--default-package-location=/path/to/package-cert-manager-debian.json`
-4. During startup, the controller validates the package and if succesful loads its `bundle` into memory for later use as the "default package".
+4. During startup, the controller validates the package and if successful loads its `bundle` into memory for later use as the "default package".
 5. When a `Bundle` resource requests to `useDefaultCAs`, the `bundle` field from the default package is inserted into the target.
 
 ### User Stories


### PR DESCRIPTION
One-character typo fix inside `design/20220722-publicbundle.md:152`. No functional change.

Signed-off-by: SAY-5 <SAY-5@users.noreply.github.com>