### PR TITLE
feat(helm): aggregate Bundle read access into the cluster-reader ClusterRole

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -15,6 +15,13 @@
 > ```
 
 Create required ClusterRoles, Roles, ClusterRoleBindings and RoleBindings for trust-manager.
+#### **global.rbac.aggregateClusterRoles** ~ `bool`
+> Default value:
+> ```yaml
+> true
+> ```
+
+Aggregate read access to Bundles into the "cluster-reader" ClusterRole, mirroring how cert-manager aggregates its cluster-scoped ClusterIssuers. Bundle is a cluster-scoped resource, so this only takes effect for subjects bound via a ClusterRoleBinding. For more information, see [User-facing roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles).
 ### CRDs
 
 #### **crds.enabled** ~ `bool`

--- a/deploy/charts/trust-manager/templates/clusterrole-aggregate.yaml
+++ b/deploy/charts/trust-manager/templates/clusterrole-aggregate.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.global.rbac.create }}
+{{- if .Values.global.rbac.aggregateClusterRoles }}
+# Bundle is a cluster-scoped resource, so its read access is aggregated into
+# the "cluster-reader" ClusterRole (mirroring how cert-manager aggregates its
+# cluster-scoped ClusterIssuers), rather than into the namespaced
+# view/edit/admin roles.
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  labels:
+    {{- include "trust-manager.labels" . | nindent 4 }}
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+  {{- with .Values.commonAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  name: {{ include "trust-manager.name" . }}-cluster-view
+rules:
+- apiGroups:
+  - "trust.cert-manager.io"
+  resources:
+  - "bundles"
+  verbs: ["get", "list", "watch"]
+{{- end }}
+{{- end }}

--- a/deploy/charts/trust-manager/tests/clusterrole_aggregate_test.yaml
+++ b/deploy/charts/trust-manager/tests/clusterrole_aggregate_test.yaml
@@ -1,0 +1,53 @@
+suite: Aggregated user-facing ClusterRole for Bundles
+templates:
+  - templates/clusterrole-aggregate.yaml
+release:
+  name: tm
+  namespace: trust
+tests:
+  - it: default — renders the cluster-view (read) aggregated role
+    asserts:
+      - hasDocuments:
+          count: 1
+      - equal:
+          path: metadata.name
+          value: trust-manager-cluster-view
+        documentIndex: 0
+      - equal:
+          path: metadata.labels["rbac.authorization.k8s.io/aggregate-to-cluster-reader"]
+          value: "true"
+        documentIndex: 0
+      - equal:
+          path: rules[0].verbs
+          value: ["get", "list", "watch"]
+        documentIndex: 0
+      - equal:
+          path: rules[0].apiGroups
+          value: ["trust.cert-manager.io"]
+        documentIndex: 0
+      - equal:
+          path: rules[0].resources
+          value: ["bundles"]
+        documentIndex: 0
+      - lengthEqual:
+          path: rules
+          count: 1
+        documentIndex: 0
+
+  - it: global.rbac.aggregateClusterRoles=false suppresses the role
+    set:
+      global:
+        rbac:
+          aggregateClusterRoles: false
+    asserts:
+      - hasDocuments:
+          count: 0
+
+  - it: global.rbac.create=false suppresses the role
+    set:
+      global:
+        rbac:
+          create: false
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/deploy/charts/trust-manager/values.schema.json
+++ b/deploy/charts/trust-manager/values.schema.json
@@ -707,11 +707,19 @@
     },
     "helm-values.global.rbac": {
       "properties": {
+        "aggregateClusterRoles": {
+          "$ref": "#/$defs/helm-values.global.rbac.aggregateClusterRoles"
+        },
         "create": {
           "$ref": "#/$defs/helm-values.global.rbac.create"
         }
       },
       "type": "object"
+    },
+    "helm-values.global.rbac.aggregateClusterRoles": {
+      "default": true,
+      "description": "Aggregate read access to Bundles into the \"cluster-reader\" ClusterRole, mirroring how cert-manager aggregates its cluster-scoped ClusterIssuers. Bundle is a cluster-scoped resource, so this only takes effect for subjects bound via a ClusterRoleBinding. For more information, see [User-facing roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles).",
+      "type": "boolean"
     },
     "helm-values.global.rbac.create": {
       "default": true,

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -3,6 +3,9 @@ global:
   rbac:
     # Create required ClusterRoles, Roles, ClusterRoleBindings and RoleBindings for trust-manager.
     create: true
+    # Aggregate read access to Bundles into the "cluster-reader" ClusterRole, mirroring how cert-manager aggregates its cluster-scoped ClusterIssuers. Bundle is a cluster-scoped resource, so this only takes effect for subjects bound via a ClusterRoleBinding.
+    # For more information, see [User-facing roles](https://kubernetes.io/docs/reference/access-authn-authz/rbac/#user-facing-roles).
+    aggregateClusterRoles: true
 
 # +docs:section=CRDs
 crds:


### PR DESCRIPTION
## What

Adds a user-facing aggregated ClusterRole for trust-manager `Bundle` resources, as requested in #886, mirroring cert-manager's precedent (`global.rbac.aggregateClusterRoles`).

When `global.rbac.create` is true and the new `global.rbac.aggregateClusterRoles` flag is true (default `true`), one ClusterRole is created:

- `trust-manager-cluster-view`: `get/list/watch` on `bundles`, aggregated to `cluster-reader`.

## Why read goes to cluster-reader (not view)

`Bundle` is cluster-scoped. cert-manager aggregates its own cluster-scoped resource (ClusterIssuers) read access into `cluster-reader` via `aggregate-to-cluster-reader`, rather than into the namespaced `view` role, so I followed that exact pattern. Because the resource is cluster-scoped, this grant takes effect for subjects bound via a ClusterRoleBinding to `cluster-reader`. A namespaced RoleBinding does not confer Bundle access.

## On write access

An earlier revision of this PR also aggregated write into `edit`/`admin`. Per review that has been dropped. A namespaced RoleBinding to `edit`/`admin` cannot grant access to a cluster-scoped resource, so aggregating write into those roles is the wrong tool while `Bundle` is cluster-scoped. Once a namespace-scoped Bundle exists (after the ClusterBundle migration), edit aggregation can be added on that resource. This PR therefore references #886 rather than closing it.

## Opt-in / safety

- Default on to match cert-manager and give the out-of-the-box UX #886 asks for.
- Set `global.rbac.aggregateClusterRoles: false` to opt out.

## Verification

- `helm template` with the flag on, off, and with `global.rbac.create=false`.
- New helm-unittest suite `tests/clusterrole_aggregate_test.yaml` passes.
- `values.schema.json` and `README.md` regenerated via `make generate-helm-schema generate-helm-docs`. `make verify-helm-values` and `verify-helm-lint` pass.

Refs #886
