### PR TITLE
Bump KAL to the latest pseudo-version

### DIFF
--- a/.custom-gcl.yml
+++ b/.custom-gcl.yml
@@ -2,4 +2,4 @@ version: v2.13.1
 name: golangci-kube-api-linter
 plugins:
 - module: 'sigs.k8s.io/kube-api-linter'
-  version: 'v0.0.0-20260114104534-18147eee9c49' # Pin to a commit while there's no tag
+  version: 'v0.0.0-20260716143926-092fe0c72997' # Pin to a commit while there's no tag

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ testbin/*
 
 # editor and IDE paraphernalia
 .idea
+*.iml
 *.swp
 *.swo
 *~

--- a/pkg/apis/trust/v1alpha1/types_bundle.go
+++ b/pkg/apis/trust/v1alpha1/types_bundle.go
@@ -83,12 +83,12 @@ type BundleSource struct {
 	// configMap is a reference (by name) to a ConfigMap's `data` key(s), or to a
 	// list of ConfigMap's `data` key(s) using label selector, in the trust namespace.
 	// +optional
-	ConfigMap *SourceObjectKeySelector `json:"configMap,omitempty"`
+	ConfigMap *SourceObjectKeySelector `json:"configMap,omitempty"` //nolint:kubeapilinter // We think pointers work best here
 
 	// secret is a reference (by name) to a Secret's `data` key(s), or to a
 	// list of Secret's `data` key(s) using label selector, in the trust namespace.
 	// +optional
-	Secret *SourceObjectKeySelector `json:"secret,omitempty"`
+	Secret *SourceObjectKeySelector `json:"secret,omitempty"` //nolint:kubeapilinter // We think pointers work best here
 
 	// inLine is a simple string to append as the source data.
 	// +optional
@@ -125,7 +125,7 @@ type BundleTarget struct {
 
 	// additionalFormats specifies any additional formats to write to the target
 	// +optional
-	AdditionalFormats *AdditionalFormats `json:"additionalFormats,omitempty"`
+	AdditionalFormats *AdditionalFormats `json:"additionalFormats,omitempty"` //nolint:kubeapilinter // We think pointers work best here
 
 	// namespaceSelector will, if set, only sync the target resource in
 	// Namespaces which match the selector.


### PR DESCRIPTION
This PR is a preparation for https://github.com/cert-manager/trust-manager/pull/1070. Instead of fixing the new lint violations, I propose suppressing them. The new violations are reported on the soon-to-be-deprecated Bundle API, and changing a lot of fields to non-pointers will only create unnecessary noise and PR conflicts. We have also previously added suppressions for the same lint violations in the Bundle API.

The PR also contains a minor unrelated change to the .gitignore file. I can do this in a separate PR, but it would be easiest for me to include it here. 🌻 