### PR TITLE
Bump default CAs bundle version to trigger release

### DIFF
--- a/make/00_debian_bookworm_version.mk
+++ b/make/00_debian_bookworm_version.mk
@@ -17,5 +17,5 @@
 # This file is used to store the latest version of the debian trust package and the DEBIAN_BOOKWORM_BUNDLE_VERSION
 # variable is automatically updated by the `upgrade-debian-bookworm-trust-package-version` target and cron GH action.
 
-DEBIAN_BOOKWORM_BUNDLE_VERSION := 20250419~deb12u1.0
+DEBIAN_BOOKWORM_BUNDLE_VERSION := 20250419~deb12u1.1
 DEBIAN_BOOKWORM_BUNDLE_SOURCE_IMAGE=docker.io/library/debian:12-slim

--- a/make/00_debian_trixie_version.mk
+++ b/make/00_debian_trixie_version.mk
@@ -17,5 +17,5 @@
 # This file is used to store the latest version of the debian trust package and the DEBIAN_TRIXIE_BUNDLE_VERSION
 # variable is automatically updated by the `upgrade-debian-trixie-trust-package-version` target and cron GH action.
 
-DEBIAN_TRIXIE_BUNDLE_VERSION := 20250419.1
+DEBIAN_TRIXIE_BUNDLE_VERSION := 20250419.2
 DEBIAN_TRIXIE_BUNDLE_SOURCE_IMAGE=docker.io/library/debian:13-slim


### PR DESCRIPTION
All our default bundle images are reported as vulnerable by vulnerability scanners. This PR is the same drill as in https://github.com/cert-manager/trust-manager/pull/768 (example) to trigger a new release of the bundle images. This is done now in preparation for a new trust-manager release.