### PR TITLE
Reuse the target version suffix in exact mode

### DIFF
--- a/make/debian-trust-package-fetch.sh
+++ b/make/debian-trust-package-fetch.sh
@@ -143,7 +143,7 @@ version_suffix=".0"
 # resets the suffix to ".0" as before.
 if [[ "$installed_version" == "$target_ca_certificates_version" ]]; then
 	version_suffix=".${TARGET_DEBIAN_BUNDLE_VERSION##*.}"
-	echo "+++ installed version matches target version; reusing the current suffix '$version_suffix'"
+	echo "+++ installed version matches the target base version; reusing the target suffix '$version_suffix'"
 fi
 
 echo "{}" | jq \

--- a/make/debian-trust-package-fetch.sh
+++ b/make/debian-trust-package-fetch.sh
@@ -136,7 +136,12 @@ $CTR run --rm --mount type=bind,source="$TMP_DIR",target=/workdir "$DEBIAN_SOURC
 installed_version=$(cat "$TMP_DIR/version.txt")
 version_suffix=".0"
 
-if [[ "$ACTION" == "latest" && "$installed_version" == "$target_ca_certificates_version" ]]; then
+# Reuse the target suffix whenever the installed base version matches the target,
+# so that in "exact" mode (release builds) the version embedded in the package
+# matches the image tag. In "exact" mode apt installs exactly the target base
+# version, so the suffix is always reused; in "latest" mode a newer base version
+# resets the suffix to ".0" as before.
+if [[ "$installed_version" == "$target_ca_certificates_version" ]]; then
 	version_suffix=".${TARGET_DEBIAN_BUNDLE_VERSION##*.}"
 	echo "+++ installed version matches target version; reusing the current suffix '$version_suffix'"
 fi


### PR DESCRIPTION
Fixes the problem described in [my review on #1086](https://github.com/cert-manager/trust-manager/pull/1086#pullrequestreview-5080237181): a version suffix bump changes the image tag, but not the version embedded in `cert-manager-package-debian.json`, because the release build runs [`debian-trust-package-fetch.sh` in `exact` mode](https://github.com/cert-manager/trust-manager/blob/10a35e3bac14617788b91956738a44efbd2a6654/make/debian-trust-package.mk#L30-L32) and the script only reused the target suffix in `latest` mode. The embedded version is what surfaces as `defaultCAPackageVersion` in Bundle status, so operators could not tell a rebuilt package from the one it replaced. The image published from #768 shows the problem:

```console
$ crane export quay.io/jetstack/trust-pkg-debian-trixie:20250419.1 - \
    | tar -xO --wildcards '*cert-manager-package-debian.json' | jq .version
"20250419.0"
```

In `exact` mode apt installs exactly the target base version, so the installed version always matches the target and the target suffix can safely be reused — this change drops the `ACTION == "latest"` half of the condition. `latest` mode (the daily cron) is unchanged: an unchanged base still reuses the current suffix, and a newer base still resets it to `.0`.

Tested by running the script in `exact` mode with target `20250419.2` against `debian:13-slim`; the destination file now embeds `"version": "20250419.2"` where it previously embedded `"version": "20250419.0"`.

*with claude fable-5*
