### PR TITLE
fix: make TrustBundleHash deterministic across reconciles

### DIFF
--- a/pkg/bundle/internal/target/target.go
+++ b/pkg/bundle/internal/target/target.go
@@ -24,6 +24,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"slices"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -408,12 +409,16 @@ func TrustBundleHash(data []byte, additionalFormats *trustapi.AdditionalFormats,
 		_, _ = hash.Write([]byte(*additionalFormats.PKCS12.Password))
 	}
 
-	// Add Target annotations and labels to the hash so it becomes aware of changes and triggers an update.
-	for k, v := range target.GetAnnotations() {
-		_, _ = hash.Write([]byte(k + v))
+	// Add Target annotations and labels to the hash so it becomes aware of changes
+	// and triggers an update. Iterate in sorted key order so the hash is stable
+	// regardless of Go's randomized map iteration order (#971).
+	annotations := target.GetAnnotations()
+	for _, k := range slices.Sorted(maps.Keys(annotations)) {
+		_, _ = hash.Write([]byte(k + annotations[k]))
 	}
-	for k, v := range target.GetLabels() {
-		_, _ = hash.Write([]byte(k + v))
+	labels := target.GetLabels()
+	for _, k := range slices.Sorted(maps.Keys(labels)) {
+		_, _ = hash.Write([]byte(k + labels[k]))
 	}
 
 	hashValue := [32]byte{}

--- a/pkg/bundle/internal/target/target_test.go
+++ b/pkg/bundle/internal/target/target_test.go
@@ -1193,8 +1193,9 @@ func Test_TrustBundleHash_Deterministic(t *testing.T) {
 	}
 
 	want := TrustBundleHash([]byte("data"), nil, target)
-	for i := 0; i < 1000; i++ {
-		assert.Equalf(t, want, TrustBundleHash([]byte("data"), nil, target),
-			"TrustBundleHash must be deterministic, but iteration %d differed", i)
+	for i := range 1000 {
+		if got := TrustBundleHash([]byte("data"), nil, target); got != want {
+			t.Fatalf("TrustBundleHash must be deterministic, but iteration %d produced %q, want %q", i, got, want)
+		}
 	}
 }

--- a/pkg/bundle/internal/target/target_test.go
+++ b/pkg/bundle/internal/target/target_test.go
@@ -1163,3 +1163,38 @@ func assertPKCS12Data(t *testing.T, binData []byte, password string) {
 	p, _ := pem.Decode([]byte(data))
 	assert.Equal(t, p.Bytes, cas[0].Raw)
 }
+
+func Test_TrustBundleHash_Deterministic(t *testing.T) {
+	// Regression test for #971: TrustBundleHash folded the target annotations and
+	// labels into the hash by iterating Go maps directly. With more than one key,
+	// Go's randomized map iteration order made the hash vary between calls, so
+	// needsUpdate() was always true and the controller rewrote the target on every
+	// reconcile. The hash must be stable across calls for the same input.
+	//
+	// Note: this needs multiple keys to expose the bug — a single annotation/label
+	// (as in the existing integration tests) cannot trigger the randomization.
+	target := &trustapi.TargetTemplate{
+		Metadata: trustapi.TargetMetadata{
+			Annotations: map[string]string{
+				"annotation1": "value1",
+				"annotation2": "value2",
+				"annotation3": "value3",
+				"annotation4": "value4",
+				"annotation5": "value5",
+			},
+			Labels: map[string]string{
+				"label1": "value1",
+				"label2": "value2",
+				"label3": "value3",
+				"label4": "value4",
+				"label5": "value5",
+			},
+		},
+	}
+
+	want := TrustBundleHash([]byte("data"), nil, target)
+	for i := 0; i < 1000; i++ {
+		assert.Equalf(t, want, TrustBundleHash([]byte("data"), nil, target),
+			"TrustBundleHash must be deterministic, but iteration %d differed", i)
+	}
+}


### PR DESCRIPTION
Closes #971

## Problem

`TrustBundleHash` folds the target's annotations and labels into the hash by iterating Go maps directly:

```go
for k, v := range target.GetAnnotations() { hash.Write([]byte(k + v)) }
for k, v := range target.GetLabels()      { hash.Write([]byte(k + v)) }
```

With more than one key, Go's randomized map iteration order makes the computed `trust.cert-manager.io/hash` annotation differ between reconciles **even when the desired metadata is unchanged**. `needsUpdate()` then returns true on every reconcile, the controller patches the target, the owned-object watch re-enqueues the `Bundle`, and the loop repeats — matching the report in #971 (a flood of "Successfully synced Bundle" events and etcd `mvcc: database space exceeded`).

## Fix

Iterate the annotation and label keys in **sorted order** before writing them to the hash, so the hash is stable for a given input. Same bytes, deterministic order — no external behaviour change.

## Why the existing tests didn't catch it

This needs **2+ keys** to expose Go's map randomization. #972's integration tests use a single label/annotation, so they pass despite the bug (which is likely why it couldn't be reproduced). This PR adds `Test_TrustBundleHash_Deterministic`, which hashes a target with several annotations and labels repeatedly and asserts the result is stable:

- **before the fix:** `FAIL … iteration 0 differed`
- **after the fix:** `ok`

Verified locally: `go test ./pkg/bundle/internal/target/...` passes, `go vet` + `gofmt` clean.
