### PR TITLE
feat: log applied data and binaryData keys when syncing bundle targets

### DIFF
--- a/pkg/bundle/internal/target/target.go
+++ b/pkg/bundle/internal/target/target.go
@@ -174,7 +174,13 @@ func (r *Reconciler) applyConfigMap(
 		return false, fmt.Errorf("failed to patch %s %s: %w", target.Kind, target.NamespacedName, err)
 	}
 
-	logf.FromContext(ctx).V(2).Info("applied bundle to namespace")
+	// Log the applied keys to make it possible to tell from the logs which keys were
+	// written to the target, and to which field (additional formats are binary and
+	// end up in binaryData, which some UIs don't display).
+	logf.FromContext(ctx).V(2).Info("applied bundle to namespace",
+		"dataKeys", slices.Sorted(maps.Keys(data)),
+		"binaryDataKeys", slices.Sorted(maps.Keys(binData)),
+	)
 
 	return true, nil
 }
@@ -237,7 +243,11 @@ func (r *Reconciler) applySecret(
 		return false, fmt.Errorf("failed to patch %s %s: %w", target.Kind, target.NamespacedName, err)
 	}
 
-	logf.FromContext(ctx).V(2).Info("applied bundle to namespace")
+	// Log the applied keys to make it possible to tell from the logs which keys were
+	// written to the target (additional format keys are included in data for Secrets).
+	logf.FromContext(ctx).V(2).Info("applied bundle to namespace",
+		"dataKeys", slices.Sorted(maps.Keys(data)),
+	)
 
 	return true, nil
 }

--- a/pkg/bundle/internal/target/target_test.go
+++ b/pkg/bundle/internal/target/target_test.go
@@ -23,6 +23,7 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/go-logr/logr"
 	jks "github.com/pavlo-v-chernykh/keystore-go/v4"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -986,6 +987,102 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 					assertPKCS12Data(t, binData, trustapi.DefaultPKCS12Password)
 				}
 			}
+		})
+	}
+}
+
+// Test_ApplyTarget_LogsAppliedKeys ensures that the reconciler logs exactly which keys
+// were applied to the target, and to which field. Additional formats are binary and are
+// written to the binaryData field of target ConfigMaps, which is not displayed by some
+// Kubernetes UIs. The log allows verifying from the logs alone that additional formats
+// were synced (see issue #800).
+func Test_ApplyTarget_LogsAppliedKeys(t *testing.T) {
+	additionalFormats := &trustapi.AdditionalFormats{
+		JKS: &trustapi.JKS{
+			KeySelector: trustapi.KeySelector{Key: jksKey},
+			Password:    trustapi.DefaultJKSPassword,
+		},
+		PKCS12: &trustapi.PKCS12{
+			KeySelector: trustapi.KeySelector{Key: pkcs12Key},
+			Password:    ptr.To(trustapi.DefaultPKCS12Password),
+		},
+	}
+
+	tests := map[string]struct {
+		kind       Kind
+		target     trustapi.BundleTarget
+		expLogArgs []any
+	}{
+		"ConfigMap target should log data and binaryData keys": {
+			kind: KindConfigMap,
+			target: trustapi.BundleTarget{
+				ConfigMap:         &trustapi.TargetTemplate{Key: key},
+				AdditionalFormats: additionalFormats,
+			},
+			expLogArgs: []any{
+				"dataKeys", []string{key},
+				"binaryDataKeys", []string{jksKey, pkcs12Key},
+			},
+		},
+		"Secret target should log data keys": {
+			kind: KindSecret,
+			target: trustapi.BundleTarget{
+				Secret:            &trustapi.TargetTemplate{Key: key},
+				AdditionalFormats: additionalFormats,
+			},
+			expLogArgs: []any{
+				"dataKeys", []string{jksKey, pkcs12Key, key},
+			},
+		},
+	}
+
+	for name, tt := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			fakeClient := fake.NewClientBuilder().
+				WithReturnManagedFields().
+				WithScheme(test.Scheme).
+				Build()
+
+			r := &Reconciler{
+				Client: fakeClient,
+				Cache:  fakeClient,
+				PatchResourceOverwrite: func(_ context.Context, _ any) error {
+					return nil
+				},
+			}
+
+			certPool := util.NewCertPool()
+			err := certPool.AddCertsFromPEM([]byte(data))
+			assert.NoError(t, err)
+
+			logger := ktesting.NewLogger(t, ktesting.NewConfig(ktesting.BufferLogs(true)))
+			ctx := logr.NewContext(t.Context(), logger)
+			synced, err := r.ApplyTarget(ctx, Resource{
+				Kind:           tt.kind,
+				NamespacedName: types.NamespacedName{Name: bundleName, Namespace: namespace},
+			}, &trustapi.Bundle{
+				ObjectMeta: metav1.ObjectMeta{Name: bundleName},
+				Spec:       trustapi.BundleSpec{Target: tt.target},
+			}, source.BundleData{CertPool: certPool})
+			assert.NoError(t, err)
+			assert.True(t, synced)
+
+			underlier, ok := logger.GetSink().(ktesting.Underlier)
+			if !ok {
+				t.Fatalf("expected logger sink to implement ktesting.Underlier, got %T", logger.GetSink())
+			}
+
+			found := false
+			for _, entry := range underlier.GetBuffer().Data() {
+				if entry.Message != "applied bundle to namespace" {
+					continue
+				}
+				found = true
+				assert.Equal(t, tt.expLogArgs, entry.ParameterKVList)
+			}
+			assert.True(t, found, "expected %q to be logged", "applied bundle to namespace")
 		})
 	}
 }


