### PR TITLE
Add --tls-curve-preferences for the webhook server

### DIFF
--- a/cmd/trust-manager/app/app.go
+++ b/cmd/trust-manager/app/app.go
@@ -126,6 +126,9 @@ func NewCommand() *cobra.Command {
 	return cmd
 }
 
+// GetTLSOptions builds controller-runtime TLSOpts for the webhook server from
+// CLI/Helm TLS settings. Omitted fields are left unset so crypto/tls uses the
+// Go runtime defaults for that field.
 func GetTLSOptions(config options.TLSConfig) ([]func(*tls.Config), error) {
 	var tlsOptions []func(config *tls.Config)
 
@@ -146,6 +149,19 @@ func GetTLSOptions(config options.TLSConfig) ([]func(*tls.Config), error) {
 		}
 		tlsOptions = append(tlsOptions, func(cfg *tls.Config) {
 			cfg.CipherSuites = suites
+		})
+	}
+
+	// Apply an explicit key-exchange allow-list when provided. An empty list is
+	// left unset so crypto/tls keeps the Go runtime defaults, which can change
+	// between Go versions (for example when hybrid post-quantum groups are added).
+	if len(config.CurvePreferences) > 0 {
+		curves, err := cliflag.TLSCurvePreferences(config.CurvePreferences)
+		if err != nil {
+			return nil, err
+		}
+		tlsOptions = append(tlsOptions, func(cfg *tls.Config) {
+			cfg.CurvePreferences = curves
 		})
 	}
 

--- a/cmd/trust-manager/app/app_test.go
+++ b/cmd/trust-manager/app/app_test.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 The cert-manager Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package app
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/cert-manager/trust-manager/cmd/trust-manager/app/options"
+)
+
+func TestGetTLSOptions(t *testing.T) {
+	tests := map[string]struct {
+		config      options.TLSConfig
+		wantMin     uint16
+		wantCiphers []uint16
+		wantCurves  []tls.CurveID
+		wantErr     bool
+	}{
+		"empty config leaves tls.Config defaults unset": {
+			config: options.TLSConfig{},
+		},
+		"curve preferences are applied as crypto/tls CurveIDs": {
+			config: options.TLSConfig{
+				CurvePreferences: []int32{int32(tls.X25519), int32(tls.CurveP256)},
+			},
+			wantCurves: []tls.CurveID{tls.X25519, tls.CurveP256},
+		},
+		"curve preferences combine with min version and cipher suites": {
+			config: options.TLSConfig{
+				MinVersion:       "VersionTLS12",
+				CipherSuites:     []string{"TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256"},
+				CurvePreferences: []int32{int32(tls.X25519)},
+			},
+			wantMin:     tls.VersionTLS12,
+			wantCiphers: []uint16{tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256},
+			wantCurves:  []tls.CurveID{tls.X25519},
+		},
+		"unknown curve ID is rejected": {
+			config: options.TLSConfig{
+				CurvePreferences: []int32{9999},
+			},
+			wantErr: true,
+		},
+		"duplicate curve ID is rejected": {
+			config: options.TLSConfig{
+				CurvePreferences: []int32{int32(tls.X25519), int32(tls.X25519)},
+			},
+			wantErr: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			opts, err := GetTLSOptions(tc.config)
+			if tc.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			cfg := &tls.Config{}
+			for _, opt := range opts {
+				opt(cfg)
+			}
+
+			assert.Equal(t, tc.wantMin, cfg.MinVersion)
+			assert.Equal(t, tc.wantCiphers, cfg.CipherSuites)
+			assert.Equal(t, tc.wantCurves, cfg.CurvePreferences)
+		})
+	}
+}
+
+// Helm passes a single comma-separated flag value (same shape as kube-apiserver).
+func TestTLSCurvePreferencesFlag(t *testing.T) {
+	opts := options.New()
+	cmd := &cobra.Command{Use: "trust-manager"}
+	opts.Prepare(cmd)
+
+	// 23=P-256, 29=X25519; Helm passes this same comma-separated form.
+	require.NoError(t, cmd.ParseFlags([]string{"--tls-curve-preferences=23,29"}))
+	assert.Equal(t, []int32{int32(tls.CurveP256), int32(tls.X25519)}, opts.TLSConfig.CurvePreferences)
+
+	tlsOpts, err := GetTLSOptions(opts.TLSConfig)
+	require.NoError(t, err)
+
+	cfg := &tls.Config{}
+	for _, opt := range tlsOpts {
+		opt(cfg)
+	}
+	assert.Equal(t, []tls.CurveID{tls.CurveP256, tls.X25519}, cfg.CurvePreferences)
+}

