### PR TITLE
feat: read CA data from ConfigMap binaryData field in Bundle sources

### DIFF
--- a/pkg/bundle/internal/source/source.go
+++ b/pkg/bundle/internal/source/source.go
@@ -178,16 +178,31 @@ func (b configMapBundleSource) addToCertPool(ctx context.Context, pool *util.Cer
 
 	for _, cm := range configMaps {
 		if len(b.ref.Key) > 0 {
+			// ConfigMaps may store values under either the string Data field or
+			// the byte BinaryData field. Prefer Data, but fall back to
+			// BinaryData so base64-encoded CAs are also resolvable.
 			data, ok := cm.Data[b.ref.Key]
-			if !ok {
+			binaryData, binaryOk := cm.BinaryData[b.ref.Key]
+			switch {
+			case ok:
+				if err := pool.AddCertsFromPEM([]byte(data)); err != nil {
+					return InvalidPEMError{fmt.Errorf("invalid PEM data in ConfigMap %s/%s at key %q: %w", cm.Namespace, cm.Name, b.ref.Key, err)}
+				}
+			case binaryOk:
+				if err := pool.AddCertsFromPEM(binaryData); err != nil {
+					return InvalidPEMError{fmt.Errorf("invalid PEM data in ConfigMap %s/%s at key %q: %w", cm.Namespace, cm.Name, b.ref.Key, err)}
+				}
+			default:
 				return NotFoundError{fmt.Errorf("no data found in ConfigMap %s/%s at key %q", cm.Namespace, cm.Name, b.ref.Key)}
-			}
-			if err := pool.AddCertsFromPEM([]byte(data)); err != nil {
-				return InvalidPEMError{fmt.Errorf("invalid PEM data in ConfigMap %s/%s at key %q: %w", cm.Namespace, cm.Name, b.ref.Key, err)}
 			}
 		} else if ptr.Deref(b.ref.IncludeAllKeys, false) {
 			for key, data := range cm.Data {
 				if err := pool.AddCertsFromPEM([]byte(data)); err != nil {
+					return InvalidPEMError{fmt.Errorf("invalid PEM data in ConfigMap %s/%s at key %q: %w", cm.Namespace, cm.Name, key, err)}
+				}
+			}
+			for key, data := range cm.BinaryData {
+				if err := pool.AddCertsFromPEM(data); err != nil {
 					return InvalidPEMError{fmt.Errorf("invalid PEM data in ConfigMap %s/%s at key %q: %w", cm.Namespace, cm.Name, key, err)}
 				}
 			}

--- a/pkg/bundle/internal/source/source_test.go
+++ b/pkg/bundle/internal/source/source_test.go
@@ -84,6 +84,51 @@ func Test_BuildBundle(t *testing.T) {
 			}},
 			expData: dummy.JoinCerts(dummy.TestCertificate2, dummy.TestCertificate1),
 		},
+		"if single ConfigMap source referencing single key stored in binaryData, return data": {
+			sources: []trustapi.BundleSource{
+				{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "configmap", Key: "key"}},
+			},
+			objects: []runtime.Object{&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "configmap"},
+				BinaryData: map[string][]byte{"key": []byte(dummy.TestCertificate1 + "\n" + dummy.TestCertificate2)},
+			}},
+			expData: dummy.JoinCerts(dummy.TestCertificate2, dummy.TestCertificate1),
+		},
+		"if single ConfigMap source with key in both data and binaryData, data takes precedence": {
+			sources: []trustapi.BundleSource{
+				{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "configmap", Key: "key"}},
+			},
+			objects: []runtime.Object{&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "configmap"},
+				Data:       map[string]string{"key": dummy.TestCertificate1},
+				BinaryData: map[string][]byte{"key": []byte(dummy.TestCertificate2)},
+			}},
+			expData: dummy.JoinCerts(dummy.TestCertificate1),
+		},
+		"if single ConfigMap source whose key is absent from both data and binaryData, return NotFoundError": {
+			sources: []trustapi.BundleSource{
+				{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "configmap", Key: "key"}},
+			},
+			objects: []runtime.Object{&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "configmap"},
+				Data:       map[string]string{"other": dummy.TestCertificate1},
+				BinaryData: map[string][]byte{"another": []byte(dummy.TestCertificate2)},
+			}},
+			expError:         true,
+			expNotFoundError: true,
+		},
+		"if single ConfigMap source with invalid PEM in binaryData, return error": {
+			sources: []trustapi.BundleSource{
+				{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "configmap", Key: "key"}},
+			},
+			objects: []runtime.Object{&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "configmap"},
+				// A complete PEM block whose contents are not a valid certificate,
+				// mirroring the invalid-PEM behaviour of the data field.
+				BinaryData: map[string][]byte{"key": []byte("-----BEGIN CERTIFICATE-----\naW52YWxpZA==\n-----END CERTIFICATE-----")},
+			}},
+			expError: true,
+		},
 		"if single ConfigMap source including all keys, return data": {
 			sources: []trustapi.BundleSource{
 				{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "configmap", IncludeAllKeys: new(true)}},
@@ -93,6 +138,17 @@ func Test_BuildBundle(t *testing.T) {
 				Data:       map[string]string{"cert-1": dummy.TestCertificate1 + "\n" + dummy.TestCertificate2, "cert-2": dummy.TestCertificate3},
 			}},
 			expData: dummy.JoinCerts(dummy.TestCertificate2, dummy.TestCertificate1, dummy.TestCertificate3),
