### PR TITLE
release: publish trust-manager.crds.yaml as a GitHub Release artifact

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -36,6 +36,14 @@ jobs:
       - id: release
         run: make release
 
+      - name: Upload rendered CRD artifact for github_release job
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: trust-manager-crds
+          path: ${{ steps.release.outputs.RELEASE_CRDS_ARTIFACT }}
+          if-no-files-found: error
+          retention-days: 1
+
     outputs:
       RELEASE_OCI_MANAGER_IMAGE: ${{ steps.release.outputs.RELEASE_OCI_MANAGER_IMAGE }}
       RELEASE_OCI_MANAGER_TAG: ${{ steps.release.outputs.RELEASE_OCI_MANAGER_TAG }}
@@ -63,6 +71,12 @@ jobs:
           echo "HELM_CHART_IMAGE: ${{ needs.build_and_push.outputs.RELEASE_HELM_CHART_IMAGE }}" >> .notes-file
           echo "HELM_CHART_VERSION: ${{ needs.build_and_push.outputs.RELEASE_HELM_CHART_VERSION }}" >> .notes-file
 
+      - name: Download rendered CRD artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: trust-manager-crds
+          path: release-assets
+
       - env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -71,4 +85,5 @@ jobs:
             --title="${VERSION}" \
             --draft \
             --verify-tag \
-            --notes-file .notes-file
+            --notes-file .notes-file \
+            release-assets/trust-manager.crds.yaml

--- a/make/02_mod.mk
+++ b/make/02_mod.mk
@@ -35,6 +35,7 @@ smoke:
 include make/validate-trust-package.mk
 include make/debian-bullseye-trust-package.mk
 include make/debian-bookworm-trust-package.mk
+include make/release-crds.mk
 
 .PHONY: prerelease-scan
 ## Perform security scans on the codebase with govulncheck and on released trust packages
@@ -43,13 +44,14 @@ include make/debian-bookworm-trust-package.mk
 prerelease-scan: verify-govulncheck scan-debian-bookworm-trust-package scan-debian-bullseye-trust-package | $(NEEDS_TRIVY) $(NEEDS_CRANE)
 
 .PHONY: release
-## Publish all release artifacts (image + helm chart)
+## Publish all release artifacts (image + helm chart + standalone CRD manifest)
 ## @category [shared] Release
 release:
 	$(MAKE) oci-push-manager
 	$(MAKE) helm-chart-oci-push
 	$(MAKE) oci-maybe-push-package_debian_bullseye
 	$(MAKE) oci-maybe-push-package_debian_bookworm
+	$(MAKE) render-crds
 
 	@echo "RELEASE_OCI_MANAGER_IMAGE=$(oci_manager_image_name)" >> "$(GITHUB_OUTPUT)"
 	@echo "RELEASE_OCI_MANAGER_TAG=$(oci_manager_image_tag)" >> "$(GITHUB_OUTPUT)"
@@ -59,6 +61,7 @@ release:
 	@echo "RELEASE_OCI_PACKAGE_DEBIAN_BOOKWORM_TAG=$(oci_package_debian_bookworm_image_tag)" >> "$(GITHUB_OUTPUT)"
 	@echo "RELEASE_HELM_CHART_IMAGE=$(helm_chart_image_name)" >> "$(GITHUB_OUTPUT)"
 	@echo "RELEASE_HELM_CHART_VERSION=$(helm_chart_version)" >> "$(GITHUB_OUTPUT)"
+	@echo "RELEASE_CRDS_ARTIFACT=$(crds_release_artifact)" >> "$(GITHUB_OUTPUT)"
 
 	@echo "Release complete!"
 

