### PR TITLE
fix: scope metrics ServiceMonitor selector to the metrics service

### DIFF
--- a/deploy/charts/trust-manager/templates/metrics-service.yaml
+++ b/deploy/charts/trust-manager/templates/metrics-service.yaml
@@ -6,6 +6,7 @@ metadata:
   namespace: {{ include "trust-manager.namespace" . }}
   labels:
     app: {{ include "trust-manager.name" . }}
+    app.kubernetes.io/component: metrics
     {{- include "trust-manager.labels" . | nindent 4 }}
   {{- with .Values.commonAnnotations }}
   annotations:

--- a/deploy/charts/trust-manager/templates/metrics-servicemonitor.yaml
+++ b/deploy/charts/trust-manager/templates/metrics-servicemonitor.yaml
@@ -20,6 +20,7 @@ spec:
   selector:
     matchLabels:
       app: {{ include "trust-manager.name" . }}
+      app.kubernetes.io/component: metrics
   namespaceSelector:
     matchNames:
       - {{ include "trust-manager.namespace" . }}


### PR DESCRIPTION
Closes #988

The metrics `ServiceMonitor` selected on `app: trust-manager`, a label shared by both the webhook Service (`trust-manager`) and the metrics Service (`trust-manager-metrics`), so it matched **both** Services (as reported in #988).

This adds an `app.kubernetes.io/component: metrics` label to the metrics Service and includes it in the ServiceMonitor selector, so it now matches only the metrics Service.

Verified locally with `helm template` (metrics + servicemonitor enabled):
- `trust-manager-metrics` Service gets `app.kubernetes.io/component: metrics`
- the webhook `trust-manager` Service does **not** carry that label
- the ServiceMonitor selector resolves to `{app: trust-manager, app.kubernetes.io/component: metrics}`, matching only the metrics Service
