### PR TITLE
Don't run release workflows in forks

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -11,6 +11,8 @@ jobs:
   build_and_push:
     runs-on: ubuntu-latest
 
+    if: github.repository == 'cert-manager/trust-manager'
+
     permissions:
       contents: read # needed for checkout
       packages: write # needed for push images

--- a/.github/workflows/trust-package-release-debian-bookworm.yaml
+++ b/.github/workflows/trust-package-release-debian-bookworm.yaml
@@ -9,6 +9,8 @@ jobs:
   build_and_push:
     runs-on: ubuntu-latest
 
+    if: github.repository == 'cert-manager/trust-manager'
+
     permissions:
       contents: read # needed for checkout
       packages: write # needed for push images

--- a/.github/workflows/trust-package-release-debian-trixie.yaml
+++ b/.github/workflows/trust-package-release-debian-trixie.yaml
@@ -9,6 +9,8 @@ jobs:
   build_and_push:
     runs-on: ubuntu-latest
 
+    if: github.repository == 'cert-manager/trust-manager'
+
     permissions:
       contents: read # needed for checkout
       packages: write # needed for push images


### PR DESCRIPTION
Similar to https://github.com/cert-manager/trust-manager/pull/1100. After resyncing my fork again, I got two spam emails from GitHub.