### PR TITLE
feat(helm): make webhook failurePolicy configurable

### DIFF
--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -572,6 +572,18 @@ Port that the webhook listens on.
 > ```
 
 Timeout of webhook HTTP request.
+#### **app.webhook.failurePolicy** ~ `string`
+> Default value:
+> ```yaml
+> Fail
+> ```
+
+The failure policy of the Bundle validating webhook. Accepted values are Fail and Ignore.  
+  
+Setting this to "Ignore" allows Bundles to be admitted while the webhook is unavailable, e.g. when Bundles are installed in the same Helm release as trust-manager itself (using  
+`extraObjects`) and the webhook endpoints aren't ready yet. Bundles admitted while the  
+webhook is unavailable skip webhook validation; the CRD schema is still enforced by the  
+Kubernetes API server.
 #### **app.webhook.service.type** ~ `string`
 > Default value:
 > ```yaml
@@ -779,7 +791,8 @@ NOTE: These annotations won't be added to the CRDs.
 > []
 > ```
 
-Extra manifests to be deployed. This is useful for deploying additional resources that are not part of the chart.  
+Extra manifests to be deployed. This is useful for deploying additional resources that are not part of the chart. NOTE: Bundles deployed here are validated by the trust-manager webhook, which may not be ready when the objects are applied, causing the Helm install or upgrade to fail. Consider setting  
+`app.webhook.failurePolicy` to "Ignore" or deploying Bundles separately from this chart.  
 For example:
 
 ```yaml

--- a/deploy/charts/trust-manager/templates/webhook.yaml
+++ b/deploy/charts/trust-manager/templates/webhook.yaml
@@ -114,7 +114,7 @@ webhooks:
           - bundles
     admissionReviewVersions: ["v1"]
     timeoutSeconds: {{ .Values.app.webhook.timeoutSeconds }}
-    failurePolicy: Fail
+    failurePolicy: {{ .Values.app.webhook.failurePolicy }}
     sideEffects: None
     clientConfig:
 {{ if .Values.app.webhook.tls.helmCert.enabled }}

--- a/deploy/charts/trust-manager/tests/webhook_test.yaml
+++ b/deploy/charts/trust-manager/tests/webhook_test.yaml
@@ -1,0 +1,28 @@
+suite: ValidatingWebhookConfiguration failure policy
+templates:
+  - templates/webhook.yaml
+release:
+  name: tm
+  namespace: trust
+tests:
+  - it: defaults to failurePolicy Fail
+    documentSelector:
+      path: kind
+      value: ValidatingWebhookConfiguration
+    asserts:
+      - equal:
+          path: webhooks[0].failurePolicy
+          value: Fail
+
+  - it: renders the configured failurePolicy
+    set:
+      app:
+        webhook:
+          failurePolicy: Ignore
+    documentSelector:
+      path: kind
+      value: ValidatingWebhookConfiguration
+    asserts:
+      - equal:
+          path: webhooks[0].failurePolicy
+          value: Ignore

--- a/deploy/charts/trust-manager/values.schema.json
+++ b/deploy/charts/trust-manager/values.schema.json
@@ -386,6 +386,9 @@
     "helm-values.app.webhook": {
       "additionalProperties": false,
       "properties": {
+        "failurePolicy": {
+          "$ref": "#/$defs/helm-values.app.webhook.failurePolicy"
+        },
         "host": {
           "$ref": "#/$defs/helm-values.app.webhook.host"
         },
@@ -406,6 +409,11 @@
         }
       },
       "type": "object"
+    },
+    "helm-values.app.webhook.failurePolicy": {
+      "default": "Fail",
+      "description": "The failure policy of the Bundle validating webhook. Accepted values are Fail and Ignore.\n\nSetting this to \"Ignore\" allows Bundles to be admitted while the webhook is unavailable, e.g. when Bundles are installed in the same Helm release as trust-manager itself (using\n`extraObjects`) and the webhook endpoints aren't ready yet. Bundles admitted while the\nwebhook is unavailable skip webhook validation; the CRD schema is still enforced by the\nKubernetes API server.",
+      "type": "string"
     },
     "helm-values.app.webhook.host": {
       "default": "0.0.0.0",
@@ -690,7 +698,7 @@
     },
     "helm-values.extraObjects": {
       "default": [],
-      "description": "Extra manifests to be deployed. This is useful for deploying additional resources that are not part of the chart.\nFor example:\nextraObjects:\n - apiVersion: cilium.io/v2\n   kind: CiliumNetworkPolicy\n   metadata:\n     name: trust-manager\n     namespace: trust-manager\n   spec:\n     endpointSelector:\n       matchLabels:\n         io.cilium.k8s.policy.serviceaccount: trust-manager\n     egress:\n       - toEntities:\n           - kube-apiserver",
+      "description": "Extra manifests to be deployed. This is useful for deploying additional resources that are not part of the chart. NOTE: Bundles deployed here are validated by the trust-manager webhook, which may not be ready when the objects are applied, causing the Helm install or upgrade to fail. Consider setting\n`app.webhook.failurePolicy` to \"Ignore\" or deploying Bundles separately from this chart.\nFor example:\nextraObjects:\n - apiVersion: cilium.io/v2\n   kind: CiliumNetworkPolicy\n   metadata:\n     name: trust-manager\n     namespace: trust-manager\n   spec:\n     endpointSelector:\n       matchLabels:\n         io.cilium.k8s.policy.serviceaccount: trust-manager\n     egress:\n       - toEntities:\n           - kube-apiserver",
       "items": {},
       "type": "array"
     },

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -350,6 +350,15 @@ app:
     # Timeout of webhook HTTP request.
     timeoutSeconds: 5
 
