### PR TITLE
Make new trust package based on Debian Trixie the new default

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -225,7 +225,7 @@ Example: quay.io/jetstack/trust-manager
 #### **defaultPackageImage.name** ~ `string`
 > Default value:
 > ```yaml
-> trust-pkg-debian-bookworm
+> trust-pkg-debian-trixie
 > ```
 
 The image name for trust-manager.  

--- a/deploy/charts/trust-manager/values.schema.json
+++ b/deploy/charts/trust-manager/values.schema.json
@@ -635,7 +635,7 @@
       "type": "string"
     },
     "helm-values.defaultPackageImage.name": {
-      "default": "trust-pkg-debian-bookworm",
+      "default": "trust-pkg-debian-trixie",
       "description": "The image name for trust-manager.\nThis is used (together with `imageRegistry` and `imageNamespace`) to construct the full image reference.",
       "type": "string"
     },

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -146,7 +146,7 @@ defaultPackageImage:
   # This is used (together with `imageRegistry` and `imageNamespace`) to construct the full
   # image reference.
   # +docs:property
-  name: trust-pkg-debian-bookworm
+  name: trust-pkg-debian-trixie
 
   # Override the image tag of the default package image.
   # Is set at chart build time to the version specified in ./make/00_debian_bookworm_version.mk.


### PR DESCRIPTION
Following up on https://github.com/cert-manager/trust-manager/pull/985, we should make the new trixie-based trust package image the new default.