### PR TITLE
fix: include PKCS12 profile in target hash so profile changes trigger an update

### DIFF
--- a/pkg/bundle/internal/target/target.go
+++ b/pkg/bundle/internal/target/target.go
@@ -418,6 +418,9 @@ func TrustBundleHash(data []byte, additionalFormats *trustapi.AdditionalFormats,
 	if additionalFormats != nil && additionalFormats.PKCS12 != nil && additionalFormats.PKCS12.Password != nil {
 		_, _ = hash.Write([]byte(*additionalFormats.PKCS12.Password))
 	}
+	if additionalFormats != nil && additionalFormats.PKCS12 != nil && additionalFormats.PKCS12.Profile != "" {
+		_, _ = hash.Write([]byte(additionalFormats.PKCS12.Profile))
+	}
 
 	// Add Target annotations and labels to the hash so it becomes aware of changes
 	// and triggers an update. Iterate in sorted key order so the hash is stable

--- a/pkg/bundle/internal/target/target.go
+++ b/pkg/bundle/internal/target/target.go
@@ -408,6 +408,9 @@ func TrustBundleHash(data []byte, additionalFormats *trustapi.AdditionalFormats,
 	if additionalFormats != nil && additionalFormats.PKCS12 != nil && additionalFormats.PKCS12.Password != nil {
 		_, _ = hash.Write([]byte(*additionalFormats.PKCS12.Password))
 	}
+	if additionalFormats != nil && additionalFormats.PKCS12 != nil && additionalFormats.PKCS12.Profile != "" {
+		_, _ = hash.Write([]byte(additionalFormats.PKCS12.Profile))
+	}
 
 	// Add Target annotations and labels to the hash so it becomes aware of changes
 	// and triggers an update. Iterate in sorted key order so the hash is stable

--- a/pkg/bundle/internal/target/target_test.go
+++ b/pkg/bundle/internal/target/target_test.go
@@ -54,6 +54,10 @@ const (
 	data             = dummy.TestCertificate1
 	targetAnnotation = "dummyannotation"
 	targetLabel      = "dummylabel"
+
+	// The default PKCS12 password is empty, which produces a password-less truststore where the
+	// profile has no effect. The profile test cases need a real password.
+	customPKCS12Password = "pkcs12-password"
 )
 
 func Test_ApplyTarget_ConfigMap(t *testing.T) {
@@ -65,6 +69,10 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 		withJKS bool
 		// Add PKCS12 to AdditionalFormats
 		withPKCS12 bool
+		// Password of the PKCS12 truststore, empty means the default password
+		pkcs12Password string
+		// Encryption profile of the PKCS12 truststore
+		pkcs12Profile trustapi.PKCS12Profile
 		// Add annotation to target metadata
 		withTargetAnnotation bool
 		// Add label to target metadata
@@ -286,6 +294,59 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 			expPKCS12:      true,
 			expNeedsUpdate: true,
 		},
+		"if object exists with owner but outdated PKCS12 profile, expect update": {
+			object: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        bundleName,
+					Namespace:   namespace,
+					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: pkcs12ProfileHash(trustapi.LegacyRC2PKCS12Profile)},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:               "Bundle",
+							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Name:               bundleName,
+							Controller:         new(true),
+							BlockOwnerDeletion: new(true),
+						},
+					},
+					ManagedFields: ssa_client.ManagedFieldEntries([]string{key}, []string{pkcs12Key}),
+				},
+				Data:       map[string]string{key: data},
+				BinaryData: map[string][]byte{pkcs12Key: []byte("legacy profile truststore")},
+			},
+			withPKCS12:     true,
+			pkcs12Password: customPKCS12Password,
+			pkcs12Profile:  trustapi.Modern2023PKCS12Profile,
+			expPKCS12:      true,
+			expNeedsUpdate: true,
+		},
+		"if object exists with owner and unchanged PKCS12 profile, expect no update": {
+			object: &corev1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        bundleName,
+					Namespace:   namespace,
+					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: pkcs12ProfileHash(trustapi.Modern2023PKCS12Profile)},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:               "Bundle",
+							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Name:               bundleName,
+							Controller:         new(true),
+							BlockOwnerDeletion: new(true),
+						},
+					},
+					ManagedFields: ssa_client.ManagedFieldEntries([]string{key}, []string{pkcs12Key}),
+				},
+				Data:       map[string]string{key: data},
+				BinaryData: map[string][]byte{pkcs12Key: []byte("modern profile truststore")},
+			},
+			withPKCS12:     true,
+			pkcs12Password: customPKCS12Password,
+			pkcs12Profile:  trustapi.Modern2023PKCS12Profile,
+			expNeedsUpdate: false,
+		},
 		"if object exists with correct data, expect no update": {
 			object: &corev1.ConfigMap{
 				ObjectMeta: metav1.ObjectMeta{
@@ -487,12 +548,17 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 					Password: trustapi.DefaultJKSPassword,
 				}
 			}
+			pkcs12Password := trustapi.DefaultPKCS12Password
+			if tt.pkcs12Password != "" {
+				pkcs12Password = tt.pkcs12Password
+			}
 			if tt.withPKCS12 {
 				spec.Target.AdditionalFormats.PKCS12 = &trustapi.PKCS12{
 					KeySelector: trustapi.KeySelector{
 						Key: pkcs12Key,
 					},
-					Password: ptr.To(trustapi.DefaultPKCS12Password),
+					Password: new(pkcs12Password),
+					Profile:  tt.pkcs12Profile,
 				}
 			}
 			if tt.withTargetAnnotation {
@@ -544,7 +610,7 @@ func Test_ApplyTarget_ConfigMap(t *testing.T) {
 				assert.Equal(t, tt.expPKCS12, pkcs12Exists)
 
 				if tt.expPKCS12 {
-					assertPKCS12Data(t, binData, trustapi.DefaultPKCS12Password)
+					assertPKCS12Data(t, binData, pkcs12Password)
 				}
 
 				if tt.expTargetLabel {
@@ -567,6 +633,10 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 		withJKS bool
 		// Add PKCS12 to AdditionalFormats
 		withPKCS12 bool
+		// Password of the PKCS12 truststore, empty means the default password
+		pkcs12Password string
+		// Encryption profile of the PKCS12 truststore
+		pkcs12Profile trustapi.PKCS12Profile
 		// Expect JKS to exist in the secret at the end of the sync.
 		expJKS bool
 		// Expect PKCS12 to exist in the secret at the end of the sync.
@@ -780,6 +850,63 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 			expPKCS12:      true,
 			expNeedsUpdate: true,
 		},
+		"if object exists with owner but outdated PKCS12 profile, expect update": {
+			object: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        bundleName,
+					Namespace:   namespace,
+					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: pkcs12ProfileHash(trustapi.LegacyRC2PKCS12Profile)},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:               "Bundle",
+							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Name:               bundleName,
+							Controller:         new(true),
+							BlockOwnerDeletion: new(true),
+						},
+					},
+					ManagedFields: ssa_client.ManagedFieldEntries([]string{key, pkcs12Key}, nil),
+				},
+				Data: map[string][]byte{
+					key:       []byte(data),
+					pkcs12Key: []byte("legacy profile truststore"),
+				},
+			},
+			withPKCS12:     true,
+			pkcs12Password: customPKCS12Password,
+			pkcs12Profile:  trustapi.Modern2023PKCS12Profile,
+			expPKCS12:      true,
+			expNeedsUpdate: true,
+		},
+		"if object exists with owner and unchanged PKCS12 profile, expect no update": {
+			object: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        bundleName,
+					Namespace:   namespace,
+					Labels:      map[string]string{trustapi.BundleLabelKey: bundleName},
+					Annotations: map[string]string{trustapi.BundleHashAnnotationKey: pkcs12ProfileHash(trustapi.Modern2023PKCS12Profile)},
+					OwnerReferences: []metav1.OwnerReference{
+						{
+							Kind:               "Bundle",
+							APIVersion:         "trust.cert-manager.io/v1alpha1",
+							Name:               bundleName,
+							Controller:         new(true),
+							BlockOwnerDeletion: new(true),
+						},
+					},
+					ManagedFields: ssa_client.ManagedFieldEntries([]string{key, pkcs12Key}, nil),
+				},
+				Data: map[string][]byte{
+					key:       []byte(data),
+					pkcs12Key: []byte("modern profile truststore"),
+				},
+			},
+			withPKCS12:     true,
+			pkcs12Password: customPKCS12Password,
+			pkcs12Profile:  trustapi.Modern2023PKCS12Profile,
+			expNeedsUpdate: false,
+		},
 		"if object exists with correct data, expect no update": {
 			object: &corev1.Secret{
 				ObjectMeta: metav1.ObjectMeta{
@@ -933,12 +1060,17 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 					Password: trustapi.DefaultJKSPassword,
 				}
 			}
+			pkcs12Password := trustapi.DefaultPKCS12Password
+			if tt.pkcs12Password != "" {
+				pkcs12Password = tt.pkcs12Password
+			}
 			if tt.withPKCS12 {
 				spec.Target.AdditionalFormats.PKCS12 = &trustapi.PKCS12{
 					KeySelector: trustapi.KeySelector{
 						Key: pkcs12Key,
 					},
-					Password: ptr.To(trustapi.DefaultPKCS12Password),
+					Password: new(pkcs12Password),
+					Profile:  tt.pkcs12Profile,
 				}
 			}
 
@@ -984,7 +1116,7 @@ func Test_ApplyTarget_Secret(t *testing.T) {
 				assert.Equal(t, tt.expPKCS12, pkcs12Exists)
 
 				if tt.expPKCS12 {
-					assertPKCS12Data(t, binData, trustapi.DefaultPKCS12Password)
+					assertPKCS12Data(t, binData, pkcs12Password)
 				}
 			}
 		})