+    # The failure policy of the Bundle validating webhook. Accepted values are Fail and Ignore.
+    #
+    # Setting this to "Ignore" allows Bundles to be admitted while the webhook is unavailable,
+    # e.g. when Bundles are installed in the same Helm release as trust-manager itself (using
+    # `extraObjects`) and the webhook endpoints aren't ready yet. Bundles admitted while the
+    # webhook is unavailable skip webhook validation; the CRD schema is still enforced by the
+    # Kubernetes API server.
+    failurePolicy: Fail
+
     service:
       # The type of Kubernetes Service used by the Webhook.
       type: ClusterIP
@@ -468,6 +477,9 @@ commonLabels: {}
 # NOTE: These annotations won't be added to the CRDs.
 commonAnnotations: {}
 # Extra manifests to be deployed. This is useful for deploying additional resources that are not part of the chart.
+# NOTE: Bundles deployed here are validated by the trust-manager webhook, which may not be ready when
+# the objects are applied, causing the Helm install or upgrade to fail. Consider setting
+# `app.webhook.failurePolicy` to "Ignore" or deploying Bundles separately from this chart.
 # For example:
 # extraObjects:
 #  - apiVersion: cilium.io/v2


### PR DESCRIPTION
Fixes #881

## Problem

Deploying `Bundle`s via `extraObjects` in the same Helm release as trust-manager itself can fail the install/upgrade:

```
Internal error occurred: failed calling webhook "trust.cert-manager.io": failed to call webhook:
Post "https://trust-manager.mynamespace.svc:443/validate-trust-cert-manager-io-v1alpha1-bundle?timeout=5s":
dial tcp 10.233.23.225:443: connect: connection refused
```

Helm applies the `Bundle`s in the same manifest batch as the `Deployment` (no readiness ordering), so whenever the cluster-scoped `ValidatingWebhookConfiguration` already exists — every `helm upgrade`, or a re-install where it lingered — while the webhook `Service` has no ready endpoints, the `Bundle` CREATE is rejected and the whole release fails. Re-running the same command succeeds once the pod is ready, exactly as reported in #881.

Note this is *not* solved by the startupapicheck proposal (#837, PRs #900/#958): a post-install hook Job runs only **after** the main manifests — including `extraObjects` — have already been applied, so it can't sequence resources within the same release. Adding `helm.sh/hook` annotations to the `extraObjects` is also not a good workaround, since hook resources are not managed by the release (they leak on uninstall) and only sequence correctly with `--wait`.

## Solution

Expose the webhook failure policy as `app.webhook.failurePolicy` (default: `Fail` — no behavior change), instead of hardcoding `Fail` in the template.

Users who deploy `Bundle`s in the same release (e.g. via `extraObjects`) can set `Ignore`, allowing `Bundle`s to be admitted while the webhook is briefly unavailable:

- webhook validation still applies whenever the webhook is reachable (unlike disabling the webhook, which was rejected in #742);
- the CRD structural schema is always enforced by the API server;
- this is consistent with the long-term direction of moving validation into CEL and eventually removing the webhook (#742 discussion).

The `extraObjects` value documentation now also calls out the caveat and points at the new value.

If you'd rather address this differently (e.g. docs-only, or waiting for the ClusterBundle/CEL migration), happy to adjust.

## Changes

- `values.yaml`: new `app.webhook.failurePolicy` value (default `Fail`) + caveat note on `extraObjects`
- `templates/webhook.yaml`: render the value instead of the hardcoded `Fail`
- `tests/webhook_test.yaml`: new helm-unittest suite covering the default (`Fail`) and the override (`Ignore`); the override test fails without this change (schema rejects the unknown property)
- `values.schema.json` / `README.md`: regenerated with `make generate-helm-schema generate-helm-docs`

## Testing

- `make verify-helm-unittest` — 6 suites / 20 tests pass (new suite fails before the fix)
- `make verify-helm-values` — no errors
- `make verify-helm-lint` — 0 charts failed
- `make verify-helm-kubeconform` — passes
- `helm template` sanity checks: defaults render `failurePolicy: Fail` (unchanged); with `app.webhook.failurePolicy=Ignore` plus the reporter's `Bundle` `extraObjects`, the webhook renders `Ignore` and the `Bundle`s render as before
