### PR TITLE
Add new trust package based on Debian Trixie

### DIFF
--- a/.github/workflows/trust-package-release-debian-trixie.yaml
+++ b/.github/workflows/trust-package-release-debian-trixie.yaml
@@ -1,0 +1,43 @@
+name: trust-package-release-debian-trixie
+on:
+  push:
+    branches: ['main']
+    paths:
+      - make/00_debian_trixie_version.mk
+
+jobs:
+  build_and_push:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read # needed for checkout
+      packages: write # needed for push images
+      id-token: write # needed for keyless signing
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        # Adding `fetch-depth: 0` makes sure tags are also fetched. We need
+        # the tags so `git describe` returns a valid version.
+        # see https://github.com/actions/checkout/issues/701 for extra info about this option
+        with: { fetch-depth: 0 }
+
+      - id: go-version
+        run: |
+          make print-go-version >> "$GITHUB_OUTPUT"
+
+      - uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          registry: quay.io
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_PASSWORD }}
+
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
+        with:
+          go-version: ${{ steps.go-version.outputs.result }}
+
+      - id: release
+        run: make release-debian-trixie-trust-package
+
+    outputs:
+      RELEASE_OCI_MANAGER_IMAGE: ${{ steps.release.outputs.RELEASE_OCI_PACKAGE_DEBIAN_TRIXIE_IMAGE }}
+      RELEASE_OCI_MANAGER_TAG: ${{ steps.release.outputs.RELEASE_OCI_PACKAGE_DEBIAN_TRIXIE_TAG }}

--- a/.github/workflows/trust-package-security-scan.yaml
+++ b/.github/workflows/trust-package-security-scan.yaml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: [bullseye, bookworm]
+        release: [bullseye, bookworm, trixie]
 
     runs-on: ubuntu-latest
 

--- a/.github/workflows/trust-package-upgrade-debian.yaml
+++ b/.github/workflows/trust-package-upgrade-debian.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        release: [bullseye, bookworm]
+        release: [bullseye, bookworm, trixie]
 
     concurrency: trust-package-upgrade-debian-${{ matrix.release }}
 

--- a/make/00_debian_trixie_version.mk
+++ b/make/00_debian_trixie_version.mk
@@ -1,0 +1,21 @@
+# Copyright 2026 The cert-manager Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# WARNING: Changing this file triggers a build and release of the Debian trust package for Trixie (Debian 13)
+#
+# This file is used to store the latest version of the debian trust package and the DEBIAN_TRIXIE_BUNDLE_VERSION
+# variable is automatically updated by the `upgrade-debian-trixie-trust-package-version` target and cron GH action.
+
+DEBIAN_TRIXIE_BUNDLE_VERSION := 20250419.1
+DEBIAN_TRIXIE_BUNDLE_SOURCE_IMAGE=docker.io/library/debian:13-slim

--- a/make/00_mod.mk
+++ b/make/00_mod.mk
@@ -16,13 +16,14 @@ oci_platforms := linux/amd64,linux/arm/v7,linux/arm64,linux/ppc64le,linux/s390x
 
 include make/00_debian_bullseye_version.mk
 include make/00_debian_bookworm_version.mk
+include make/00_debian_trixie_version.mk
 
 repo_name := github.com/cert-manager/trust-manager
 
 kind_cluster_name := trust-manager
 kind_cluster_config := $(bin_dir)/scratch/kind_cluster.yaml
 
-build_names := manager package_debian_bullseye package_debian_bookworm
+build_names := manager package_debian_bullseye package_debian_bookworm package_debian_trixie
 
 go_manager_main_dir := ./cmd/trust-manager
 go_manager_mod_dir := .