--- a/cmd/trust-manager/app/options/options.go
+++ b/cmd/trust-manager/app/options/options.go
@@ -101,7 +101,8 @@ type TLSConfig struct {
 	// webhook server, specified as numeric Go crypto/tls CurveID values.
 	//
 	// The name and value format match Kubernetes --tls-curve-preferences
-	// (k8s.io/component-base/cli/flag.TLSCurvePreferences). The name refers to
+	// (https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/).
+	// The name refers to
 	// elliptic curves for legacy reasons; the field also covers newer groups
 	// such as hybrid post-quantum KEMs. The order of the list is ignored; Go
 	// selects from the set using its own preference order.

--- a/cmd/trust-manager/app/options/options.go
+++ b/cmd/trust-manager/app/options/options.go
@@ -87,12 +87,12 @@ type Options struct {
 
 type TLSConfig struct {
 	// MinVersion is the minimum TLS version supported.
-	// Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
+	// Values are from tls package constants (https://pkg.go.dev/crypto/tls#pkg-constants).
 	// If not specified, the default for the Go version will be used and may change over time.
 	MinVersion string
 
 	// CipherSuites is the list of allowed cipher suites for the webhook server.
-	// Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
+	// Values are from tls package constants (https://pkg.go.dev/crypto/tls#pkg-constants).
 	// Only affects TLS 1.2; TLS 1.3 cipher suites are not configurable in Go.
 	// If not specified, the default for the Go version will be used and may change over time.
 	CipherSuites []string

--- a/cmd/trust-manager/app/options/options.go
+++ b/cmd/trust-manager/app/options/options.go
@@ -93,8 +93,22 @@ type TLSConfig struct {
 
 	// CipherSuites is the list of allowed cipher suites for the webhook server.
 	// Values are from tls package constants (https://golang.org/pkg/crypto/tls/#pkg-constants).
+	// Only affects TLS 1.2; TLS 1.3 cipher suites are not configurable in Go.
 	// If not specified, the default for the Go version will be used and may change over time.
 	CipherSuites []string
+
+	// CurvePreferences is the list of allowed TLS key-exchange groups for the
+	// webhook server, specified as numeric Go crypto/tls CurveID values.
+	//
+	// The name and value format match Kubernetes --tls-curve-preferences
+	// (k8s.io/component-base/cli/flag.TLSCurvePreferences). The name refers to
+	// elliptic curves for legacy reasons; the field also covers newer groups
+	// such as hybrid post-quantum KEMs. The order of the list is ignored; Go
+	// selects from the set using its own preference order.
+	// Applies to TLS 1.2 and TLS 1.3; unlike CipherSuites, this is still
+	// effective when the webhook is TLS 1.3-only.
+	// If not specified, the default for the Go version will be used and may change over time.
+	CurvePreferences []int32
 }
 
 type logOptions struct {
@@ -299,7 +313,21 @@ func (o *Options) addTLSConfigFlags(fs *pflag.FlagSet) {
 	fs.StringSliceVar(&o.TLSConfig.CipherSuites,
 		"tls-cipher-suites", nil,
 		"Comma-separated list of cipher suites for the webhook server. "+
-			"If omitted, the default Go cipher suites will be used. \n"+
+			"If omitted, the default Go cipher suites will be used. "+
+			"Only affects TLS 1.2; TLS 1.3 cipher suites are not configurable in Go. \n"+
 			"Preferred values: "+strings.Join(tlsCipherPreferredValues, ", ")+". \n"+
 			"Insecure values: "+strings.Join(tlsCipherInsecureValues, ", ")+".")
+
+	// Numeric CurveIDs (not names) keep this flag aligned with kube-apiserver
+	// and cliflag.TLSCurvePreferences. Example: 23=P-256, 29=X25519.
+	fs.Int32SliceVar(&o.TLSConfig.CurvePreferences,
+		"tls-curve-preferences", nil,
+		"Comma-separated list of numeric Go crypto/tls CurveID values, "+
+			"as the allowed key exchange mechanisms for the webhook server. "+
+			"Applies to TLS 1.2 and TLS 1.3. "+
+			"The supported values depend on the Go version used. "+
+			"See https://pkg.go.dev/crypto/tls#CurveID for values supported for each Go version. "+
+			"The order of the list is ignored, and key exchange mechanisms are chosen "+
+			"by Go from this list using an internal preference order. "+
+			"If omitted, the default Go curves will be used.")
 }

--- a/deploy/charts/trust-manager/README.md
+++ b/deploy/charts/trust-manager/README.md
@@ -459,7 +459,14 @@ Minimum TLS version supported. If omitted, the default Go minimum version will b
 > ""
 > ```
 
-Comma-separated list of cipher suites for the server. If omitted, the default Go cipher suites will be used.
+Comma-separated list of cipher suites for the webhook server. If omitted, the default Go cipher suites will be used. Only affects TLS 1.2; TLS 1.3 cipher suites are not configurable in Go. Acceptable names match Kubernetes component-base (same as kube-apiserver --tls-cipher-suites); see [TLSCipherPossibleValues](https://pkg.go.dev/k8s.io/component-base/cli/flag#TLSCipherPossibleValues). Some listed values are considered insecure — prefer [PreferredTLSCipherNames](https://pkg.go.dev/k8s.io/component-base/cli/flag#PreferredTLSCipherNames).
+#### **app.curvePreferences** ~ `string`
+> Default value:
+> ```yaml
+> ""
+> ```
+
+Comma-separated list of numeric Go crypto/tls CurveID values for the webhook server (for example 23,29 for P-256 and X25519). Applies to TLS 1.2 and TLS 1.3 key exchange. Unlike cipherSuites, this still takes effect when the webhook is TLS 1.3-only. The order of the list is ignored. If omitted, the default Go curves will be used. See https://pkg.go.dev/crypto/tls#CurveID.
 #### **app.logFormat** ~ `string`
 > Default value:
 > ```yaml

--- a/deploy/charts/trust-manager/templates/deployment.yaml
+++ b/deploy/charts/trust-manager/templates/deployment.yaml
@@ -82,6 +82,9 @@ spec:
           {{- with .Values.app.cipherSuites }}
           - "--tls-cipher-suites={{.}}"
           {{- end }}
+          {{- with .Values.app.curvePreferences }}
+          - "--tls-curve-preferences={{.}}"
+          {{- end }}
           - "--log-format={{.Values.app.logFormat}}"
           - "--log-level={{.Values.app.logLevel}}"
           - "--metrics-port={{.Values.app.metrics.port}}"

--- a/deploy/charts/trust-manager/values.schema.json
+++ b/deploy/charts/trust-manager/values.schema.json
@@ -113,6 +113,9 @@
         "cipherSuites": {
           "$ref": "#/$defs/helm-values.app.cipherSuites"
         },
+        "curvePreferences": {
+          "$ref": "#/$defs/helm-values.app.curvePreferences"
+        },
         "leaderElection": {
           "$ref": "#/$defs/helm-values.app.leaderElection"
         },
@@ -154,7 +157,12 @@
     },
     "helm-values.app.cipherSuites": {
       "default": "",
-      "description": "Comma-separated list of cipher suites for the server. If omitted, the default Go cipher suites will be used.",
+      "description": "Comma-separated list of cipher suites for the webhook server. If omitted, the default Go cipher suites will be used. Only affects TLS 1.2; TLS 1.3 cipher suites are not configurable in Go. Acceptable names match Kubernetes component-base (same as kube-apiserver --tls-cipher-suites); see [TLSCipherPossibleValues](https://pkg.go.dev/k8s.io/component-base/cli/flag#TLSCipherPossibleValues). Some listed values are considered insecure — prefer [PreferredTLSCipherNames](https://pkg.go.dev/k8s.io/component-base/cli/flag#PreferredTLSCipherNames).",
+      "type": "string"
+    },
+    "helm-values.app.curvePreferences": {
+      "default": "",
+      "description": "Comma-separated list of numeric Go crypto/tls CurveID values for the webhook server (for example 23,29 for P-256 and X25519). Applies to TLS 1.2 and TLS 1.3 key exchange. Unlike cipherSuites, this still takes effect when the webhook is TLS 1.3-only. The order of the list is ignored. If omitted, the default Go curves will be used. See https://pkg.go.dev/crypto/tls#CurveID.",
       "type": "string"
     },
     "helm-values.app.leaderElection": {

--- a/deploy/charts/trust-manager/values.yaml
+++ b/deploy/charts/trust-manager/values.yaml
@@ -286,8 +286,17 @@ app:
   # Minimum TLS version supported. If omitted, the default Go minimum version will be used.
   minTLSVersion: ""
 
-  # Comma-separated list of cipher suites for the server. If omitted, the default Go cipher suites will be used.
+  # Comma-separated list of cipher suites for the webhook server. If omitted, the default Go cipher suites will be used.
+  # Only affects TLS 1.2; TLS 1.3 cipher suites are not configurable in Go.
+  # Acceptable names match Kubernetes component-base (same as kube-apiserver --tls-cipher-suites);
+  # see [TLSCipherPossibleValues](https://pkg.go.dev/k8s.io/component-base/cli/flag#TLSCipherPossibleValues).
+  # Some listed values are considered insecure — prefer [PreferredTLSCipherNames](https://pkg.go.dev/k8s.io/component-base/cli/flag#PreferredTLSCipherNames).
   cipherSuites: ""
+
+  # Comma-separated list of numeric Go crypto/tls CurveID values for the webhook server (for example 23,29 for P-256 and X25519).
+  # Applies to TLS 1.2 and TLS 1.3 key exchange. Unlike cipherSuites, this still takes effect when the webhook is TLS 1.3-only.
+  # The order of the list is ignored. If omitted, the default Go curves will be used. See https://pkg.go.dev/crypto/tls#CurveID.
+  curvePreferences: ""
 
   # The format of trust-manager logging. Accepted values are text or json.
   logFormat: text


### PR DESCRIPTION
## Summary

- Add `--tls-curve-preferences` so the webhook server can restrict TLS key-exchange groups (`tls.Config.CurvePreferences`), matching Kubernetes `--tls-curve-preferences` and `cliflag.TLSCurvePreferences`.
- Empty / omitted keeps Go defaults. Values are numeric `crypto/tls` CurveIDs (for example `23,29` for P-256 and X25519).
- Expose Helm `app.curvePreferences` and document that cipher suites apply only to TLS 1.2, while curve preferences apply to TLS 1.2 and TLS 1.3.

This is the remaining webhook TLS knob next to `--tls-min-version` and `--tls-cipher-suites` (#528 / #556).

## Test plan

- [x] `go test ./cmd/trust-manager/app/`
- [x] `make verify-golangci-lint`
- [x] `make verify-helm-values`
- [x] Helm template: unset omits the flag; `app.curvePreferences: "23,29"` renders `--tls-curve-preferences=23,29`

/kind feature

```release-note
Added `--tls-curve-preferences` (Helm: `app.curvePreferences`) to configure webhook TLS key-exchange groups. Cipher suite docs now note that they apply only to TLS 1.2.
```