### PR TITLE
Fix leftovers after migrating to Debian Trixie trust package

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -233,7 +233,7 @@ This is used (together with `imageRegistry` and `imageNamespace`) to construct t
 
 #### **defaultPackageImage.tag** ~ `string`
 
-Override the image tag of the default package image. Is set at chart build time to the version specified in ./make/00_debian_bookworm_version.mk.
+Override the image tag of the default package image. Is set at chart build time to the version specified in ./make/00_debian_trixie_version.mk.
 
 #### **defaultPackageImage.digest** ~ `string`
 

--- a/deploy/charts/trust-manager/values.schema.json
+++ b/deploy/charts/trust-manager/values.schema.json
@@ -654,7 +654,7 @@
       "type": "string"
     },
     "helm-values.defaultPackageImage.tag": {
-      "description": "Override the image tag of the default package image. Is set at chart build time to the version specified in ./make/00_debian_bookworm_version.mk.",
+      "description": "Override the image tag of the default package image. Is set at chart build time to the version specified in ./make/00_debian_trixie_version.mk.",
       "type": "string"
     },
     "helm-values.enabled": {

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -149,7 +149,7 @@ defaultPackageImage:
   name: trust-pkg-debian-trixie
 
   # Override the image tag of the default package image.
-  # Is set at chart build time to the version specified in ./make/00_debian_bookworm_version.mk.
+  # Is set at chart build time to the version specified in ./make/00_debian_trixie_version.mk.
   # +docs:property
   # tag: vX.Y.Z
 

--- a/make/00_mod.mk
+++ b/make/00_mod.mk
@@ -81,6 +81,6 @@ golangci_lint_config := .golangci.yaml
 
 define helm_values_mutation_function
 $(YQ) \
-	'( .defaultPackageImage._defaultReference = ":$(oci_package_debian_bookworm_image_tag)" )' \
+	'( .defaultPackageImage._defaultReference = ":$(oci_package_debian_trixie_image_tag)" )' \
 	$1 --inplace
 endef

--- a/make/test-smoke.mk
+++ b/make/test-smoke.mk
@@ -41,12 +41,12 @@ smoke-setup-cert-manager: | kind-cluster $(NEEDS_HELM) $(NEEDS_KUBECTL)
 # When a "test-smoke" target is run, the currently active cluster must be the kind
 # cluster created by the "kind-cluster" target.
 ifeq ($(findstring test-smoke,$(MAKECMDGOALS)),test-smoke)
-install: kind-cluster oci-load-manager oci-load-package_debian_bullseye oci-load-package_debian_bookworm oci-load-package_debian_trixie
+install: kind-cluster oci-load-manager oci-load-package_debian_trixie oci-load-package_debian_bookworm oci-load-package_debian_trixie
 endif
 
 test-smoke-deps: INSTALL_OPTIONS :=
 test-smoke-deps: INSTALL_OPTIONS += --set image.repository=$(oci_manager_image_name_development)
-test-smoke-deps: INSTALL_OPTIONS += --set defaultPackageImage.repository=$(oci_package_debian_bookworm_image_name_development)
+test-smoke-deps: INSTALL_OPTIONS += --set defaultPackageImage.repository=$(oci_package_debian_trixie_image_name_development)
 test-smoke-deps: INSTALL_OPTIONS += --set secretTargets.enabled=true --set secretTargets.authorizedSecretsAll=true
 test-smoke-deps: smoke-setup-cert-manager
 test-smoke-deps: install


### PR DESCRIPTION
I am happy that I attempted an alpha release first, as the Helm chart was still using the image tag of the Debian Bookworm trust package image, creating an invalid image reference. In this PR, I am trying to update the leftovers I could find.