### PR TITLE
Add tests for stable resourceVersion when adding labels/annotations to target

### DIFF
--- a/test/integration/bundle/controller_test.go
+++ b/test/integration/bundle/controller_test.go
@@ -578,10 +578,39 @@ var _ = Describe("Integration", func() {
 
 	Context("Reconcile consistency", func() {
 		It("should have stable resourceVersion", func() {
-			var configMap corev1.ConfigMap
-			Expect(cl.Get(ctx, client.ObjectKey{Namespace: "kube-system", Name: testBundle.Name}, &configMap)).To(Succeed())
+			configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: testBundle.Name}}
+			Eventually(komega.Object(configMap)).Should(HaveField("Data", HaveKey("target-key")))
+
 			resourceVersion := configMap.ResourceVersion
-			Consistently(komega.Object(&configMap)).Should(HaveField("ObjectMeta.ResourceVersion", Equal(resourceVersion)))
+			Consistently(komega.Object(configMap)).Should(HaveField("ObjectMeta.ResourceVersion", Equal(resourceVersion)))
+		})
+
+		It("should have stable resourceVersion when adding labels", func() {
+			Expect(komega.Update(testBundle, func() {
+				testBundle.Spec.Target.ConfigMap.Metadata.Labels = map[string]string{
+					"testKey": "testValue",
+				}
+			})()).To(Succeed())
+
+			configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: testBundle.Name}}
+			Eventually(komega.Object(configMap)).Should(HaveField("ObjectMeta.Labels", HaveKeyWithValue("testKey", "testValue")))
+
+			resourceVersion := configMap.ResourceVersion
+			Consistently(komega.Object(configMap)).Should(HaveField("ObjectMeta.ResourceVersion", Equal(resourceVersion)))
+		})
+
+		It("should have stable resourceVersion when adding annotations", func() {
+			Expect(komega.Update(testBundle, func() {
+				testBundle.Spec.Target.ConfigMap.Metadata.Annotations = map[string]string{
+					"testKey": "testValue",
+				}
+			})()).To(Succeed())
+
+			configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: testBundle.Name}}
+			Eventually(komega.Object(configMap)).Should(HaveField("ObjectMeta.Annotations", HaveKeyWithValue("testKey", "testValue")))
+
+			resourceVersion := configMap.ResourceVersion
+			Consistently(komega.Object(configMap)).Should(HaveField("ObjectMeta.ResourceVersion", Equal(resourceVersion)))
 		})
 
 		It("should have stable resourceVersion for JKS target", func() {
@@ -611,12 +640,10 @@ var _ = Describe("Integration", func() {
 		})
 	})
 
-	It("should add target annotations when added to a bundle", func() {
+	It("should add target labels when added to a bundle", func() {
 		Expect(komega.Update(testBundle, func() {
-			testBundle.Spec.Target.ConfigMap.Metadata = trustapi.TargetMetadata{
-				Annotations: map[string]string{
-					"test1": "test1",
-				},
+			testBundle.Spec.Target.ConfigMap.Metadata.Labels = map[string]string{
+				"testKey": "testValue",
 			}
 		})()).To(Succeed())
 
@@ -632,7 +659,30 @@ var _ = Describe("Integration", func() {
 
 			var configMap corev1.ConfigMap
 			Expect(cl.Get(ctx, client.ObjectKey{Namespace: namespace.Name, Name: testBundle.Name}, &configMap)).ToNot(HaveOccurred())
-			Expect(configMap.Annotations).To(HaveKeyWithValue("test1", "test1"), "Ensuring target contains additional annotations")
+			Expect(configMap.Labels).To(HaveKeyWithValue("testKey", "testValue"), "Ensuring target contains additional labels")
+		}
+	})
+
+	It("should add target annotations when added to a bundle", func() {
+		Expect(komega.Update(testBundle, func() {
+			testBundle.Spec.Target.ConfigMap.Metadata.Annotations = map[string]string{
+				"testKey": "testValue",
+			}
+		})()).To(Succeed())
+
+		testenv.EventuallyBundleHasSyncedAllNamespaces(ctx, cl, testBundle.Name, dummy.DefaultJoinedCerts())
+
+		var namespaceList corev1.NamespaceList
+		Expect(cl.List(ctx, &namespaceList)).ToNot(HaveOccurred())
+
+		for _, namespace := range namespaceList.Items {
+			if namespace.Status.Phase == corev1.NamespaceTerminating {
+				continue
+			}
+
+			var configMap corev1.ConfigMap
+			Expect(cl.Get(ctx, client.ObjectKey{Namespace: namespace.Name, Name: testBundle.Name}, &configMap)).ToNot(HaveOccurred())
+			Expect(configMap.Annotations).To(HaveKeyWithValue("testKey", "testValue"), "Ensuring target contains additional annotations")
 		}
 	})
 })


### PR DESCRIPTION
This work was done when investigating https://github.com/cert-manager/trust-manager/issues/971. The tests show that it is not an obvious issue with our reconciler, but it might be worth keeping the tests.