### PR TITLE
Trigger new releases of older trust-packages

### DIFF
--- a/make/00_debian_bookworm_version.mk
+++ b/make/00_debian_bookworm_version.mk
@@ -17,5 +17,5 @@
 # This file is used to store the latest version of the debian trust package and the DEBIAN_BOOKWORM_BUNDLE_VERSION
 # variable is automatically updated by the `upgrade-debian-bookworm-trust-package-version` target and cron GH action.
 
-DEBIAN_BOOKWORM_BUNDLE_VERSION := 20230311+deb12u1.6
+DEBIAN_BOOKWORM_BUNDLE_VERSION := 20230311+deb12u1.7
 DEBIAN_BOOKWORM_BUNDLE_SOURCE_IMAGE=docker.io/library/debian:12-slim

--- a/make/00_debian_bullseye_version.mk
+++ b/make/00_debian_bullseye_version.mk
@@ -17,5 +17,5 @@
 # This file is used to store the latest version of the debian trust package and the DEBIAN_BULLSEYE_BUNDLE_VERSION
 # variable is automatically updated by the `upgrade-debian-bullseye-trust-package-version` target and cron GH action.
 
-DEBIAN_BULLSEYE_BUNDLE_VERSION := 20230311+deb12u1~deb11u1.2
+DEBIAN_BULLSEYE_BUNDLE_VERSION := 20230311+deb12u1~deb11u1.3
 DEBIAN_BULLSEYE_BUNDLE_SOURCE_IMAGE=docker.io/library/debian:11-slim


### PR DESCRIPTION
Both are reported as vulnerable due to an outdated Go version (ref.). https://github.com/cert-manager/trust-manager/actions/runs/27282425445