### PR TITLE
fix: disabling the default package volumes if default package is disabled

### DIFF
--- a/deploy/charts/trust-manager/templates/deployment.yaml
+++ b/deploy/charts/trust-manager/templates/deployment.yaml
@@ -122,9 +122,11 @@ spec:
         - mountPath: /tls
           name: tls
           readOnly: true
+        {{- if .Values.defaultPackage.enabled }}
         - mountPath: /packages
           name: packages
           readOnly: true
+        {{- end }}
         {{- with .Values.volumeMounts }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
@@ -161,9 +163,11 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+      {{- if .Values.defaultPackage.enabled }}
       - name: packages
         emptyDir:
           sizeLimit: 50M
+      {{- end }}
       - name: tls
         secret:
           defaultMode: 420

--- a/deploy/charts/trust-manager/tests/default_package_test.yaml
+++ b/deploy/charts/trust-manager/tests/default_package_test.yaml
@@ -1,0 +1,43 @@
+suite: Deployment defaultPackage behavior
+templates:
+  - templates/deployment.yaml
+release:
+  name: tm
+  namespace: trust
+tests:
+  - it: defaultPackage enabled renders packages mount, volume, and arg
+    set:
+      defaultPackage:
+        enabled: true
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /packages
+            name: packages
+            readOnly: true
+      - equal:
+          path: spec.template.spec.volumes[0].name
+          value: packages
+      - contains:
+          path: spec.template.spec.containers[0].args
+          content: --default-package-location=/packages/cert-manager-package-debian.json
+
+  - it: defaultPackage disabled does not render packages mount, volume, or arg
+    set:
+      defaultPackage:
+        enabled: false
+    asserts:
+      - notContains:
+          path: spec.template.spec.containers[0].volumeMounts
+          content:
+            mountPath: /packages
+            name: packages
+            readOnly: true
+      - notContains:
+          path: spec.template.spec.volumes
+          content:
+            name: packages
+      - notContains:
+          path: spec.template.spec.containers[0].args
+          content: --default-package-location=/packages/cert-manager-package-debian.json


### PR DESCRIPTION
This PR fixes disabled default package rendering in the Helm chart.

When `defaultPackage.enabled=false`, the Deployment was still rendering package-path resources in the main pod spec (`/packages` volume mount and `packages` volume), which implies default package usage even in disabled mode.

## What this changes

- Gate main container `/packages` `volumeMount` on `defaultPackage.enabled`
- Gate pod `packages` `volume` on `defaultPackage.enabled`
- Add Helm unit tests for both enabled and disabled behavior

## Behavior after this change

- `defaultPackage.enabled=true`:
  - `packages` init flow remains unchanged
  - `/packages` mount + `packages` volume are rendered
  - `--default-package-location=/packages/cert-manager-package-debian.json` is rendered
- `defaultPackage.enabled=false`:
  - `/packages` mount is not rendered
  - `packages` volume is not rendered
  - `--default-package-location` remains omitted (unchanged from current behavior)

## Validation

- `helm template trust-manager ./deploy/charts/trust-manager --set "defaultPackage.enabled=true"`
- `helm template trust-manager ./deploy/charts/trust-manager --set "defaultPackage.enabled=false"`
- `helm unittest ./deploy/charts/trust-manager`

### Before

See `Observed` in [This comment](https://github.com/cert-manager/trust-manager/issues/986#issue-4549908287)

### After

```yaml
---
# Source: trust-manager/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: trust-manager
  namespace: default
  labels:
    app.kubernetes.io/name: trust-manager
    helm.sh/chart: trust-manager-v0.0.0
    app.kubernetes.io/instance: trust-manager
    app.kubernetes.io/version: "v0.0.0"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app: trust-manager
  template:
    metadata:
      labels:
        app: trust-manager
        app.kubernetes.io/name: trust-manager
        helm.sh/chart: trust-manager-v0.0.0
        app.kubernetes.io/instance: trust-manager
        app.kubernetes.io/version: "v0.0.0"
        app.kubernetes.io/managed-by: Helm
    spec:
      serviceAccountName: trust-manager
      automountServiceAccountToken: true
      containers:
      - name: trust-manager
        image: "quay.io/jetstack/trust-manager:v0.0.0"
        imagePullPolicy: IfNotPresent
        ports:
        - containerPort: 6443
          name: webhook # for the PodMonitor port field
        - containerPort: 9402
          name: metrics # for the PodMonitor port field
        readinessProbe:
          httpGet:
            port: 6060
            path: /readyz
          initialDelaySeconds: 3
          periodSeconds: 7
        args:
          - "--log-format=text"
          - "--log-level=1"
          - "--metrics-port=9402"
          - "--readiness-probe-port=6060"
          - "--readiness-probe-path=/readyz"
          - "--leader-elect=true"
          - "--leader-election-lease-duration=15s"
          - "--leader-election-renew-deadline=10s"
            # trust
          - "--trust-namespace=cert-manager"
            # webhook
          - "--webhook-host=0.0.0.0"
          - "--webhook-port=6443"
          - "--webhook-certificate-dir=/tls"
        volumeMounts:
        - mountPath: /tls
          name: tls
          readOnly: true
        resources:
            {}
        securityContext:
          allowPrivilegeEscalation: false
          capabilities:
            drop:
            - ALL
          readOnlyRootFilesystem: true
          runAsNonRoot: true
          seccompProfile:
            type: RuntimeDefault
      nodeSelector:
        kubernetes.io/os: linux
      volumes:
      - name: tls
        secret:
          defaultMode: 420
          secretName: trust-manager-tls
```

Fixes #986