--- a/make/release-crds.mk
+++ b/make/release-crds.mk
@@ -1,0 +1,41 @@
+# Copyright 2026 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Renders the trust-manager CRD as a single, ready-to-apply YAML file for
+# attachment to GitHub Releases — same convenience as cert-manager's
+# `cert-manager.crds.yaml`. See https://github.com/cert-manager/trust-manager/issues/142.
+#
+# Usage:
+#   make render-crds
+#   # produces $(crds_release_artifact)
+
+crds_release_artifact := $(bin_dir)/scratch/trust-manager.crds.yaml
+
+# Template against the packaged chart archive (not the source dir) so the
+# rendered CRD picks up the chart's app-version from `helm package --app-version`
+# rather than the unversioned `Chart.yaml` on disk. Without this the
+# `app.kubernetes.io/version` label in the published CRD would be `v0.0.0`.
+$(crds_release_artifact): $(helm_chart_archive) | $(NEEDS_HELM) $(NEEDS_YQ) $(bin_dir)/scratch
+	$(HELM) template trust-manager $(helm_chart_archive) \
+		--set crds.enabled=true \
+		--set crds.keep=false \
+		--show-only templates/crd-trust.cert-manager.io_bundles.yaml \
+		--no-hooks \
+		| $(YQ) 'del(.metadata.labels."app.kubernetes.io/managed-by", .metadata.labels."helm.sh/chart")' \
+		> $@
+
+.PHONY: render-crds
+## Render the bundle CRD as a stand-alone YAML file suitable for kubectl apply.
+## @category Release
+render-crds: $(crds_release_artifact)


### PR DESCRIPTION
## Summary

Fixes #142. Adds a new \`render-crds\` make target that produces a stand-alone \`trust-manager.crds.yaml\` and attaches it to each draft GitHub Release — same convenience cert-manager itself ships as \`cert-manager.crds.yaml\`.

## What changed

### \`make/release-crds.mk\` (new)

\`\`\`make
$(crds_release_artifact): $(helm_chart_archive) | $(NEEDS_HELM) $(NEEDS_YQ) $(bin_dir)/scratch
	$(HELM) template trust-manager $(helm_chart_archive) \\
		--set crds.enabled=true \\
		--set crds.keep=false \\
		--show-only templates/crd-trust.cert-manager.io_bundles.yaml \\
		--no-hooks \\
		| $(YQ) 'del(.metadata.labels.\"app.kubernetes.io/managed-by\", .metadata.labels.\"helm.sh/chart\")' \\
		> $@
\`\`\`

Rendering against \`\$(helm_chart_archive)\` (the packaged tarball) rather than \`\$(helm_chart_source_dir)\` is deliberate — \`helm package --app-version\` rewrites the chart's version, so the rendered CRD picks up the actual release tag in its \`app.kubernetes.io/version\` label. Templating against the source dir directly would ship a CRD labelled \`v0.0.0\`.

The yq filter strips the Helm-runtime-only labels (\`app.kubernetes.io/managed-by\`, \`helm.sh/chart\`) and \`crds.keep=false\` removes the \`helm.sh/resource-policy: keep\` annotation, so the artifact is suitable for plain \`kubectl apply\`.

### \`make/02_mod.mk\`

Includes the new file and runs \`render-crds\` as the last step of \`make release\`. Echoes \`RELEASE_CRDS_ARTIFACT=\$(crds_release_artifact)\` to \`\$GITHUB_OUTPUT\` so the workflow can find it.

### \`.github/workflows/release.yaml\`

The \`build_and_push\` job uploads \`\_bin/scratch/trust-manager.crds.yaml\` as a workflow artifact (pinned \`actions/upload-artifact@v7.0.1\` SHA, matching the repo's existing SHA-pinning convention). The \`github_release\` job downloads it and passes it as a positional file argument to \`gh release create\` so it's attached to the draft release.

## Test plan

- [x] \`helm template … | yq …\` renders cleanly against the current chart locally — output is well-formed CRD YAML, no Helm-runtime labels left.
- [ ] Full release pipeline (only verifiable on a tag push). Worth flagging: \`render-crds\` is fatal in \`make release\` — if the template or yq filter fails, the release blocks. That's intentional (you'd want to know your release artifact pipeline broke), but happy to make it best-effort if you'd prefer.

## Notes

- The downstream URL pattern after merge will be \`https://github.com/cert-manager/trust-manager/releases/download/<tag>/trust-manager.crds.yaml\` — matching cert-manager's pattern, addressing the workaround commenters were asking for in #142.
- I picked v7.0.1 / v8.0.1 for upload/download artifact since they're the current latest. Happy to drop to older majors if you have a preference.

Fixes #142