+		},
+		"if single ConfigMap source including all keys across data and binaryData, return data": {
+			sources: []trustapi.BundleSource{
+				{ConfigMap: &trustapi.SourceObjectKeySelector{Name: "configmap", IncludeAllKeys: new(true)}},
+			},
+			objects: []runtime.Object{&corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{Name: "configmap"},
+				Data:       map[string]string{"cert-1": dummy.TestCertificate1},
+				BinaryData: map[string][]byte{"cert-2": []byte(dummy.TestCertificate2)},
+			}},
+			expData: dummy.JoinCerts(dummy.TestCertificate2, dummy.TestCertificate1),
 		},
 		"if single ConfigMap source, return data even when order changes": {
 			// Test uses the same data as the previous one but with different order


### PR DESCRIPTION
## Summary

ConfigMap `Bundle` sources only resolved keys from the string `Data` field, so a CA stored under a ConfigMap's `binaryData` failed with `no data found in ConfigMap ... at key`. This adds `binaryData` support to `configMapBundleSource.addToCertPool` (#983):

- When resolving a single `key`, fall back to `cm.BinaryData[key]` if the key is absent from `cm.Data`, treating the bytes as PEM exactly like the `Data` path.
- When `includeAllKeys` is set, iterate `cm.BinaryData` entries in addition to `cm.Data`.
- `Data` continues to take precedence, and the existing `NotFound` / `InvalidPEM` semantics are unchanged (a key missing from both maps still returns `NotFound`). The Secret path is untouched, since Secret values already live in `Data`.

## Why this matters

`binaryData` is a standard, valid place for base64-encoded values in a ConfigMap, and internal CAs are sometimes distributed that way. @erikgb reproduced the gap and agreed trust-manager should support fetching from `binaryData` as well. Today those ConfigMaps are simply unusable as Bundle sources.

## Testing

Added unit tests in `pkg/bundle/internal/source/source_test.go` covering:

- a CA stored only under `binaryData[key]` (the issue's exact case),
- a key present in both `data` and `binaryData` (`data` wins),
- `includeAllKeys` mixing `data` and `binaryData` entries,
- a key absent from both maps (still `NotFoundError`),
- invalid PEM in `binaryData` (returns an error, mirroring the `data` behaviour).

`go test ./pkg/bundle/internal/source/...`, `go vet`, and `gofmt` all pass.

Fixes #983
