### PR TITLE
fix(chart): honor serviceAccount.name override in ServiceAccount manifest

### DIFF
--- a/deploy/charts/trust-manager/templates/serviceaccount.yaml
+++ b/deploy/charts/trust-manager/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 automountServiceAccountToken: {{ .Values.serviceAccount.automountServiceAccountToken }}
 metadata:
-  name: {{ include "trust-manager.name" . }}
+  name: {{ include "trust-manager.serviceAccountName" . }}
   namespace: {{ include "trust-manager.namespace" . }}
   labels:
     {{- include "trust-manager.labels" . | nindent 4 }}

--- a/deploy/charts/trust-manager/tests/serviceaccount_test.yaml
+++ b/deploy/charts/trust-manager/tests/serviceaccount_test.yaml
@@ -1,0 +1,50 @@
+suite: ServiceAccount honors serviceAccount.name override
+templates:
+  - templates/serviceaccount.yaml
+  - templates/deployment.yaml
+release:
+  name: tm
+  namespace: trust
+tests:
+  - it: default (serviceAccount.create=true, no name) — SA name and Deployment SA reference both equal trust-manager
+    set:
+      serviceAccount:
+        create: true
+    asserts:
+      - equal:
+          path: metadata.name
+          value: trust-manager
+        template: templates/serviceaccount.yaml
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: trust-manager
+        template: templates/deployment.yaml
+
+  - it: custom name (serviceAccount.create=true, name=my-sa) — both render the custom name
+    set:
+      serviceAccount:
+        create: true
+        name: my-sa
+    asserts:
+      - equal:
+          path: metadata.name
+          value: my-sa
+        template: templates/serviceaccount.yaml
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: my-sa
+        template: templates/deployment.yaml
+
+  - it: serviceAccount.create=false suppresses SA manifest; Deployment binds to serviceAccount.name or default
+    set:
+      serviceAccount:
+        create: false
+        name: external-sa
+    asserts:
+      - hasDocuments:
+          count: 0
+        template: templates/serviceaccount.yaml
+      - equal:
+          path: spec.template.spec.serviceAccountName
+          value: external-sa
+        template: templates/deployment.yaml


### PR DESCRIPTION
## What this PR does

Fixes a chart bug where `serviceaccount.yaml` hard-codes `metadata.name` to `trust-manager.name`, while the Deployment template binds via the `trust-manager.serviceAccountName` helper. The helper honors `.Values.serviceAccount.name`, the SA template does not — so any user that sets a custom `serviceAccount.name` with `serviceAccount.create: true` ends up with a name mismatch.

### Reproduction

```yaml
# values.yaml
serviceAccount:
  create: true
  name: my-trust-sa
```

After `helm install`:

- `ServiceAccount/trust-manager` is created (from the chart-name default).
- `Deployment/trust-manager` references `serviceAccountName: my-trust-sa`.
- Pods stay `Pending` on `ServiceAccount "my-trust-sa" not found`.

### Fix

Switch `serviceaccount.yaml:6` from `{{ include "trust-manager.name" . }}` to `{{ include "trust-manager.serviceAccountName" . }}` so the SA manifest and the Deployment binding resolve through the same helper.

### Test

Adds the first helm-unittest coverage under `deploy/charts/trust-manager/tests/` (the `verify-helm-unittest` make target was already wired up in `make/_shared/helm/helm.mk`, it just had no test files yet). Three scenarios:

1. `create=true`, no name override — SA name and Deployment SA reference both default to `trust-manager`.
2. `create=true`, `name=my-sa` — both resolve to `my-sa`. Would fail without the fix.
3. `create=false`, `name=external-sa` — SA manifest suppressed, Deployment binds to `external-sa`.

Verified scenario 2 fails on unfixed `main` with `Expected: my-sa / Actual: trust-manager` and passes after the fix.

### Provenance

Surfaced in a [cozystack/cozystack#2744](https://github.com/cozystack/cozystack/pull/2744) review of a downstream vendoring of `trust-manager` v0.22.1. Downstream consumers that override `serviceAccount.name` (for example, for namespace-scoped naming policies) hit this. Installs without the override are not affected because both sides fall back to the chart-name default.
