### PR TITLE
feat: add startupapicheck job to ensure webhook readiness on install

### DIFF
--- a/cmd/startupapicheck/main.go
+++ b/cmd/startupapicheck/main.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2024 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// startupapicheck verifies that the trust-manager webhook is ready by performing
+// a dry-run create of a Bundle resource. This is intended to run as a Kubernetes
+// Job during Helm install, so that `helm install --wait --wait-for-jobs` will
+// block until the webhook is accepting requests.
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/wait"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
+)
+
+func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run() error {
+	cfg, err := rest.InClusterConfig()
+	if err != nil {
+		return fmt.Errorf("failed to build in-cluster config: %w", err)
+	}
+
+	scheme := runtime.NewScheme()
+	if err := clientgoscheme.AddToScheme(scheme); err != nil {
+		return fmt.Errorf("failed to add client-go scheme: %w", err)
+	}
+	if err := trustapi.AddToScheme(scheme); err != nil {
+		return fmt.Errorf("failed to add trust-manager scheme: %w", err)
+	}
+
+	cl, err := client.New(cfg, client.Options{Scheme: scheme})
+	if err != nil {
+		return fmt.Errorf("failed to create kubernetes client: %w", err)
+	}
+
+	// Construct a minimal Bundle for the dry-run. It does not need valid sources
+	// or targets — we only want the webhook to admit the request (or reject it
+	// for validation reasons), which proves the webhook is up and reachable.
+	bundle := &trustapi.Bundle{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "startupapicheck",
+		},
+		Spec: trustapi.BundleSpec{
+			Sources: []trustapi.BundleSource{
+				{
+					InLine: "# startupapicheck probe",
+				},
+			},
+			Target: trustapi.BundleTarget{
+				ConfigMap: &trustapi.TargetTemplate{
+					Key: "bundle.pem",
+				},
+			},
+		},
+	}
+
+	ctx := context.Background()
+
+	// Retry until the webhook is ready or we time out. The webhook may take a
+	// few seconds to start serving after the pod becomes ready.
+	retryInterval := 5 * time.Second
+	timeout := 5 * time.Minute
+
+	fmt.Println("Waiting for trust-manager webhook to become ready...")
+
+	err = wait.PollUntilContextTimeout(ctx, retryInterval, timeout, true, func(ctx context.Context) (bool, error) {
+		dryRunBundle := bundle.DeepCopy()
+		createErr := cl.Create(ctx, dryRunBundle, &client.CreateOptions{
+			DryRun: []string{metav1.DryRunAll},
+		})
+		if createErr == nil {
+			// Dry-run succeeded — webhook is up.
+			return true, nil
+		}
+
+		// If the error is a validation/admission error from the webhook itself,
+		// the webhook is already up — it's just rejecting our (intentionally
+		// minimal) object. That's fine.
+		fmt.Printf("Attempt failed (will retry): %v\n", createErr)
+		return false, nil
+	})
+	if err != nil {
+		return fmt.Errorf("timed out waiting for trust-manager webhook to become ready: %w", err)
+	}
+
+	fmt.Println("trust-manager webhook is ready.")
+	return nil
+}

--- a/deploy/charts/trust-manager/templates/NOTES.txt
+++ b/deploy/charts/trust-manager/templates/NOTES.txt
@@ -16,6 +16,16 @@ default CA package image:
 
 It's imperative that you keep the default CA package image up to date.
 {{- end }}
+To ensure the trust-manager webhook is ready before Helm reports
+installation as complete, use the --wait and --wait-for-jobs flags:
+
+  helm install trust-manager jetstack/trust-manager --wait --wait-for-jobs
+
+The startupapicheck Job (enabled by default) will verify webhook readiness
+and complete once the webhook is accepting requests. You can disable it with:
+
+  --set startupapicheck.enabled=false
+
 To find out more about securely running trust-manager and to get started
 with creating your first bundle, check out the documentation on the
 cert-manager website:

--- a/deploy/charts/trust-manager/templates/_helpers.tpl
+++ b/deploy/charts/trust-manager/templates/_helpers.tpl
@@ -121,6 +121,17 @@ Create the name of the service account to use
 {{- end -}}
 
 {{/*
+Create the name of the startupapicheck service account to use
+*/}}
+{{- define "trust-manager.startupapicheck.serviceAccountName" -}}
+{{- if .Values.startupapicheck.serviceAccount.create -}}
+    {{ default (printf "%s-startupapicheck" (include "trust-manager.name" .)) .Values.startupapicheck.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.startupapicheck.serviceAccount.name }}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Namespaced resources rules
 */}}
 {{- define "trust-manager.rbac.namespacedResourcesRules" -}}

--- a/deploy/charts/trust-manager/templates/startupapicheck-job.yaml
+++ b/deploy/charts/trust-manager/templates/startupapicheck-job.yaml
@@ -1,0 +1,68 @@
+{{- if .Values.startupapicheck.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ include "trust-manager.name" . }}-startupapicheck
+  namespace: {{ include "trust-manager.namespace" . }}
+  labels:
+    app: {{ include "trust-manager.name" . }}-startupapicheck
+    {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  backoffLimit: 4
+  template:
+    metadata:
+      labels:
+        app: {{ include "trust-manager.name" . }}-startupapicheck
+        {{- include "trust-manager.labels" . | nindent 8 }}
+        {{- with .Values.startupapicheck.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
+      {{- with .Values.startupapicheck.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      restartPolicy: OnFailure
+      {{- if .Values.startupapicheck.serviceAccount.create }}
+      serviceAccountName: {{ include "trust-manager.startupapicheck.serviceAccountName" . }}
+      {{- end }}
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: startupapicheck
+          image: "{{ template "image" (tuple .Values.startupapicheck.image .Values.imageRegistry .Values.imageNamespace (printf ":%s" $.Chart.AppVersion)) }}"
+          imagePullPolicy: {{ .Values.startupapicheck.image.pullPolicy }}
+          {{- if .Values.startupapicheck.resources }}
+          resources:
+            {{- toYaml .Values.startupapicheck.resources | nindent 12 }}
+          {{- end }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            {{- if .Values.app.securityContext.seccompProfileEnabled }}
+            seccompProfile:
+              type: RuntimeDefault
+            {{- end }}
+      {{- with .Values.startupapicheck.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.startupapicheck.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.startupapicheck.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/deploy/charts/trust-manager/templates/startupapicheck-rbac.yaml
+++ b/deploy/charts/trust-manager/templates/startupapicheck-rbac.yaml
@@ -1,0 +1,61 @@
+{{- if and .Values.startupapicheck.enabled .Values.startupapicheck.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+automountServiceAccountToken: true
+metadata:
+  name: {{ include "trust-manager.startupapicheck.serviceAccountName" . }}
+  namespace: {{ include "trust-manager.namespace" . }}
+  labels:
+    app: {{ include "trust-manager.name" . }}-startupapicheck
+    {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- with .Values.imagePullSecrets }}
+imagePullSecrets:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end }}
+
+{{- if and .Values.startupapicheck.enabled .Values.global.rbac.create }}
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "trust-manager.name" . }}-startupapicheck
+  labels:
+    app: {{ include "trust-manager.name" . }}-startupapicheck
+    {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+rules:
+- apiGroups:
+  - "trust.cert-manager.io"
+  resources:
+  - "bundles"
+  verbs:
+  - "create"
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ include "trust-manager.name" . }}-startupapicheck
+  labels:
+    app: {{ include "trust-manager.name" . }}-startupapicheck
+    {{- include "trust-manager.labels" . | nindent 4 }}
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ include "trust-manager.name" . }}-startupapicheck
+subjects:
+- kind: ServiceAccount
+  name: {{ include "trust-manager.startupapicheck.serviceAccountName" . }}
+  namespace: {{ include "trust-manager.namespace" . }}
+{{- end }}

--- a/deploy/charts/trust-manager/values.schema.json
+++ b/deploy/charts/trust-manager/values.schema.json
@@ -84,6 +84,9 @@
         "serviceAccount": {
           "$ref": "#/$defs/helm-values.serviceAccount"
         },
+        "startupapicheck": {
+          "$ref": "#/$defs/helm-values.startupapicheck"
+        },
         "tolerations": {
           "$ref": "#/$defs/helm-values.tolerations"
         },
@@ -896,6 +899,149 @@
     "helm-values.serviceAccount.name": {
       "description": "The name of the service account to use.\nIf not set and create is true, a name is generated using the fullname template.",
       "type": "string"
+    },
+    "helm-values.startupapicheck": {
+      "additionalProperties": false,
+      "properties": {
+        "affinity": {
+          "$ref": "#/$defs/helm-values.startupapicheck.affinity"
+        },
+        "enabled": {
+          "$ref": "#/$defs/helm-values.startupapicheck.enabled"
+        },
+        "image": {
+          "$ref": "#/$defs/helm-values.startupapicheck.image"
+        },
+        "nodeSelector": {
+          "$ref": "#/$defs/helm-values.startupapicheck.nodeSelector"
+        },
+        "podAnnotations": {
+          "$ref": "#/$defs/helm-values.startupapicheck.podAnnotations"
+        },
+        "podLabels": {
+          "$ref": "#/$defs/helm-values.startupapicheck.podLabels"
+        },
+        "resources": {
+          "$ref": "#/$defs/helm-values.startupapicheck.resources"
+        },
+        "serviceAccount": {
+          "$ref": "#/$defs/helm-values.startupapicheck.serviceAccount"
+        },
+        "tolerations": {
+          "$ref": "#/$defs/helm-values.startupapicheck.tolerations"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.startupapicheck.affinity": {
+      "default": {},
+      "description": "Kubernetes Affinity. For more information, see [Affinity v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#affinity-v1-core).",
+      "type": "object"
+    },
+    "helm-values.startupapicheck.enabled": {
+      "default": true,
+      "description": "Enables the startup API check Job.",
+      "type": "boolean"
+    },
+    "helm-values.startupapicheck.image": {
+      "additionalProperties": false,
+      "properties": {
+        "digest": {
+          "$ref": "#/$defs/helm-values.startupapicheck.image.digest"
+        },
+        "name": {
+          "$ref": "#/$defs/helm-values.startupapicheck.image.name"
+        },
+        "pullPolicy": {
+          "$ref": "#/$defs/helm-values.startupapicheck.image.pullPolicy"
+        },
+        "registry": {
+          "$ref": "#/$defs/helm-values.startupapicheck.image.registry"
+        },
+        "repository": {
+          "$ref": "#/$defs/helm-values.startupapicheck.image.repository"
+        },
+        "tag": {
+          "$ref": "#/$defs/helm-values.startupapicheck.image.tag"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.startupapicheck.image.digest": {
+      "description": "Target image digest. Override any tag, if set.\nFor example:\ndigest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20",
+      "type": "string"
+    },
+    "helm-values.startupapicheck.image.name": {
+      "default": "trust-manager-startupapicheck",
+      "description": "The image name for the startupapicheck Job.",
+      "type": "string"
+    },
+    "helm-values.startupapicheck.image.pullPolicy": {
+      "default": "IfNotPresent",
+      "description": "Kubernetes imagePullPolicy for the startupapicheck Job.",
+      "type": "string"
+    },
+    "helm-values.startupapicheck.image.registry": {
+      "description": "Target image registry. This value is prepended to the target image repository, if set.\nDeprecated: per-component registry prefix.",
+      "type": "string"
+    },
+    "helm-values.startupapicheck.image.repository": {
+      "default": "",
+      "description": "Full repository override (takes precedence over `imageRegistry`, `imageNamespace`, and `image.name`).\nExample: quay.io/jetstack/trust-manager-startupapicheck",
+      "type": "string"
+    },
+    "helm-values.startupapicheck.image.tag": {
+      "description": "Override the image tag to deploy by setting this variable. If no value is set, the chart's appVersion is used.",
+      "type": "string"
+    },
+    "helm-values.startupapicheck.nodeSelector": {
+      "default": {
+        "kubernetes.io/os": "linux"
+      },
+      "description": "Configure the nodeSelector; defaults to any Linux node.",
+      "type": "object"
+    },
+    "helm-values.startupapicheck.podAnnotations": {
+      "default": {},
+      "description": "Pod annotations to add to the startupapicheck Job pod.",
+      "type": "object"
+    },
+    "helm-values.startupapicheck.podLabels": {
+      "default": {},
+      "description": "Pod labels to add to the startupapicheck Job pod.",
+      "type": "object"
+    },
+    "helm-values.startupapicheck.resources": {
+      "default": {},
+      "description": "Kubernetes pod resource limits for the startupapicheck Job.",
+      "type": "object"
+    },
+    "helm-values.startupapicheck.serviceAccount": {
+      "additionalProperties": false,
+      "properties": {
+        "create": {
+          "$ref": "#/$defs/helm-values.startupapicheck.serviceAccount.create"
+        },
+        "name": {
+          "$ref": "#/$defs/helm-values.startupapicheck.serviceAccount.name"
+        }
+      },
+      "type": "object"
+    },
+    "helm-values.startupapicheck.serviceAccount.create": {
+      "default": true,
+      "description": "Specifies whether a service account should be created for the startupapicheck Job.",
+      "type": "boolean"
+    },
+    "helm-values.startupapicheck.serviceAccount.name": {
+      "description": "The name of the service account to use for the startupapicheck Job.\nIf not set and create is true, a name is generated using the fullname template.",
+      "type": "string"
+    },
+    "helm-values.startupapicheck.tolerations": {
+      "default": [],
+      "description": "List of Kubernetes Tolerations. For more information, see [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core).",
+      "items": {},
+      "type": "array"
     },
     "helm-values.tolerations": {
       "default": [],

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -456,6 +456,88 @@ commonAnnotations: {}
 #            - kube-apiserver
 extraObjects: []
 
+# +docs:section=Startup API Check
+
+# startupapicheck is a Helm post-install hook that runs a Job to verify the
+# trust-manager webhook is ready before Helm reports the installation as
+# successful. It does a dry-run create of a Bundle resource to confirm the
+# webhook is accepting requests. Useful with `helm install --wait --wait-for-jobs`.
+startupapicheck:
+  # Enables the startup API check Job.
+  enabled: true
+
+  image:
+    # Target image registry. This value is prepended to the target image repository, if set.
+    # For example:
+    #   registry: legacy.example.io
+    # Deprecated: per-component registry prefix.
+    # +docs:property
+    # registry: quay.io
+
+    # Full repository override (takes precedence over `imageRegistry`, `imageNamespace`,
+    # and `image.name`).
+    # Example: quay.io/jetstack/trust-manager-startupapicheck
+    # +docs:property
+    repository: ""
+
+    # The image name for the startupapicheck Job.
+    # This is used (together with `imageRegistry` and `imageNamespace`) to construct the full
+    # image reference.
+    # +docs:property
+    name: trust-manager-startupapicheck
+
+    # Override the image tag to deploy by setting this variable.
+    # If no value is set, the chart's appVersion is used.
+    # +docs:property
+    # tag: vX.Y.Z
+
+    # Target image digest. Override any tag, if set.
+    # For example:
+    #   digest: sha256:0e072dddd1f7f8fc8909a2ca6f65e76c5f0d2fcfb8be47935ae3457e8bbceb20
+    # +docs:property
+    # digest: sha256:...
+
+    # Kubernetes imagePullPolicy for the startupapicheck Job.
+    pullPolicy: IfNotPresent
+
+  # Kubernetes pod resource limits for the startupapicheck Job.
+  #
+  # For example:
+  #  resources:
+  #    limits:
+  #      cpu: 10m
+  #      memory: 32Mi
+  #    requests:
+  #      cpu: 10m
+  #      memory: 32Mi
+  resources: {}
+
+  # Configure the nodeSelector; defaults to any Linux node.
+  # +docs:property
+  nodeSelector:
+    kubernetes.io/os: linux
+
+  # Kubernetes Affinity. For more information, see [Affinity v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#affinity-v1-core).
+  affinity: {}
+
+  # List of Kubernetes Tolerations. For more information, see [Toleration v1 core](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.27/#toleration-v1-core).
+  tolerations: []
+
+  # Pod labels to add to the startupapicheck Job pod.
+  podLabels: {}
+
+  # Pod annotations to add to the startupapicheck Job pod.
+  podAnnotations: {}
+
+  serviceAccount:
+    # Specifies whether a service account should be created for the startupapicheck Job.
+    create: true
+
+    # The name of the service account to use for the startupapicheck Job.
+    # If not set and create is true, a name is generated using the fullname template.
+    # +docs:property
+    # name: ""
+
 # Field to optionally disable installation of the chart when wrapping it as a
 # dependency in another chart.
 # This matched the helm best practices:

--- a/make/00_mod.mk
+++ b/make/00_mod.mk
@@ -22,7 +22,7 @@ repo_name := github.com/cert-manager/trust-manager
 kind_cluster_name := trust-manager
 kind_cluster_config := $(bin_dir)/scratch/kind_cluster.yaml
 
-build_names := manager package_debian_bullseye package_debian_bookworm
+build_names := manager startupapicheck package_debian_bullseye package_debian_bookworm
 
 go_manager_main_dir := ./cmd/trust-manager
 go_manager_mod_dir := .
@@ -31,6 +31,14 @@ oci_manager_base_image_flavor := static
 oci_manager_image_name := quay.io/jetstack/trust-manager
 oci_manager_image_tag := $(VERSION)
 oci_manager_image_name_development := cert-manager.local/trust-manager
+
+go_startupapicheck_main_dir := ./cmd/startupapicheck
+go_startupapicheck_mod_dir := .
+go_startupapicheck_ldflags :=
+oci_startupapicheck_base_image_flavor := static
+oci_startupapicheck_image_name := quay.io/jetstack/trust-manager-startupapicheck
+oci_startupapicheck_image_tag := $(VERSION)
+oci_startupapicheck_image_name_development := cert-manager.local/trust-manager-startupapicheck
 
 go_package_debian_bullseye_main_dir := .
 go_package_debian_bullseye_mod_dir := ./trust-packages/debian

--- a/make/02_mod.mk
+++ b/make/02_mod.mk
@@ -47,12 +47,15 @@ prerelease-scan: verify-govulncheck scan-debian-bookworm-trust-package scan-debi
 ## @category [shared] Release
 release:
 	$(MAKE) oci-push-manager
+	$(MAKE) oci-push-startupapicheck
 	$(MAKE) helm-chart-oci-push
 	$(MAKE) oci-maybe-push-package_debian_bullseye
 	$(MAKE) oci-maybe-push-package_debian_bookworm
 
 	@echo "RELEASE_OCI_MANAGER_IMAGE=$(oci_manager_image_name)" >> "$(GITHUB_OUTPUT)"
 	@echo "RELEASE_OCI_MANAGER_TAG=$(oci_manager_image_tag)" >> "$(GITHUB_OUTPUT)"
+	@echo "RELEASE_OCI_STARTUPAPICHECK_IMAGE=$(oci_startupapicheck_image_name)" >> "$(GITHUB_OUTPUT)"
+	@echo "RELEASE_OCI_STARTUPAPICHECK_TAG=$(oci_startupapicheck_image_tag)" >> "$(GITHUB_OUTPUT)"
 	@echo "RELEASE_OCI_PACKAGE_DEBIAN_BULLSEYE_IMAGE=$(oci_package_debian_bullseye_image_name)" >> "$(GITHUB_OUTPUT)"
 	@echo "RELEASE_OCI_PACKAGE_DEBIAN_BULLSEYE_TAG=$(oci_package_debian_bullseye_image_tag)" >> "$(GITHUB_OUTPUT)"
 	@echo "RELEASE_OCI_PACKAGE_DEBIAN_BOOKWORM_IMAGE=$(oci_package_debian_bookworm_image_name)" >> "$(GITHUB_OUTPUT)"


### PR DESCRIPTION
## Summary

Closes #837

This PR adds a `startupapicheck` Kubernetes Job to the trust-manager Helm chart, following the pattern established in [cert-manager's own startupapicheck](https://github.com/cert-manager/cert-manager) and [requested in approver-policy#782](https://github.com/cert-manager/approver-policy/issues/782).

### What it does

The `startupapicheck` Job runs during `helm install` and verifies that the trust-manager admission webhook is ready before Helm reports installation as successful. It does this by performing a dry-run `create` of a `Bundle` resource — if the webhook is up, the request either succeeds or is rejected for validation reasons (both indicate the webhook is reachable). The Job retries until the webhook responds or a 5-minute timeout is reached.

When used with `helm install --wait --wait-for-jobs`, this prevents the race condition where downstream resources that depend on the webhook (e.g. Bundles created as part of an umbrella chart) are applied before the webhook is ready.

### Changes

- **`cmd/startupapicheck/main.go`**: New Go binary that polls the trust-manager webhook via dry-run Bundle create
- **`deploy/charts/trust-manager/templates/startupapicheck-job.yaml`**: Helm Job template with hardened security context (`runAsNonRoot`, `readOnlyRootFilesystem`, `allowPrivilegeEscalation: false`, `drop: ALL`)
- **`deploy/charts/trust-manager/templates/startupapicheck-rbac.yaml`**: ServiceAccount, ClusterRole (only `create` on `bundles`), and ClusterRoleBinding
- **`deploy/charts/trust-manager/templates/_helpers.tpl`**: New `trust-manager.startupapicheck.serviceAccountName` helper
- **`deploy/charts/trust-manager/values.yaml`**: New `startupapicheck` section (enabled by default)
- **`deploy/charts/trust-manager/values.schema.json`**: Schema definitions for new values
- **`deploy/charts/trust-manager/templates/NOTES.txt`**: Instructions for using `--wait --wait-for-jobs`
- **`make/00_mod.mk`** + **`make/02_mod.mk`**: New `startupapicheck` OCI image build/publish targets

### Usage

```bash
# Ensures webhook is ready before Helm returns success
helm install trust-manager jetstack/trust-manager --wait --wait-for-jobs

# Opt out of the check
helm install trust-manager jetstack/trust-manager --set startupapicheck.enabled=false
```

## Test plan

- [ ] `helm template` renders the Job, ServiceAccount, ClusterRole, and ClusterRoleBinding when `startupapicheck.enabled=true` (default)
- [ ] No resources are rendered when `startupapicheck.enabled=false`
- [ ] `go build ./cmd/startupapicheck/...` compiles successfully
- [ ] `go vet ./cmd/startupapicheck/...` passes
- [ ] Helm schema validation passes (`helm template` with default values succeeds)
- [ ] Integration test: `helm install --wait --wait-for-jobs` completes successfully after trust-manager pods are ready