### PR TITLE
Adopt the shared kube-api-linter makefile module

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -1,5 +1,0 @@
-version: v2.13.1
-name: golangci-kube-api-linter
-plugins:
-- module: 'sigs.k8s.io/kube-api-linter'
-  version: 'v0.0.0-20260716143926-092fe0c72997' # Pin to a commit while there's no tag

--- a/klone.yaml
+++ b/klone.yaml
@@ -52,6 +52,11 @@ targets:
       repo_ref: main
       repo_hash: c2362005d2607bce04328c0557c5488c9d56812e
       repo_path: modules/klone
+    - folder_name: kube-api-linter
+      repo_url: https://github.com/cert-manager/makefile-modules.git
+      repo_ref: main
+      repo_hash: 555e973908fcb9b8ced9e8043c60891359322205
+      repo_path: modules/kube-api-linter
     - folder_name: licenses
       repo_url: https://github.com/cert-manager/makefile-modules.git
       repo_ref: main

--- a/make/00_mod.mk
+++ b/make/00_mod.mk
@@ -78,6 +78,7 @@ helm_chart_version := $(VERSION)
 helm_labels_template_name := trust-manager.labels
 
 golangci_lint_config := .golangci.yaml
+kube_api_linter_config := .golangci-kal.yml
 
 define helm_values_mutation_function
 $(YQ) \

--- a/make/02_mod.mk
+++ b/make/02_mod.mk
@@ -113,4 +113,3 @@ generate-conversion: | $(NEEDS_CONVERSION-GEN)
 
 shared_generate_targets += generate-conversion
 
-include make/kube-api-lint.mk

--- a/make/_shared/kube-api-linter/01_mod.mk
+++ b/make/_shared/kube-api-linter/01_mod.mk
@@ -12,29 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-KUBE_API_LINT := $(bin_dir)/tools/kube-api-lint
+ifndef kube_api_linter_config
+$(error kube_api_linter_config is not set)
+endif
 
-$(KUBE_API_LINT): | $(NEEDS_GO) $(NEEDS_GOLANGCI-LINT) $(bin_dir)/scratch
-	@echo "Building kube-api-lint custom golangci-lint binary"
-	GOVERSION=$(VENDORED_GO_VERSION) \
-		$(GOLANGCI-LINT) custom -v \
-		--destination $(bin_dir)/tools \
-		--name kube-api-lint
+kube_api_linter_timeout ?= 10m
 
 .PHONY: verify-kube-api-lint
-## Verify all APIs using Kube API Linter
+## Verify Kubernetes API types using Kube API Linter
 ## @category [shared] Generate/ Verify
-verify-kube-api-lint: | $(NEEDS_GO) $(KUBE_API_LINT)
-	@echo "Running kube-api-lint"
-	GOVERSION=$(VENDORED_GO_VERSION) \
-		$(KUBE_API_LINT) run -c $(CURDIR)/.golangci-kal.yml
+verify-kube-api-lint: | $(NEEDS_GO) $(NEEDS_KUBE-API-LINTER)
+	GOVERSION=$(VENDORED_GO_VERSION) $(KUBE-API-LINTER) run -c $(CURDIR)/$(kube_api_linter_config) --timeout $(kube_api_linter_timeout)
 
 shared_verify_targets_dirty += verify-kube-api-lint
 
 .PHONY: fix-kube-api-lint
-## Fix all APIs using Kube API Linter
+## Fix Kubernetes API types using Kube API Linter
 ## @category [shared] Generate/ Verify
-fix-kube-api-lint: | $(NEEDS_GO) $(KUBE_API_LINT)
-	@echo "Running kube-api-lint with --fix"
-	GOVERSION=$(VENDORED_GO_VERSION) \
-		$(KUBE_API_LINT) run --fix -c $(CURDIR)/.golangci-kal.yml
+fix-kube-api-lint: | $(NEEDS_GO) $(NEEDS_KUBE-API-LINTER)
+	GOVERSION=$(VENDORED_GO_VERSION) $(KUBE-API-LINTER) run --fix -c $(CURDIR)/$(kube_api_linter_config) --timeout $(kube_api_linter_timeout)


### PR DESCRIPTION
Replaces the local Kube API Linter setup added in #850 with the shared `kube-api-linter` module from cert-manager/makefile-modules#541 (now merged):

- `make/kube-api-lint.mk` and `.custom-gcl.yml` are deleted; `klone.yaml` klones the `kube-api-linter` module from makefile-modules `main` (all modules now at the same commit). The curated `.golangci-kal.yml` config is kept as `kube_api_linter_config`.
- No API changes: #1080 already bumped kube-api-linter to the July snapshot the module defaults to, and suppressed the 3 new `optionalfields` findings, so this is now a pure build-system change.

Verified locally after rebasing on #1080: `make verify-kube-api-lint` reports 0 issues.

/hold

*with claude fable-5*
