### PR TITLE
fix(chart): render servicemonitor.labels inside metadata.labels

### DIFF
--- a/deploy/charts/trust-manager/templates/metrics-servicemonitor.yaml
+++ b/deploy/charts/trust-manager/templates/metrics-servicemonitor.yaml
@@ -8,13 +8,13 @@ metadata:
     app: {{ include "trust-manager.name" . }}
     {{- include "trust-manager.labels" . | nindent 4 }}
     prometheus: {{ .Values.app.metrics.service.servicemonitor.prometheusInstance }}
+    {{- with .Values.app.metrics.service.servicemonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.commonAnnotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
-{{- if .Values.app.metrics.service.servicemonitor.labels }}
-{{ toYaml .Values.app.metrics.service.servicemonitor.labels | indent 4}}
-{{- end }}
 spec:
   jobLabel: {{ include "trust-manager.name" . }}
   selector:

--- a/deploy/charts/trust-manager/tests/metrics_servicemonitor_test.yaml
+++ b/deploy/charts/trust-manager/tests/metrics_servicemonitor_test.yaml
@@ -1,0 +1,70 @@
+suite: ServiceMonitor renders extra labels under metadata.labels
+templates:
+  - templates/metrics-servicemonitor.yaml
+release:
+  name: tm
+  namespace: trust
+tests:
+  - it: default labels render under metadata.labels
+    set:
+      app:
+        metrics:
+          service:
+            enabled: true
+            servicemonitor:
+              enabled: true
+              prometheusInstance: default
+    asserts:
+      - equal:
+          path: metadata.labels.app
+          value: trust-manager
+      - equal:
+          path: metadata.labels.prometheus
+          value: default
+
+  - it: extra servicemonitor.labels land under metadata.labels (not metadata or annotations)
+    set:
+      app:
+        metrics:
+          service:
+            enabled: true
+            servicemonitor:
+              enabled: true
+              prometheusInstance: default
+              labels:
+                tier: production
+                team: platform
+    asserts:
+      - equal:
+          path: metadata.labels.tier
+          value: production
+      - equal:
+          path: metadata.labels.team
+          value: platform
+      - notExists:
+          path: metadata.tier
+      - notExists:
+          path: metadata.annotations
+
+  - it: extra labels coexist with commonAnnotations without leaking into annotations
+    set:
+      commonAnnotations:
+        owner: trust-team
+      app:
+        metrics:
+          service:
+            enabled: true
+            servicemonitor:
+              enabled: true
+              prometheusInstance: default
+              labels:
+                tier: production
+    asserts:
+      - equal:
+          path: metadata.labels.tier
+          value: production
+      - equal:
+          path: metadata.annotations.owner
+          value: trust-team
+      - notExists:
+          path: metadata.annotations.tier


### PR DESCRIPTION
## What this PR does

Fixes a chart bug where `app.metrics.service.servicemonitor.labels` overrides silently leak into the rendered ServiceMonitor's `metadata.annotations` instead of landing inside `metadata.labels`.

### Repro

The template in `deploy/charts/trust-manager/templates/metrics-servicemonitor.yaml` has the extra-labels block hanging outside the `metadata.labels:` parent:

```yaml
  labels:
    app: ...
    prometheus: ...
  {{- with .Values.commonAnnotations }}
  annotations:
    {{- toYaml . | nindent 4 }}
  {{- end }}
{{- if .Values.app.metrics.service.servicemonitor.labels }}
{{ toYaml .Values.app.metrics.service.servicemonitor.labels | indent 4}}
{{- end }}
```

When both `commonAnnotations` and `servicemonitor.labels` are set — the configured extra labels land inside the `annotations:` block (because `annotations:` is the closest preceding column-2 parent for the indent-4 entries). So configured labels never apply, they silently become extra annotations.

With only `servicemonitor.labels` set (no `commonAnnotations`) the indent-4 block happens to merge into `metadata.labels:` correctly, so the bug is conditional on both keys being present — easy to miss without a dedicated test.

### Fix

Move the block inside `metadata.labels:` where it belongs.

### Test

Adds helm-unittest coverage under `deploy/charts/trust-manager/tests/metrics_servicemonitor_test.yaml` with three scenarios:

1. Default values — `app` and `prometheus` labels render under `metadata.labels`.
2. `servicemonitor.labels` set on its own — custom labels render under `metadata.labels`, do not appear at the `metadata` top level.
3. `servicemonitor.labels` + `commonAnnotations` both set — custom labels stay under `metadata.labels`, commonAnnotations stay under `metadata.annotations`, no leakage in either direction.

Verified scenario 3 fails on unfixed `main` with `metadata.annotations.tier expected to NOT exists` and passes after the move.

### Provenance

Same downstream vendoring review that surfaced #980 ([cozystack/cozystack#2744](https://github.com/cozystack/cozystack/pull/2744)) also flagged this. Independent of #980 (different file, different bug), so opening as a separate PR.