### PR DESCRIPTION
Ref #800 (same report as #358)

## Problem

#800 (and previously #358) reports that a `Bundle` with `target.additionalFormats.pkcs12` (or
`jks`) produces target ConfigMaps that "only contain the `trust-bundle.pem` field", with no errors
and a successful sync.

I could not reproduce a defect at HEAD:

- `applyConfigMap`/`applySecret` unconditionally encode `additionalFormats` and include them in the
  SSA patch, and `needsUpdate()` treats a missing JKS/PKCS#12 managed key as "needs update", so
  targets self-heal even if degraded.
- The existing unit tests (fresh create + add-format-to-existing-target, both formats, ConfigMap and
  Secret) and the full `test/integration/bundle` suite (envtest, kube-apiserver v1.36.2) pass.
- The `-v=5` logs attached to #800 show the healthy path: one reconcile applies to all namespaces,
  then steady state.

The most likely explanation is the one confirmed in #358: the truststores **are** in the target
ConfigMap, in the **`binaryData`** field (they are binary and cannot go in `data`), and the UI used
to inspect the ConfigMap (the reporter is on Rancher Desktop) does not display `binaryData` keys.

What is missing in trust-manager is the ability to verify this from the logs: when asked
"anything in the logs that could indicate the cause?" the honest answer was no, because the target
sync log line doesn't say what was written.

## Change

Include the exact applied keys in the existing `"applied bundle to namespace"` V(2) log line:

```
... "applied bundle to namespace" ... dataKeys=["trust-bundle.pem"] binaryDataKeys=["truststore.p12"]
```

- ConfigMap targets log `dataKeys` and `binaryDataKeys` separately, making it visible that
  additional formats land in `binaryData`.
- Secret targets log `dataKeys` (additional formats are merged into `data` there).
- Keys are sorted for deterministic output; only key names are logged, never values.

With this in place, any future report of this kind is resolvable from a `-v=2` log capture, and the
reporters on #800 can immediately tell whether the controller wrote the truststore.

## Testing

- New unit test `Test_ApplyTarget_LogsAppliedKeys` asserts the structured log arguments for both
  target kinds (captured via `ktesting.BufferLogs`); it fails without the production change.
- `go test ./pkg/bundle/...` passes.
- `test/integration/bundle` suite (envtest, kube-apiserver v1.36.2) passes before and after.
- `go vet`, `gofmt` and `golangci-lint run` (repo config) are clean on the changed package.

## Notes for reviewers

- I intentionally did not use `Fixes #800`: if the reporters confirm the keys are present in
  `binaryData` (`kubectl get configmap <bundle> -o yaml`), #800 can be closed as a duplicate of
  #358; if the keys are genuinely absent, this log line pinpoints where to look next.
- A complementary docs note ("additional formats are written to `binaryData` of target ConfigMaps;
  some Kubernetes dashboards do not display `binaryData`") probably belongs in cert-manager/website;
  happy to follow up there.

```release-note
The bundle target sync debug log now includes the exact `data` and `binaryData` keys applied to the target, making it possible to verify from logs that `additionalFormats` were written. Note that additional formats are stored in the `binaryData` field of target ConfigMaps, which some Kubernetes UIs do not display.
```
