### PR TITLE
Add duration for the webhook tls certificate

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -593,6 +593,12 @@ The name of cert-manager's Service Account. Only used if `app.webhook.tls.approv
 > ```yaml
 > {}
 > ```
+
+Certificate duration, if unset the default from cert-manager will be used
+
+```yaml
+duration: 2160h
+```
 #### **app.webhook.hostNetwork** ~ `bool`
 > Default value:
 > ```yaml

--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -588,17 +588,18 @@ The namespace in which cert-manager was installed. Only used if `app.webhook.tls
 > ```
 
 The name of cert-manager's Service Account. Only used if `app.webhook.tls.approverPolicy.enabled` is true.
+#### **app.webhook.tls.certificate.duration** ~ `string`
+> Default value:
+> ```yaml
+> ""
+> ```
+
+Certificate duration, if unset/empty the default from cert-manager will be used. Example configuration to set 1 year: duration: 8766h
 #### **app.webhook.tls.certificate.secretTemplate** ~ `object`
 > Default value:
 > ```yaml
 > {}
 > ```
-
-Certificate duration, if unset the default from cert-manager will be used
-
-```yaml
-duration: 2160h
-```
 #### **app.webhook.hostNetwork** ~ `bool`
 > Default value:
 > ```yaml

--- a/deploy/charts/trust-manager/templates/certificate.yaml
+++ b/deploy/charts/trust-manager/templates/certificate.yaml
@@ -39,6 +39,7 @@ spec:
   privateKey:
     rotationPolicy: Always
   revisionHistoryLimit: 1
+  duration: {{ .Values.app.webhook.tls.certificate.duration }}
   issuerRef:
     name: {{ include "trust-manager.name" . }}
     kind: Issuer

--- a/deploy/charts/trust-manager/templates/certificate.yaml
+++ b/deploy/charts/trust-manager/templates/certificate.yaml
@@ -39,7 +39,9 @@ spec:
   privateKey:
     rotationPolicy: Always
   revisionHistoryLimit: 1
+  {{- if .Values.app.webhook.tls.certificate.duration }}
   duration: {{ .Values.app.webhook.tls.certificate.duration }}
+  {{- end }}
   issuerRef:
     name: {{ include "trust-manager.name" . }}
     kind: Issuer

--- a/deploy/charts/trust-manager/values.schema.json
+++ b/deploy/charts/trust-manager/values.schema.json
@@ -509,6 +509,9 @@
       "properties": {
         "secretTemplate": {
           "$ref": "#/$defs/helm-values.app.webhook.tls.certificate.secretTemplate"
+        },
+        "duration": {
+          "$ref": "#/$defs/helm-values.app.webhook.tls.certificate.duration"
         }
       },
       "type": "object"
@@ -516,6 +519,10 @@
     "helm-values.app.webhook.tls.certificate.secretTemplate": {
       "default": {},
       "type": "object"
+    },
+    "helm-values.app.webhook.tls.certificate.duration": {
+      "default": "2160h",
+      "type": "string"
     },
     "helm-values.app.webhook.tls.helmCert": {
       "additionalProperties": false,

--- a/deploy/charts/trust-manager/values.schema.json
+++ b/deploy/charts/trust-manager/values.schema.json
@@ -507,22 +507,23 @@
     "helm-values.app.webhook.tls.certificate": {
       "additionalProperties": false,
       "properties": {
-        "secretTemplate": {
-          "$ref": "#/$defs/helm-values.app.webhook.tls.certificate.secretTemplate"
-        },
         "duration": {
           "$ref": "#/$defs/helm-values.app.webhook.tls.certificate.duration"
+        },
+        "secretTemplate": {
+          "$ref": "#/$defs/helm-values.app.webhook.tls.certificate.secretTemplate"
         }
       },
       "type": "object"
     },
+    "helm-values.app.webhook.tls.certificate.duration": {
+      "default": "",
+      "description": "Certificate duration, if unset/empty the default from cert-manager will be used. Example configuration to set 1 year: duration: 8766h",
+      "type": "string"
+    },
     "helm-values.app.webhook.tls.certificate.secretTemplate": {
       "default": {},
       "type": "object"
-    },
-    "helm-values.app.webhook.tls.certificate.duration": {
-      "default": "2160h",
-      "type": "string"
     },
     "helm-values.app.webhook.tls.helmCert": {
       "additionalProperties": false,

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -354,8 +354,9 @@ app:
         # The name of cert-manager's Service Account. Only used if `app.webhook.tls.approverPolicy.enabled` is true.
         certManagerServiceAccount: "cert-manager"
 
-      # Add labels/annotations to secrets created by Certificate resources when using cert-manager provisioned TLS certificate.
+      # Configure certificate duration and add labels/annotations to secrets created by Certificate resources when using cert-manager provisioned TLS certificate.
       certificate:
+        duration: 2160h
         secretTemplate: {}
           # For example:
           #   annotations:

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -356,7 +356,8 @@ app:
 
       # Configure certificate duration and add labels/annotations to secrets created by Certificate resources when using cert-manager provisioned TLS certificate.
       certificate:
-        duration: 2160h
+        # Certificate duration, if unset the default from cert-manager will be used
+        # duration: 2160h
         secretTemplate: {}
           # For example:
           #   annotations:

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -356,8 +356,8 @@ app:
 
       # Configure certificate duration and add labels/annotations to secrets created by Certificate resources when using cert-manager provisioned TLS certificate.
       certificate:
-        # Certificate duration, if unset the default from cert-manager will be used
-        # duration: 2160h
+        # Certificate duration, if unset/empty the default from cert-manager will be used. Example configuration to set 1 year: duration: 8766h
+        duration: ""
         secretTemplate: {}
           # For example:
           #   annotations:


### PR DESCRIPTION
Add option to set the duration of the Certificate created by cert-manager for trust-manager webhook

Closes https://github.com/cert-manager/trust-manager/issues/955