@@ -1142,6 +1274,16 @@ func Test_TrustBundleHash(t *testing.T) {
 				{data: []byte("data"), additionalFormats: &trustapi.AdditionalFormats{PKCS12: &trustapi.PKCS12{Password: new("wrong")}}},
 			},
 		},
+		"pkcs12 profile": {
+			input: inputArgs{data: []byte("data"), additionalFormats: &trustapi.AdditionalFormats{PKCS12: &trustapi.PKCS12{Password: new("password"), Profile: trustapi.LegacyRC2PKCS12Profile}}},
+			matches: []inputArgs{
+				{data: []byte("data"), additionalFormats: &trustapi.AdditionalFormats{PKCS12: &trustapi.PKCS12{Password: new("password"), Profile: trustapi.LegacyRC2PKCS12Profile}}},
+			},
+			mismatches: []inputArgs{
+				{data: []byte("data"), additionalFormats: &trustapi.AdditionalFormats{PKCS12: &trustapi.PKCS12{Password: new("password"), Profile: trustapi.LegacyDESPKCS12Profile}}},
+				{data: []byte("data"), additionalFormats: &trustapi.AdditionalFormats{PKCS12: &trustapi.PKCS12{Password: new("password"), Profile: trustapi.Modern2023PKCS12Profile}}},
+			},
+		},
 		"target metadata": {
 			input: inputArgs{
 				data:              []byte("data"),
@@ -1247,6 +1389,18 @@ func assertJKSData(t *testing.T, binData []byte, password string) {
 	// Only one certificate block for this test, so we can safely ignore the `remaining` byte array
 	p, _ := pem.Decode([]byte(data))
 	assert.Equal(t, p.Bytes, cert.Certificate.Content)
+}
+
+// pkcs12ProfileHash returns the hash a target would carry after being synced with the given
+// PKCS12 profile, so a test case can start from a target synced with an older profile.
+func pkcs12ProfileHash(profile trustapi.PKCS12Profile) string {
+	return TrustBundleHash([]byte(data), &trustapi.AdditionalFormats{
+		PKCS12: &trustapi.PKCS12{
+			KeySelector: trustapi.KeySelector{Key: pkcs12Key},
+			Password:    new(customPKCS12Password),
+			Profile:     profile,
+		},
+	}, nil)
 }
 
 func assertPKCS12Data(t *testing.T, binData []byte, password string) {

--- a/pkg/bundle/internal/target/target_test.go
+++ b/pkg/bundle/internal/target/target_test.go
@@ -1045,6 +1045,16 @@ func Test_TrustBundleHash(t *testing.T) {
 				{data: []byte("data"), additionalFormats: &trustapi.AdditionalFormats{PKCS12: &trustapi.PKCS12{Password: new("wrong")}}},
 			},
 		},
+		"pkcs12 profile": {
+			input: inputArgs{data: []byte("data"), additionalFormats: &trustapi.AdditionalFormats{PKCS12: &trustapi.PKCS12{Password: new("password"), Profile: trustapi.LegacyRC2PKCS12Profile}}},
+			matches: []inputArgs{
+				{data: []byte("data"), additionalFormats: &trustapi.AdditionalFormats{PKCS12: &trustapi.PKCS12{Password: new("password"), Profile: trustapi.LegacyRC2PKCS12Profile}}},
+			},
+			mismatches: []inputArgs{
+				{data: []byte("data"), additionalFormats: &trustapi.AdditionalFormats{PKCS12: &trustapi.PKCS12{Password: new("password"), Profile: trustapi.LegacyDESPKCS12Profile}}},
+				{data: []byte("data"), additionalFormats: &trustapi.AdditionalFormats{PKCS12: &trustapi.PKCS12{Password: new("password"), Profile: trustapi.Modern2023PKCS12Profile}}},
+			},
+		},
 		"target metadata": {
 			input: inputArgs{
 				data:              []byte("data"),

--- a/test/integration/bundle/controller_test.go
+++ b/test/integration/bundle/controller_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package test
 
 import (
+	"bytes"
 	"context"
 
 	corev1 "k8s.io/api/core/v1"
@@ -26,6 +27,7 @@ import (
 	"k8s.io/klog/v2/ktesting"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest/komega"
+	"software.sslmate.com/src/go-pkcs12"
 
 	trustapi "github.com/cert-manager/trust-manager/pkg/apis/trust/v1alpha1"
 	"github.com/cert-manager/trust-manager/test/dummy"
@@ -39,6 +41,8 @@ import (
 const (
 	eventuallyTimeout      = testenv.EventuallyTimeout
 	eventuallyPollInterval = testenv.EventuallyPollInterval
+
+	pkcs12Password = "pkcs12-password"
 )
 
 var _ = Describe("Integration", func() {
@@ -483,6 +487,45 @@ var _ = Describe("Integration", func() {
 
 			Expect(testenv.CheckJKSFileSynced(jksData, trustapi.DefaultJKSPassword, dummy.DefaultJoinedCerts())).ToNot(HaveOccurred())
 		}
+	})
+
+	It("should update the PKCS12 truststore in all targets when the profile is changed", func() {
+		// A password is required for the profile to have any effect: the default empty password
+		// produces a password-less truststore.
+		Expect(komega.Update(testBundle, func() {
+			testBundle.Spec.Target = trustapi.BundleTarget{
+				ConfigMap: &trustapi.TargetTemplate{Key: testData.Target.Key},
+				AdditionalFormats: &trustapi.AdditionalFormats{
+					PKCS12: &trustapi.PKCS12{
+						KeySelector: trustapi.KeySelector{
+							Key: "myfile.p12",
+						},
+						Password: new(pkcs12Password),
+						Profile:  trustapi.LegacyRC2PKCS12Profile,
+					},
+				},
+			}
+		})()).To(Succeed())
+
+		configMap := &corev1.ConfigMap{ObjectMeta: metav1.ObjectMeta{Namespace: "kube-system", Name: testBundle.Name}}
+		Eventually(komega.Object(configMap)).Should(HaveField("BinaryData", HaveKey("myfile.p12")))
+
+		legacyTruststore := bytes.Clone(configMap.BinaryData["myfile.p12"])
+
+		// Retried because this update races with the controller writing the Bundle status after
+		// the first update.
+		Eventually(komega.Update(testBundle, func() {
+			testBundle.Spec.Target.AdditionalFormats.PKCS12.Profile = trustapi.Modern2023PKCS12Profile
+		}), eventuallyTimeout, eventuallyPollInterval).Should(Succeed())
+
+		Eventually(func() []byte {
+			Expect(cl.Get(ctx, client.ObjectKeyFromObject(configMap), configMap)).ToNot(HaveOccurred())
+			return configMap.BinaryData["myfile.p12"]
+		}, eventuallyTimeout, eventuallyPollInterval).ShouldNot(Equal(legacyTruststore), "checking that the truststore is rewritten when only the PKCS12 profile changes")
+
+		certs, err := pkcs12.DecodeTrustStore(configMap.BinaryData["myfile.p12"], pkcs12Password)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(certs).To(HaveLen(3))
 	})
 
 	It("should re-add the owner reference of a target ConfigMap if it has been removed", func() {


### PR DESCRIPTION
`TrustBundleHash` hashes the PKCS12 password but not the profile, so changing only `spec.target.additionalFormats.pkcs12.profile` (e.g. `LegacyRC2` to `Modern2023`) leaves the hash unchanged and `needsUpdate` returns false. The target keystore keeps the old encryption profile while the Bundle still reports `Synced`. This folds the profile into the hash, matching how the password is already handled.