@@ -53,6 +54,17 @@ oci_package_debian_bookworm_image_tag := $(shell echo $(DEBIAN_BOOKWORM_BUNDLE_V
 oci_package_debian_bookworm_image_name_development := cert-manager.local/trust-pkg-debian-bookworm
 debian_bookworm_package_layer := $(bin_dir)/scratch/debian-bookworm-trust-package
 oci_package_debian_bookworm_additional_layers += $(debian_bookworm_package_layer)
+
+go_package_debian_trixie_main_dir := .
+go_package_debian_trixie_mod_dir := ./trust-packages/debian
+go_package_debian_trixie_ldflags :=
+oci_package_debian_trixie_base_image_flavor := static
+oci_package_debian_trixie_image_name := quay.io/jetstack/trust-pkg-debian-trixie
+# '+' and '~' characters are not valid in docker image tags. Transform them to '-' for image tags.
+oci_package_debian_trixie_image_tag := $(shell echo $(DEBIAN_TRIXIE_BUNDLE_VERSION) | tr '+~' '-')
+oci_package_debian_trixie_image_name_development := cert-manager.local/trust-pkg-debian-trixie
+debian_trixie_package_layer := $(bin_dir)/scratch/debian-trixie-trust-package
+oci_package_debian_trixie_additional_layers += $(debian_trixie_package_layer)
 
 
 deploy_name := trust-manager

--- a/make/02_mod.mk
+++ b/make/02_mod.mk
@@ -39,7 +39,7 @@ include make/debian-trust-package.mk
 ## Perform security scans on the codebase with govulncheck and on released trust packages
 ## using Trivy. This is intended as a signal for whether a release is safe to proceed.
 ## @category [shared] Release
-prerelease-scan: verify-govulncheck scan-debian-bookworm-trust-package scan-debian-bullseye-trust-package | $(NEEDS_TRIVY) $(NEEDS_CRANE)
+prerelease-scan: verify-govulncheck scan-debian-bullseye-trust-package scan-debian-bookworm-trust-package scan-debian-trixie-trust-package | $(NEEDS_TRIVY) $(NEEDS_CRANE)
 
 .PHONY: release
 ## Publish all release artifacts (image + helm chart)
@@ -49,6 +49,7 @@ release:
 	$(MAKE) helm-chart-oci-push
 	$(MAKE) oci-maybe-push-package_debian_bullseye
 	$(MAKE) oci-maybe-push-package_debian_bookworm
+	$(MAKE) oci-maybe-push-package_debian_trixie
 
 	@echo "RELEASE_OCI_MANAGER_IMAGE=$(oci_manager_image_name)" >> "$(GITHUB_OUTPUT)"
 	@echo "RELEASE_OCI_MANAGER_TAG=$(oci_manager_image_tag)" >> "$(GITHUB_OUTPUT)"
@@ -56,6 +57,8 @@ release:
 	@echo "RELEASE_OCI_PACKAGE_DEBIAN_BULLSEYE_TAG=$(oci_package_debian_bullseye_image_tag)" >> "$(GITHUB_OUTPUT)"
 	@echo "RELEASE_OCI_PACKAGE_DEBIAN_BOOKWORM_IMAGE=$(oci_package_debian_bookworm_image_name)" >> "$(GITHUB_OUTPUT)"
 	@echo "RELEASE_OCI_PACKAGE_DEBIAN_BOOKWORM_TAG=$(oci_package_debian_bookworm_image_tag)" >> "$(GITHUB_OUTPUT)"
+	@echo "RELEASE_OCI_PACKAGE_DEBIAN_TRIXIE_IMAGE=$(oci_package_debian_trixie_image_name)" >> "$(GITHUB_OUTPUT)"
+	@echo "RELEASE_OCI_PACKAGE_DEBIAN_TRIXIE_TAG=$(oci_package_debian_trixie_image_tag)" >> "$(GITHUB_OUTPUT)"
 	@echo "RELEASE_HELM_CHART_IMAGE=$(helm_chart_image_name)" >> "$(GITHUB_OUTPUT)"
 	@echo "RELEASE_HELM_CHART_VERSION=$(helm_chart_version)" >> "$(GITHUB_OUTPUT)"
 
@@ -76,6 +79,15 @@ release-debian-bookworm-trust-package: | $(NEEDS_CRANE)
 
 	@echo "RELEASE_OCI_PACKAGE_DEBIAN_BOOKWORM_IMAGE=$(oci_package_debian_bookworm_image_name)" >> "$(GITHUB_OUTPUT)"
 	@echo "RELEASE_OCI_PACKAGE_DEBIAN_BOOKWORM_TAG=$(oci_package_debian_bookworm_image_tag)" >> "$(GITHUB_OUTPUT)"
+
+	@echo "Release complete!"
+
+.PHONY: release-debian-trixie-trust-package
+release-debian-trixie-trust-package:
+	$(MAKE) oci-maybe-push-package_debian_trixie
+
+	@echo "RELEASE_OCI_PACKAGE_DEBIAN_TRIXIE_IMAGE=$(oci_package_debian_trixie_image_name)" >> "$(GITHUB_OUTPUT)"
+	@echo "RELEASE_OCI_PACKAGE_DEBIAN_TRIXIE_TAG=$(oci_package_debian_trixie_image_tag)" >> "$(GITHUB_OUTPUT)"
 
 	@echo "Release complete!"
 

--- a/make/debian-trust-package.mk
+++ b/make/debian-trust-package.mk
@@ -60,6 +60,7 @@ endef
 
 $(eval $(call debian-trust-package-targets,BULLSEYE,bullseye))
 $(eval $(call debian-trust-package-targets,BOOKWORM,bookworm))
+$(eval $(call debian-trust-package-targets,TRIXIE,trixie))
 
 ## Scan the latest Debian Bullseye trust package OCI image with Trivy
 ## @category [shared] Release
@@ -70,3 +71,8 @@ scan-debian-bullseye-trust-package: _scan-debian-bullseye-trust-package
 ## @category [shared] Release
 .PHONY: scan-debian-bookworm-trust-package
 scan-debian-bookworm-trust-package: _scan-debian-bookworm-trust-package
+
+## Scan the latest Debian Trixie trust package OCI image with Trivy
+## @category [shared] Release
+.PHONY: scan-debian-trixie-trust-package
+scan-debian-trixie-trust-package: _scan-debian-trixie-trust-package

--- a/make/test-smoke.mk
+++ b/make/test-smoke.mk
@@ -41,7 +41,7 @@ smoke-setup-cert-manager: | kind-cluster $(NEEDS_HELM) $(NEEDS_KUBECTL)
 # When a "test-smoke" target is run, the currently active cluster must be the kind
 # cluster created by the "kind-cluster" target.
 ifeq ($(findstring test-smoke,$(MAKECMDGOALS)),test-smoke)
-install: kind-cluster oci-load-manager oci-load-package_debian_bullseye oci-load-package_debian_bookworm
+install: kind-cluster oci-load-manager oci-load-package_debian_bullseye oci-load-package_debian_bookworm oci-load-package_debian_trixie
 endif
 
 test-smoke-deps: INSTALL_OPTIONS :=

--- a/trust-packages/debian/README.md
+++ b/trust-packages/debian/README.md
@@ -9,4 +9,4 @@ which are used in the cert-manager project.
 Therefore, by using Debian again here, we're not adding any new entities we need to trust, since we already trust
 Debian extensively elsewhere.
 
-This package is used for both Debian Bookworm and Debian Bullseye
+This package is used for Debian Bullseye, Debian Bookworm, and Debian Trixie.


### PR DESCRIPTION
... which was initiated by @SgtCoDFish in https://github.com/cert-manager/trust-manager/pull/689. I wanted to reduce the amount of duplicated code in this area, but I only managed to fix a minor fraction of it. But we need to publish an updated bundle soon. This PR is mainly copy-modifying code, but that's also when we're making most mistakes. 😓 

I will create a follow-up PR to test the new trust package and update the chart to use the new trust package by default.

Fixes https://github.com/cert-manager/trust-manager/issues/815, fixes https://github.com/cert-manager/trust-manager/issues/964


Closes https://github.com/cert-manager/trust-manager/pull/689