### PR TITLE
Don't run trust-package-upgrade-debian in forks

### DIFF
--- a/.github/workflows/trust-package-upgrade-debian.yaml
+++ b/.github/workflows/trust-package-upgrade-debian.yaml
@@ -15,6 +15,8 @@ jobs:
 
     runs-on: ubuntu-latest
 
+    if: github.repository == 'cert-manager/trust-manager'
+
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
After resyncing my fork of trust-manager, I get daily emails about failing jobs. This PR restricts the upgrade workflow to run only in the upstream repo, using a pattern already in use in this repo.